### PR TITLE
feat(parsing): document parsing with Claude Vision API

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -4,3 +4,6 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
 # Only needed for server-side admin operations (not used in auth flow)
 # SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# Anthropic — get this from https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/__tests__/parse-report.test.ts
+++ b/__tests__/parse-report.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  PARSE_REPORT_SYSTEM_PROMPT,
+  PARSE_REPORT_USER_PROMPT,
+} from "@/lib/claude/prompts";
+
+// Mock the Anthropic SDK
+const mockCreate = vi.fn();
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      create: mockCreate,
+    },
+  })),
+}));
+
+describe("Document parsing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("prompts", () => {
+    it("system prompt instructs extraction only — no medical advice", () => {
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain(
+        "do NOT provide medical advice"
+      );
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain(
+        "Do NOT interpret, diagnose, or suggest treatments"
+      );
+    });
+
+    it("system prompt requires JSON response format", () => {
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain("valid JSON");
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain("biomarkers");
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain("summary");
+    });
+
+    it("system prompt specifies 5th grade reading level for summary", () => {
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain("5th grade");
+    });
+
+    it("user prompt requests structured extraction", () => {
+      expect(PARSE_REPORT_USER_PROMPT).toContain("biomarkers");
+      expect(PARSE_REPORT_USER_PROMPT).toContain("structured JSON");
+    });
+  });
+
+  describe("parseReportWithClaude", () => {
+    it("parses valid Claude response into structured data", async () => {
+      const mockResponse = {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              biomarkers: [
+                {
+                  name: "Glucose",
+                  value: 95,
+                  unit: "mg/dL",
+                  reference_low: 70,
+                  reference_high: 100,
+                  flag: "green",
+                },
+                {
+                  name: "Cholesterol",
+                  value: 245,
+                  unit: "mg/dL",
+                  reference_low: 0,
+                  reference_high: 200,
+                  flag: "red",
+                },
+              ],
+              summary:
+                "This blood test shows your sugar levels are normal. Your cholesterol is higher than it should be.",
+            }),
+          },
+        ],
+      };
+      mockCreate.mockResolvedValue(mockResponse);
+
+      const { parseReportWithClaude } = await import(
+        "@/lib/claude/parse-report"
+      );
+      const result = await parseReportWithClaude("base64data", "image/jpeg");
+
+      expect(result.biomarkers).toHaveLength(2);
+      expect(result.biomarkers[0].name).toBe("Glucose");
+      expect(result.biomarkers[0].flag).toBe("green");
+      expect(result.biomarkers[1].name).toBe("Cholesterol");
+      expect(result.biomarkers[1].flag).toBe("red");
+      expect(result.summary).toContain("blood test");
+    });
+
+    it("handles markdown code block wrapped JSON", async () => {
+      const mockResponse = {
+        content: [
+          {
+            type: "text",
+            text: '```json\n{"biomarkers": [], "summary": "No results found."}\n```',
+          },
+        ],
+      };
+      mockCreate.mockResolvedValue(mockResponse);
+
+      const { parseReportWithClaude } = await import(
+        "@/lib/claude/parse-report"
+      );
+      const result = await parseReportWithClaude("base64data", "application/pdf");
+
+      expect(result.biomarkers).toEqual([]);
+      expect(result.summary).toBe("No results found.");
+    });
+
+    it("throws on invalid JSON response", async () => {
+      const mockResponse = {
+        content: [{ type: "text", text: "This is not JSON" }],
+      };
+      mockCreate.mockResolvedValue(mockResponse);
+
+      const { parseReportWithClaude } = await import(
+        "@/lib/claude/parse-report"
+      );
+      await expect(
+        parseReportWithClaude("base64data", "image/png")
+      ).rejects.toThrow();
+    });
+
+    it("throws when response has no text block", async () => {
+      const mockResponse = { content: [] };
+      mockCreate.mockResolvedValue(mockResponse);
+
+      const { parseReportWithClaude } = await import(
+        "@/lib/claude/parse-report"
+      );
+      await expect(
+        parseReportWithClaude("base64data", "image/jpeg")
+      ).rejects.toThrow("No text response");
+    });
+
+    it("throws when biomarkers is not an array", async () => {
+      const mockResponse = {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ biomarkers: "not an array", summary: "test" }),
+          },
+        ],
+      };
+      mockCreate.mockResolvedValue(mockResponse);
+
+      const { parseReportWithClaude } = await import(
+        "@/lib/claude/parse-report"
+      );
+      await expect(
+        parseReportWithClaude("base64data", "image/jpeg")
+      ).rejects.toThrow("biomarkers must be an array");
+    });
+  });
+});

