### PR TITLE
feat(security): RLS policies for tenant isolation

### DIFF
--- a/__tests__/rls-policies.test.ts
+++ b/__tests__/rls-policies.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const migrationPath = resolve(
+  __dirname,
+  "../supabase/migrations/003_rls_policies.sql"
+);
+const sql = readFileSync(migrationPath, "utf-8");
+
+const TABLES = [
+  "profiles",
+  "reports",
+  "parsed_results",
+  "risk_flags",
+  "chat_sessions",
+  "chat_messages",
+  "doctor_questions",
+];
+
+describe("RLS Policies Migration", () => {
+  it("enables RLS on all 7 tables", () => {
+    for (const table of TABLES) {
+      expect(sql).toContain(
+        `ALTER TABLE ${table} ENABLE ROW LEVEL SECURITY`
+      );
+    }
+  });
+
+  it("creates SELECT policies for all tables", () => {
+    for (const table of TABLES) {
+      expect(sql).toContain(`ON ${table} FOR SELECT`);
+    }
+  });
+
+  it("creates INSERT policies for all tables", () => {
+    for (const table of TABLES) {
+      expect(sql).toContain(`ON ${table} FOR INSERT`);
+    }
+  });
+
+  it("creates DELETE policies for all tables", () => {
+    for (const table of TABLES) {
+      expect(sql).toContain(`ON ${table} FOR DELETE`);
+    }
+  });
+
+  it("uses auth.uid() in all policies — never trusts client user_id", () => {
+    const authUidCount = (sql.match(/auth\.uid\(\)/g) || []).length;
+    // At least one auth.uid() per table (7 tables, multiple policies each)
+    expect(authUidCount).toBeGreaterThanOrEqual(14);
+  });
+
+  it("does NOT contain USING (true) — no overly permissive policies", () => {
+    expect(sql).not.toContain("USING (true)");
+  });
+
+  it("joined tables verify ownership through parent tables", () => {
+    // parsed_results checks via reports
+    expect(sql).toContain("reports.id = parsed_results.report_id");
+    expect(sql).toContain("reports.user_id = auth.uid()");
+
+    // risk_flags checks via parsed_results -> reports
+    expect(sql).toContain("parsed_results.id = risk_flags.parsed_result_id");
+
+    // chat_messages checks via chat_sessions
+    expect(sql).toContain("chat_sessions.id = chat_messages.session_id");
+    expect(sql).toContain("chat_sessions.user_id = auth.uid()");
+
+    // doctor_questions checks via parsed_results -> reports
+    expect(sql).toContain(
+      "parsed_results.id = doctor_questions.parsed_result_id"
+    );
+  });
+
+  it("profiles table uses id = auth.uid() (not user_id)", () => {
+    // profiles PK is id which references auth.users(id)
+    const profileSection = sql.substring(
+      sql.indexOf("PROFILES"),
+      sql.indexOf("REPORTS")
+    );
+    expect(profileSection).toContain("id = auth.uid()");
+    expect(profileSection).not.toContain("user_id");
+  });
+});

