### PR TITLE
feat(api): add health simplification engine (#27)

### DIFF
--- a/__tests__/health-simplification.test.ts
+++ b/__tests__/health-simplification.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Simplification Prompts ──────────────────────────────────────────
+
+describe("Simplification Prompts", () => {
+  it("exports system prompt, user prompt, and formatter", async () => {
+    const mod = await import("@/lib/claude/simplification-prompts");
+    expect(mod.SIMPLIFICATION_SYSTEM_PROMPT).toBeDefined();
+    expect(mod.SIMPLIFICATION_USER_PROMPT).toBeDefined();
+    expect(mod.formatBiomarkersForSimplification).toBeDefined();
+  });
+
+  it("system prompt requires 5th grade reading level", async () => {
+    const { SIMPLIFICATION_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/simplification-prompts"
+    );
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain("5th grade");
+  });
+
+  it("system prompt prohibits diagnoses", async () => {
+    const { SIMPLIFICATION_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/simplification-prompts"
+    );
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain("Do NOT diagnose");
+  });
+
+  it("system prompt requires JSON response format", async () => {
+    const { SIMPLIFICATION_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/simplification-prompts"
+    );
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain('"overall"');
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain('"biomarkers"');
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain('"explanation"');
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain('"importance"');
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain('"action"');
+  });
+
+  it("system prompt requires disclaimer in response", async () => {
+    const { SIMPLIFICATION_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/simplification-prompts"
+    );
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain('"disclaimer"');
+  });
+
+  it("formatBiomarkersForSimplification formats biomarkers correctly", async () => {
+    const { formatBiomarkersForSimplification } = await import(
+      "@/lib/claude/simplification-prompts"
+    );
+
+    const biomarkers = [
+      {
+        name: "Glucose",
+        value: 95,
+        unit: "mg/dL",
+        reference_low: 70,
+        reference_high: 100,
+        flag: "green",
+      },
+      {
+        name: "Cholesterol",
+        value: 250,
+        unit: "mg/dL",
+        reference_low: null,
+        reference_high: null,
+        flag: "red",
+      },
+    ];
+
+    const result = formatBiomarkersForSimplification(biomarkers);
+
+    expect(result).toContain("Glucose: 95 mg/dL");
+    expect(result).toContain("Normal range: 70-100 mg/dL");
+    expect(result).toContain("Flag: green");
+    expect(result).toContain("Cholesterol: 250 mg/dL");
+    expect(result).toContain("Normal range: not available");
+    expect(result).toContain("Flag: red");
+  });
+});
+
+// ── Summary API Route ───────────────────────────────────────────────
+
+describe("Summary API Route", () => {
+  it("exports a GET handler", async () => {
+    const mod = await import("@/app/api/reports/[id]/summary/route");
+    expect(mod.GET).toBeDefined();
+    expect(typeof mod.GET).toBe("function");
+  });
+});
+
+// ── Summary API Contract Tests ──────────────────────────────────────
+
+describe("Summary API Contract", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+  let mockMessagesCreate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+    mockMessagesCreate = vi.fn();
+
+    // Mock Supabase server client
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+      }),
+    }));
+
+    // Mock Claude client
+    vi.doMock("@/lib/claude/client", () => ({
+      getClaudeClient: vi.fn().mockReturnValue({
+        messages: { create: mockMessagesCreate },
+      }),
+    }));
+  });
+
+  function buildRequest(): Request {
+    return new Request("http://localhost:3000/api/reports/report-123/summary", {
+      method: "GET",
+    });
+  }
+
+  function buildParams(): Promise<{ id: string }> {
+    return Promise.resolve({ id: "report-123" });
+  }
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { GET } = await import("@/app/api/reports/[id]/summary/route");
+    const response = await GET(buildRequest(), { params: buildParams() });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 404 when report is not found", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: null, error: { message: "not found" } }),
+        }),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/reports/[id]/summary/route");
+    const response = await GET(buildRequest(), { params: buildParams() });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 403 when user does not own the report", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    // First call: reports table — returns report owned by different user
+    // Second call: parsed_results — should not be reached
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: "report-123", user_id: "other-user", status: "parsed" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+      };
+    });
+
+    const { GET } = await import("@/app/api/reports/[id]/summary/route");
+    const response = await GET(buildRequest(), { params: buildParams() });
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("Forbidden");
+  });
+
+  it("returns cached summary when available", async () => {
+    const cachedSummary = {
+      overall: "Your results look good.",
+      biomarkers: [
+        {
+          name: "Glucose",
+          value: "95 mg/dL",
+          flag: "green",
+          explanation: "This measures sugar in your blood.",
+          importance: "It tells us about diabetes risk.",
+          action: "Keep eating healthy.",
+        },
+      ],
+      disclaimer: "Talk to your doctor.",
+    };
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // reports table
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: "report-123", user_id: "user-1", status: "parsed" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      // parsed_results table — has cached summary
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: "pr-1",
+                biomarkers: [],
+                summary_plain: JSON.stringify(cachedSummary),
+              },
+              error: null,
+            }),
+          }),
+        }),
+      };
+    });
+
+    const { GET } = await import("@/app/api/reports/[id]/summary/route");
+    const response = await GET(buildRequest(), { params: buildParams() });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.cached).toBe(true);
+    expect(body.summary.overall).toBe("Your results look good.");
+    expect(body.summary.biomarkers).toHaveLength(1);
+    // Claude should NOT have been called
+    expect(mockMessagesCreate).not.toHaveBeenCalled();
+  });
+
+  it("calls Claude and returns simplified summary when no cache", async () => {
+    const simplifiedResponse = {
+      overall: "Your lab results look mostly normal.",
+      biomarkers: [
+        {
+          name: "Glucose",
+          value: "95 mg/dL",
+          flag: "green",
+          explanation: "This measures sugar in your blood.",
+          importance: "It helps check for diabetes.",
+          action: "Keep eating well and exercising.",
+        },
+      ],
+      disclaimer: "These explanations are for educational purposes only.",
+    };
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // reports table
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: "report-123", user_id: "user-1", status: "parsed" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (callCount === 2) {
+        // parsed_results table — no cached summary
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: "pr-1",
+                  biomarkers: [
+                    {
+                      name: "Glucose",
+                      value: 95,
+                      unit: "mg/dL",
+                      reference_low: 70,
+                      reference_high: 100,
+                      flag: "green",
+                    },
+                  ],
+                  summary_plain: "Basic extraction summary",
+                },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      // Update call for caching
+      return {
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      };
+    });
+
+    mockMessagesCreate.mockResolvedValue({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(simplifiedResponse),
+        },
+      ],
+    });
+
+    const { GET } = await import("@/app/api/reports/[id]/summary/route");
+    const response = await GET(buildRequest(), { params: buildParams() });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.cached).toBe(false);
+    expect(body.summary.overall).toBe("Your lab results look mostly normal.");
+    expect(body.summary.biomarkers).toHaveLength(1);
+    expect(body.summary.biomarkers[0].explanation).toContain("sugar");
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── HealthSummary Component ─────────────────────────────────────────
+
+describe("HealthSummary Component", () => {
+  it("exports a default component", async () => {
+    const mod = await import("@/components/reports/HealthSummary");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+});

--- a/app/api/reports/[id]/summary/route.ts
+++ b/app/api/reports/[id]/summary/route.ts
@@ -1,0 +1,174 @@
+import { createClient } from "@/lib/supabase/server";
+import { getClaudeClient } from "@/lib/claude/client";
+import {
+  SIMPLIFICATION_SYSTEM_PROMPT,
+  SIMPLIFICATION_USER_PROMPT,
+  formatBiomarkersForSimplification,
+} from "@/lib/claude/simplification-prompts";
+import { NextResponse } from "next/server";
+
+export interface SimplifiedBiomarker {
+  name: string;
+  value: string;
+  flag: string;
+  explanation: string;
+  importance: string;
+  action: string;
+}
+
+export interface SimplifiedSummary {
+  overall: string;
+  biomarkers: SimplifiedBiomarker[];
+  disclaimer: string;
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id: reportId } = await params;
+
+  // Verify authentication
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Fetch report and verify ownership
+  const { data: report, error: reportError } = await supabase
+    .from("reports")
+    .select("id, user_id, status")
+    .eq("id", reportId)
+    .single();
+
+  if (reportError || !report) {
+    return NextResponse.json({ error: "Report not found" }, { status: 404 });
+  }
+
+  if (report.user_id !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Fetch parsed results for this report
+  const { data: parsedResult, error: parsedError } = await supabase
+    .from("parsed_results")
+    .select("id, biomarkers, summary_plain")
+    .eq("report_id", reportId)
+    .single();
+
+  if (parsedError || !parsedResult) {
+    return NextResponse.json(
+      { error: "No parsed results found. Parse the report first." },
+      { status: 404 }
+    );
+  }
+
+  // Check for cached simplified summary
+  if (parsedResult.summary_plain && isSimplifiedSummary(parsedResult.summary_plain)) {
+    return NextResponse.json(
+      { summary: JSON.parse(parsedResult.summary_plain as string), cached: true },
+      { status: 200 }
+    );
+  }
+
+  // Validate biomarkers exist
+  const biomarkers = parsedResult.biomarkers as Array<{
+    name: string;
+    value: number;
+    unit: string;
+    reference_low: number | null;
+    reference_high: number | null;
+    flag: string;
+  }>;
+
+  if (!Array.isArray(biomarkers) || biomarkers.length === 0) {
+    return NextResponse.json(
+      { error: "No biomarkers found in parsed results" },
+      { status: 422 }
+    );
+  }
+
+  try {
+    // Build prompt with biomarker data
+    const biomarkerText = formatBiomarkersForSimplification(biomarkers);
+    const userMessage = `${SIMPLIFICATION_USER_PROMPT}\n\n${biomarkerText}`;
+
+    // Call Claude for simplification
+    const client = getClaudeClient();
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 4096,
+      system: SIMPLIFICATION_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: userMessage,
+        },
+      ],
+    });
+
+    // Extract text from response
+    const textBlock = response.content.find((block) => block.type === "text");
+    if (!textBlock || textBlock.type !== "text") {
+      throw new Error("No text response from Claude");
+    }
+
+    // Parse JSON — handle markdown code blocks
+    let jsonStr = textBlock.text.trim();
+    if (jsonStr.startsWith("```")) {
+      jsonStr = jsonStr.replace(/^```(?:json)?\n?/, "").replace(/\n?```$/, "");
+    }
+
+    const simplified = JSON.parse(jsonStr) as SimplifiedSummary;
+
+    // Validate structure
+    if (typeof simplified.overall !== "string") {
+      throw new Error("Invalid response: overall must be a string");
+    }
+    if (!Array.isArray(simplified.biomarkers)) {
+      throw new Error("Invalid response: biomarkers must be an array");
+    }
+
+    // Cache the simplified summary in parsed_results.summary_plain
+    await supabase
+      .from("parsed_results")
+      .update({ summary_plain: JSON.stringify(simplified) })
+      .eq("id", parsedResult.id);
+
+    return NextResponse.json(
+      { summary: simplified, cached: false },
+      { status: 200 }
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Simplification failed";
+    return NextResponse.json(
+      { error: `Simplification failed: ${message}` },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Checks if summary_plain contains a simplified summary JSON
+ * (vs the raw extraction summary string from initial parsing).
+ */
+function isSimplifiedSummary(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  try {
+    const parsed = JSON.parse(value);
+    return (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "overall" in parsed &&
+      "biomarkers" in parsed &&
+      Array.isArray(parsed.biomarkers)
+    );
+  } catch {
+    return false;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -474,3 +474,187 @@ button[type="submit"]:disabled {
   margin: 0.5rem 0.25rem;
   font-size: 0.85rem;
 }
+
+/* =========================
+   Health Summary Styles
+   ========================= */
+
+.health-summary {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.health-summary--loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  color: #666;
+}
+
+.health-summary__spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #e0e0e0;
+  border-top-color: #0066ff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-bottom: 1rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.health-summary--error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.health-summary__error {
+  color: #dc2626;
+  font-size: 0.95rem;
+}
+
+.health-summary__retry {
+  padding: 0.5rem 1.5rem;
+  background: #0066ff;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.health-summary__retry:hover {
+  background: #0052cc;
+}
+
+.health-summary__disclaimer {
+  background: #fff9e6;
+  border: 1px solid #ffd700;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.85rem;
+  color: #856404;
+  line-height: 1.5;
+}
+
+.health-summary__overall {
+  margin-bottom: 2rem;
+}
+
+.health-summary__overall h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+  color: #1a1a1a;
+}
+
+.health-summary__overall p {
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #333;
+}
+
+.health-summary__biomarkers h2 {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+  color: #1a1a1a;
+}
+
+.health-summary__biomarker {
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+
+.health-summary__biomarker--green {
+  border-left: 4px solid #22c55e;
+}
+
+.health-summary__biomarker--yellow {
+  border-left: 4px solid #eab308;
+}
+
+.health-summary__biomarker--red {
+  border-left: 4px solid #ef4444;
+}
+
+.health-summary__biomarker-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #f9fafb;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.health-summary__biomarker-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #1a1a1a;
+  flex: 1;
+}
+
+.health-summary__biomarker-value {
+  font-size: 0.9rem;
+  color: #555;
+  font-family: monospace;
+}
+
+.health-summary__flag {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 12px;
+  text-transform: uppercase;
+}
+
+.health-summary__flag--green {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.health-summary__flag--yellow {
+  background: #fef9c3;
+  color: #854d0e;
+}
+
+.health-summary__flag--red {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.health-summary__biomarker-body {
+  padding: 1rem;
+}
+
+.health-summary__section {
+  margin-bottom: 0.75rem;
+}
+
+.health-summary__section:last-child {
+  margin-bottom: 0;
+}
+
+.health-summary__section h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #555;
+  margin-bottom: 0.25rem;
+}
+
+.health-summary__section p {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: #333;
+}

--- a/components/reports/HealthSummary.tsx
+++ b/components/reports/HealthSummary.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+interface SimplifiedBiomarker {
+  name: string;
+  value: string;
+  flag: string;
+  explanation: string;
+  importance: string;
+  action: string;
+}
+
+interface SimplifiedSummary {
+  overall: string;
+  biomarkers: SimplifiedBiomarker[];
+  disclaimer: string;
+}
+
+interface HealthSummaryProps {
+  reportId: string;
+}
+
+export default function HealthSummary({ reportId }: HealthSummaryProps) {
+  const [summary, setSummary] = useState<SimplifiedSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSummary = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/reports/${reportId}/summary`);
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to load summary");
+      }
+
+      const data = await response.json();
+      setSummary(data.summary);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load summary");
+    } finally {
+      setLoading(false);
+    }
+  }, [reportId]);
+
+  useEffect(() => {
+    fetchSummary();
+  }, [fetchSummary]);
+
+  if (loading) {
+    return (
+      <div className="health-summary health-summary--loading">
+        <div className="health-summary__spinner" aria-label="Loading summary" />
+        <p>Simplifying your results...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="health-summary health-summary--error">
+        <p className="health-summary__error">{error}</p>
+        <button onClick={fetchSummary} className="health-summary__retry">
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  if (!summary) {
+    return null;
+  }
+
+  return (
+    <div className="health-summary">
+      <div className="health-summary__disclaimer" role="alert">
+        {summary.disclaimer}
+      </div>
+
+      <div className="health-summary__overall">
+        <h2>Your Results Overview</h2>
+        <p>{summary.overall}</p>
+      </div>
+
+      <div className="health-summary__biomarkers">
+        <h2>Your Lab Results Explained</h2>
+        {summary.biomarkers.map((biomarker, index) => (
+          <div
+            key={index}
+            className={`health-summary__biomarker health-summary__biomarker--${biomarker.flag}`}
+          >
+            <div className="health-summary__biomarker-header">
+              <span className="health-summary__biomarker-name">
+                {biomarker.name}
+              </span>
+              <span className="health-summary__biomarker-value">
+                {biomarker.value}
+              </span>
+              <span
+                className={`health-summary__flag health-summary__flag--${biomarker.flag}`}
+                aria-label={`Status: ${biomarker.flag}`}
+              >
+                {biomarker.flag === "green"
+                  ? "Normal"
+                  : biomarker.flag === "yellow"
+                    ? "Borderline"
+                    : "Needs Attention"}
+              </span>
+            </div>
+            <div className="health-summary__biomarker-body">
+              <div className="health-summary__section">
+                <h3>What is this?</h3>
+                <p>{biomarker.explanation}</p>
+              </div>
+              <div className="health-summary__section">
+                <h3>Why does it matter?</h3>
+                <p>{biomarker.importance}</p>
+              </div>
+              <div className="health-summary__section">
+                <h3>What should I do?</h3>
+                <p>{biomarker.action}</p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/claude/simplification-prompts.ts
+++ b/lib/claude/simplification-prompts.ts
@@ -1,0 +1,52 @@
+export const SIMPLIFICATION_SYSTEM_PROMPT = `You are a health education assistant that explains medical lab results in simple, easy-to-understand language. Your goal is to help people understand their health data at a 5th grade reading level.
+
+IMPORTANT RULES:
+- Use simple words. Avoid medical jargon.
+- Write at a 5th grade reading level (Flesch-Kincaid).
+- Do NOT diagnose conditions or suggest treatments.
+- Do NOT provide medical advice — only explain what values mean.
+- Each biomarker explanation MUST follow this structure: what it means, why it matters, what to do next.
+- If a value is flagged red or yellow, explain what that means simply without causing alarm.
+- Always remind the user to talk to their doctor about their results.
+
+Respond ONLY with valid JSON in this exact format:
+{
+  "overall": "string — A 2-3 sentence overall summary of the report in simple language. Start with something like 'Your lab results show...'",
+  "biomarkers": [
+    {
+      "name": "string — the biomarker name",
+      "value": "string — the value with units (e.g., '120 mg/dL')",
+      "flag": "string — 'green', 'yellow', or 'red'",
+      "explanation": "string — What this test measures, explained simply (1-2 sentences)",
+      "importance": "string — Why this number matters for your health (1-2 sentences)",
+      "action": "string — What you can do or ask your doctor about (1-2 sentences)"
+    }
+  ],
+  "disclaimer": "These explanations are for educational purposes only. They are not medical advice. Please talk to your doctor about your results and what they mean for you."
+}`;
+
+export const SIMPLIFICATION_USER_PROMPT = `Explain the following lab results in simple language that a 5th grader could understand. For each biomarker, explain what it measures, why it matters, and what the person should do next. Here are the biomarkers:`;
+
+/**
+ * Formats biomarker data into a string for the simplification prompt.
+ */
+export function formatBiomarkersForSimplification(
+  biomarkers: Array<{
+    name: string;
+    value: number;
+    unit: string;
+    reference_low: number | null;
+    reference_high: number | null;
+    flag: string;
+  }>
+): string {
+  return biomarkers
+    .map((b) => {
+      const range =
+        b.reference_low != null && b.reference_high != null
+          ? `Normal range: ${b.reference_low}-${b.reference_high} ${b.unit}`
+          : "Normal range: not available";
+      return `- ${b.name}: ${b.value} ${b.unit} (${range}, Flag: ${b.flag})`;
+    })
+    .join("\n");
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/reports/[id]/summary` endpoint that generates plain-language explanations of biomarker data at a 5th grade reading level via Claude
- Caches simplified summaries in `parsed_results.summary_plain` to avoid redundant API calls
- Creates `HealthSummary` component with green/yellow/red flag indicators and structured sections (What is this? / Why does it matter? / What should I do?)
- Includes medical disclaimer in every summary response
- 13 new tests covering prompts, API contract (401/403/404/caching/Claude integration), and component export

## New Files
- `lib/claude/simplification-prompts.ts` — System/user prompts + biomarker formatter
- `app/api/reports/[id]/summary/route.ts` — GET endpoint with auth, ownership, caching, Claude call
- `components/reports/HealthSummary.tsx` — Client component for rendering simplified summaries
- `__tests__/health-simplification.test.ts` — 13 test cases

## Modified Files
- `app/globals.css` — Health summary styles (loading spinner, flag badges, biomarker cards)

## Test plan
- [ ] GET `/api/reports/{id}/summary` returns structured simplified summary
- [ ] Cached summaries are returned without calling Claude
- [ ] Unauthenticated requests return 401
- [ ] Accessing another user's report returns 403
- [ ] HealthSummary component renders biomarker explanations with flags
- [ ] All 73 tests pass

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)