--- a/app/api/parse/route.ts
+++ b/app/api/parse/route.ts
@@ -1,0 +1,167 @@
+import { createClient } from "@/lib/supabase/server";
+import { parseReportWithClaude } from "@/lib/claude/parse-report";
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  // Verify authentication
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Parse request body
+  let body: { report_id: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  if (!body.report_id) {
+    return NextResponse.json(
+      { error: "report_id is required" },
+      { status: 400 }
+    );
+  }
+
+  // Fetch report and verify ownership (RLS handles this)
+  const { data: report, error: reportError } = await supabase
+    .from("reports")
+    .select("id, file_path, file_type, status, user_id")
+    .eq("id", body.report_id)
+    .single();
+
+  if (reportError || !report) {
+    return NextResponse.json(
+      { error: "Report not found" },
+      { status: 404 }
+    );
+  }
+
+  // Verify ownership explicitly as defense-in-depth
+  if (report.user_id !== user.id) {
+    return NextResponse.json(
+      { error: "Forbidden" },
+      { status: 403 }
+    );
+  }
+
+  // Update status to 'parsing'
+  await supabase
+    .from("reports")
+    .update({ status: "parsing" })
+    .eq("id", report.id);
+
+  try {
+    // Download file from Supabase Storage
+    const { data: fileData, error: downloadError } = await supabase.storage
+      .from("medical-reports")
+      .download(report.file_path);
+
+    if (downloadError || !fileData) {
+      await supabase
+        .from("reports")
+        .update({ status: "error" })
+        .eq("id", report.id);
+      return NextResponse.json(
+        { error: "Failed to download file" },
+        { status: 500 }
+      );
+    }
+
+    // Convert to base64
+    const arrayBuffer = await fileData.arrayBuffer();
+    const base64 = Buffer.from(arrayBuffer).toString("base64");
+
+    // Determine media type
+    const mediaType =
+      report.file_type === "pdf"
+        ? "application/pdf"
+        : report.file_path.endsWith(".png")
+          ? "image/png"
+          : "image/jpeg";
+
+    // Parse with Claude Vision
+    const parsed = await parseReportWithClaude(
+      base64,
+      mediaType as "application/pdf" | "image/png" | "image/jpeg"
+    );
+
+    // Store parsed results
+    const { data: parsedResult, error: insertError } = await supabase
+      .from("parsed_results")
+      .insert({
+        report_id: report.id,
+        raw_extraction: parsed,
+        biomarkers: parsed.biomarkers,
+        summary_plain: parsed.summary,
+      })
+      .select("id")
+      .single();
+
+    if (insertError || !parsedResult) {
+      await supabase
+        .from("reports")
+        .update({ status: "error" })
+        .eq("id", report.id);
+      return NextResponse.json(
+        { error: "Failed to store parsed results" },
+        { status: 500 }
+      );
+    }
+
+    // Create risk flags for each biomarker
+    const riskFlags = parsed.biomarkers
+      .filter((b) => b.flag && b.value != null)
+      .map((b) => ({
+        parsed_result_id: parsedResult.id,
+        biomarker_name: b.name,
+        value: b.value,
+        reference_low: b.reference_low,
+        reference_high: b.reference_high,
+        flag: b.flag,
+        trend: "unknown" as const,
+      }));
+
+    if (riskFlags.length > 0) {
+      await supabase.from("risk_flags").insert(riskFlags);
+    }
+
+    // Update report status to 'parsed'
+    await supabase
+      .from("reports")
+      .update({ status: "parsed" })
+      .eq("id", report.id);
+
+    return NextResponse.json(
+      {
+        parsed_result_id: parsedResult.id,
+        biomarker_count: parsed.biomarkers.length,
+        risk_flags_count: riskFlags.length,
+        summary: parsed.summary,
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    // Set status to error on any failure
+    await supabase
+      .from("reports")
+      .update({ status: "error" })
+      .eq("id", report.id);
+
+    const message =
+      error instanceof Error ? error.message : "Parsing failed";
+    return NextResponse.json(
+      { error: `Parsing failed: ${message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/claude/client.ts
+++ b/lib/claude/client.ts
@@ -1,0 +1,12 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+let client: Anthropic | null = null;
+
+export function getClaudeClient(): Anthropic {
+  if (!client) {
+    client = new Anthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    });
+  }
+  return client;
+}

--- a/lib/claude/parse-report.ts
+++ b/lib/claude/parse-report.ts
@@ -1,0 +1,89 @@
+import { getClaudeClient } from "./client";
+import { PARSE_REPORT_SYSTEM_PROMPT, PARSE_REPORT_USER_PROMPT } from "./prompts";
+import Anthropic from "@anthropic-ai/sdk";
+
+export interface ParsedBiomarker {
+  name: string;
+  value: number;
+  unit: string;
+  reference_low: number | null;
+  reference_high: number | null;
+  flag: "green" | "yellow" | "red";
+}
+
+export interface ParsedReportResult {
+  biomarkers: ParsedBiomarker[];
+  summary: string;
+}
+
+/**
+ * Sends a medical report (as base64 image or PDF) to Claude Vision
+ * and returns structured extraction results.
+ */
+export async function parseReportWithClaude(
+  fileBase64: string,
+  mediaType: "image/jpeg" | "image/png" | "application/pdf"
+): Promise<ParsedReportResult> {
+  const client = getClaudeClient();
+
+  const imageContent: Anthropic.ImageBlockParam | Anthropic.DocumentBlockParam =
+    mediaType === "application/pdf"
+      ? {
+          type: "document",
+          source: {
+            type: "base64",
+            media_type: mediaType,
+            data: fileBase64,
+          },
+        }
+      : {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: mediaType,
+            data: fileBase64,
+          },
+        };
+
+  const response = await client.messages.create({
+    model: "claude-sonnet-4-20250514",
+    max_tokens: 4096,
+    system: PARSE_REPORT_SYSTEM_PROMPT,
+    messages: [
+      {
+        role: "user",
+        content: [
+          imageContent,
+          {
+            type: "text",
+            text: PARSE_REPORT_USER_PROMPT,
+          },
+        ],
+      },
+    ],
+  });
+
+  // Extract text from response
+  const textBlock = response.content.find((block) => block.type === "text");
+  if (!textBlock || textBlock.type !== "text") {
+    throw new Error("No text response from Claude");
+  }
+
+  // Parse JSON from response — handle markdown code blocks
+  let jsonStr = textBlock.text.trim();
+  if (jsonStr.startsWith("```")) {
+    jsonStr = jsonStr.replace(/^```(?:json)?\n?/, "").replace(/\n?```$/, "");
+  }
+
+  const parsed = JSON.parse(jsonStr) as ParsedReportResult;
+
+  // Validate structure
+  if (!Array.isArray(parsed.biomarkers)) {
+    throw new Error("Invalid response: biomarkers must be an array");
+  }
+  if (typeof parsed.summary !== "string") {
+    throw new Error("Invalid response: summary must be a string");
+  }
+
+  return parsed;
+}

--- a/lib/claude/prompts.ts
+++ b/lib/claude/prompts.ts
@@ -1,0 +1,30 @@
+export const PARSE_REPORT_SYSTEM_PROMPT = `You are a medical report data extraction assistant. Your ONLY job is to extract structured data from medical reports. You do NOT provide medical advice, diagnoses, or treatment recommendations.
+
+Extract the following from the document:
+1. Biomarkers/lab values with their names, values, units, and reference ranges
+2. A plain-language summary of what the report contains
+
+IMPORTANT RULES:
+- Extract data exactly as it appears in the document
+- If a value is unclear or unreadable, mark it as null
+- If reference ranges are not provided, set reference_low and reference_high to null
+- Do NOT interpret, diagnose, or suggest treatments
+- Do NOT add information that is not in the document
+
+Respond ONLY with valid JSON in this exact format:
+{
+  "biomarkers": [
+    {
+      "name": "string — biomarker/test name",
+      "value": "number — the numeric value",
+      "unit": "string — unit of measurement (e.g., mg/dL, mmol/L)",
+      "reference_low": "number or null — lower bound of normal range",
+      "reference_high": "number or null — upper bound of normal range",
+      "flag": "string — 'green' if within range, 'yellow' if borderline (within 10% of boundary), 'red' if outside range, 'green' if no range available"
+    }
+  ],
+  "summary": "string — 1-3 sentence plain-language summary of the report contents, written at a 5th grade reading level"
+}`;
+
+export const PARSE_REPORT_USER_PROMPT =
+  "Extract all biomarkers, lab values, and test results from this medical report. Return structured JSON only.";

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "agile-flow-starter",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.80.0",
         "@sentry/nextjs": "^9",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.100.1",
@@ -26,6 +27,26 @@
         "jsdom": "^26",
         "typescript": "^5",
         "vitest": "^3"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
+      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -292,7 +313,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -8074,6 +8094,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -10203,6 +10236,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.80.0",
     "@sentry/nextjs": "^9",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.100.1",


### PR DESCRIPTION
## Summary
- Adds `POST /api/parse` endpoint that sends uploaded reports to Claude Vision for extraction
- Creates Claude client (`lib/claude/client.ts`) and parsing prompts (`lib/claude/prompts.ts`)
- Extracts biomarkers, lab values, units, reference ranges into structured ParsedResult records
- Auto-creates RiskFlag records (green/yellow/red) for each biomarker
- Updates report status through lifecycle: `uploaded` → `parsing` → `parsed` (or `error`)
- Defense-in-depth: verifies report ownership both via RLS and explicit user_id check

## Files Added
- `lib/claude/client.ts` — Singleton Anthropic client
- `lib/claude/prompts.ts` — System/user prompts for extraction (no medical advice)
- `lib/claude/parse-report.ts` — Claude Vision parsing logic with JSON validation
- `app/api/parse/route.ts` — Parse API route handler

## New env var required
- `ANTHROPIC_API_KEY` — add to Render and `.env.local`

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (9 new parsing tests, 54 total)
- [x] Pre-push hook passes
- [ ] Manual: Upload a lab report PDF, call `/api/parse`, verify extracted biomarkers

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)