--- a/supabase/migrations/003_rls_policies.sql
+++ b/supabase/migrations/003_rls_policies.sql
@@ -1,0 +1,237 @@
+-- HealthChat AI: Row Level Security Policies
+-- Enforces tenant isolation — users can only access their own data.
+-- Uses auth.uid() to scope all operations to the authenticated user.
+
+-- =============================================================================
+-- ENABLE RLS ON ALL TABLES
+-- =============================================================================
+
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE reports ENABLE ROW LEVEL SECURITY;
+ALTER TABLE parsed_results ENABLE ROW LEVEL SECURITY;
+ALTER TABLE risk_flags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE chat_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE chat_messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE doctor_questions ENABLE ROW LEVEL SECURITY;
+
+-- =============================================================================
+-- PROFILES — user owns their own profile (id = auth.uid())
+-- =============================================================================
+
+CREATE POLICY "Users can view their own profile"
+  ON profiles FOR SELECT
+  USING (id = auth.uid());
+
+CREATE POLICY "Users can insert their own profile"
+  ON profiles FOR INSERT
+  WITH CHECK (id = auth.uid());
+
+CREATE POLICY "Users can update their own profile"
+  ON profiles FOR UPDATE
+  USING (id = auth.uid())
+  WITH CHECK (id = auth.uid());
+
+CREATE POLICY "Users can delete their own profile"
+  ON profiles FOR DELETE
+  USING (id = auth.uid());
+
+-- =============================================================================
+-- REPORTS — user_id = auth.uid()
+-- =============================================================================
+
+CREATE POLICY "Users can view their own reports"
+  ON reports FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Users can insert their own reports"
+  ON reports FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Users can update their own reports"
+  ON reports FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Users can delete their own reports"
+  ON reports FOR DELETE
+  USING (user_id = auth.uid());
+
+-- =============================================================================
+-- PARSED RESULTS — accessible only if user owns the parent report
+-- =============================================================================
+
+CREATE POLICY "Users can view parsed results for their own reports"
+  ON parsed_results FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM reports
+      WHERE reports.id = parsed_results.report_id
+        AND reports.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can insert parsed results for their own reports"
+  ON parsed_results FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM reports
+      WHERE reports.id = parsed_results.report_id
+        AND reports.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can update parsed results for their own reports"
+  ON parsed_results FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM reports
+      WHERE reports.id = parsed_results.report_id
+        AND reports.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM reports
+      WHERE reports.id = parsed_results.report_id
+        AND reports.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can delete parsed results for their own reports"
+  ON parsed_results FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM reports
+      WHERE reports.id = parsed_results.report_id
+        AND reports.user_id = auth.uid()
+    )
+  );
+
+-- =============================================================================
+-- RISK FLAGS — accessible only if user owns the parent report (via parsed_results)
+-- =============================================================================
+
+CREATE POLICY "Users can view risk flags for their own reports"
+  ON risk_flags FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM parsed_results
+      JOIN reports ON reports.id = parsed_results.report_id
+      WHERE parsed_results.id = risk_flags.parsed_result_id
+        AND reports.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can insert risk flags for their own reports"
+  ON risk_flags FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM parsed_results
+      JOIN reports ON reports.id = parsed_results.report_id
+      WHERE parsed_results.id = risk_flags.parsed_result_id
+        AND reports.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can delete risk flags for their own reports"
+  ON risk_flags FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM parsed_results
+      JOIN reports ON reports.id = parsed_results.report_id
+      WHERE parsed_results.id = risk_flags.parsed_result_id
+        AND reports.user_id = auth.uid()
+    )
+  );
+
+-- =============================================================================
+-- CHAT SESSIONS — user_id = auth.uid()
+-- =============================================================================
+
+CREATE POLICY "Users can view their own chat sessions"
+  ON chat_sessions FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Users can insert their own chat sessions"
+  ON chat_sessions FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Users can update their own chat sessions"
+  ON chat_sessions FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Users can delete their own chat sessions"
+  ON chat_sessions FOR DELETE
+  USING (user_id = auth.uid());
+
+-- =============================================================================
+-- CHAT MESSAGES — accessible only if user owns the parent chat session
+-- =============================================================================
+
+CREATE POLICY "Users can view messages in their own chat sessions"
+  ON chat_messages FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM chat_sessions
+      WHERE chat_sessions.id = chat_messages.session_id
+        AND chat_sessions.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can insert messages in their own chat sessions"
+  ON chat_messages FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM chat_sessions
+      WHERE chat_sessions.id = chat_messages.session_id
+        AND chat_sessions.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can delete messages in their own chat sessions"
+  ON chat_messages FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM chat_sessions
+      WHERE chat_sessions.id = chat_messages.session_id
+        AND chat_sessions.user_id = auth.uid()
+    )
+  );
+
+-- =============================================================================
+-- DOCTOR QUESTIONS — accessible only if user owns the parent report (via parsed_results)
+-- =============================================================================
+
+CREATE POLICY "Users can view doctor questions for their own reports"
+  ON doctor_questions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM parsed_results
+      JOIN reports ON reports.id = parsed_results.report_id
+      WHERE parsed_results.id = doctor_questions.parsed_result_id
+        AND reports.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can insert doctor questions for their own reports"
+  ON doctor_questions FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM parsed_results
+      JOIN reports ON reports.id = parsed_results.report_id
+      WHERE parsed_results.id = doctor_questions.parsed_result_id
+        AND reports.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can delete doctor questions for their own reports"
+  ON doctor_questions FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM parsed_results
+      JOIN reports ON reports.id = parsed_results.report_id
+      WHERE parsed_results.id = doctor_questions.parsed_result_id
+        AND reports.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- Enables Row Level Security on all 7 tables (profiles, reports, parsed_results, risk_flags, chat_sessions, chat_messages, doctor_questions)
- Creates SELECT/INSERT/UPDATE/DELETE policies scoped to `auth.uid()`
- Joined tables verify ownership through parent table joins (no direct user_id shortcut)
- No overly permissive policies — zero `USING (true)` anywhere

## Policy Design
| Table | Ownership Check |
|---|---|
| profiles | `id = auth.uid()` |
| reports | `user_id = auth.uid()` |
| chat_sessions | `user_id = auth.uid()` |
| parsed_results | JOIN reports → `user_id = auth.uid()` |
| risk_flags | JOIN parsed_results → reports → `user_id = auth.uid()` |
| chat_messages | JOIN chat_sessions → `user_id = auth.uid()` |
| doctor_questions | JOIN parsed_results → reports → `user_id = auth.uid()` |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (8 new RLS tests)
- [ ] Verify migration applies via Supabase branch preview
- [ ] Verify in Supabase Dashboard: RLS enabled on all tables, policies visible

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)