### PR TITLE
feat(api): add risk flagging system Green/Yellow/Red (#28)

### DIFF
--- a/__tests__/risk-flagging.test.ts
+++ b/__tests__/risk-flagging.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Risk Calculator ─────────────────────────────────────────────────
+
+describe("Risk Calculator", () => {
+  it("exports calculateRiskFlag and calculateRiskFlags", async () => {
+    const mod = await import("@/lib/risk/calculator");
+    expect(mod.calculateRiskFlag).toBeDefined();
+    expect(mod.calculateRiskFlags).toBeDefined();
+  });
+
+  describe("calculateRiskFlag", () => {
+    let calculateRiskFlag: (
+      value: number,
+      low: number | null,
+      high: number | null
+    ) => string;
+
+    beforeEach(async () => {
+      const mod = await import("@/lib/risk/calculator");
+      calculateRiskFlag = mod.calculateRiskFlag;
+    });
+
+    // Green — within range
+    it("returns green when value is within reference range", () => {
+      expect(calculateRiskFlag(85, 70, 100)).toBe("green");
+    });
+
+    it("returns green when value equals low boundary", () => {
+      expect(calculateRiskFlag(70, 70, 100)).toBe("green");
+    });
+
+    it("returns green when value equals high boundary", () => {
+      expect(calculateRiskFlag(100, 70, 100)).toBe("green");
+    });
+
+    it("returns green when no reference range is provided", () => {
+      expect(calculateRiskFlag(150, null, null)).toBe("green");
+    });
+
+    // Yellow — within 10% of boundary
+    it("returns yellow when value is slightly below low bound (within 10%)", () => {
+      // Low = 70, 10% of 70 = 7, so 63-69 is yellow
+      expect(calculateRiskFlag(65, 70, 100)).toBe("yellow");
+    });
+
+    it("returns yellow when value is slightly above high bound (within 10%)", () => {
+      // High = 100, 10% of 100 = 10, so 101-110 is yellow
+      expect(calculateRiskFlag(105, 70, 100)).toBe("yellow");
+    });
+
+    it("returns yellow at the exact 10% boundary below low", () => {
+      // Low = 70, 10% = 7, boundary = 63
+      expect(calculateRiskFlag(63, 70, 100)).toBe("yellow");
+    });
+
+    it("returns yellow at the exact 10% boundary above high", () => {
+      // High = 100, 10% = 10, boundary = 110
+      expect(calculateRiskFlag(110, 70, 100)).toBe("yellow");
+    });
+
+    // Red — more than 10% outside range
+    it("returns red when value is >10% below low bound", () => {
+      // Low = 70, 10% = 7, below 63 is red
+      expect(calculateRiskFlag(50, 70, 100)).toBe("red");
+    });
+
+    it("returns red when value is >10% above high bound", () => {
+      // High = 100, 10% = 10, above 110 is red
+      expect(calculateRiskFlag(120, 70, 100)).toBe("red");
+    });
+
+    it("returns red just past the 10% boundary below", () => {
+      // Low = 70, 10% = 7, boundary = 63, so 62.9 is red
+      expect(calculateRiskFlag(62, 70, 100)).toBe("red");
+    });
+
+    it("returns red just past the 10% boundary above", () => {
+      // High = 100, 10% = 10, boundary = 110, so 111 is red
+      expect(calculateRiskFlag(111, 70, 100)).toBe("red");
+    });
+
+    // Only one bound
+    it("returns green when only low bound and value is above it", () => {
+      expect(calculateRiskFlag(80, 70, null)).toBe("green");
+    });
+
+    it("returns yellow when only low bound and value is slightly below", () => {
+      expect(calculateRiskFlag(65, 70, null)).toBe("yellow");
+    });
+
+    it("returns red when only low bound and value is far below", () => {
+      expect(calculateRiskFlag(50, 70, null)).toBe("red");
+    });
+
+    it("returns green when only high bound and value is below it", () => {
+      expect(calculateRiskFlag(80, null, 100)).toBe("green");
+    });
+
+    it("returns yellow when only high bound and value is slightly above", () => {
+      expect(calculateRiskFlag(105, null, 100)).toBe("yellow");
+    });
+
+    it("returns red when only high bound and value is far above", () => {
+      expect(calculateRiskFlag(120, null, 100)).toBe("red");
+    });
+  });
+
+  describe("calculateRiskFlags", () => {
+    it("calculates flags for an array of biomarkers", async () => {
+      const { calculateRiskFlags } = await import("@/lib/risk/calculator");
+
+      const results = calculateRiskFlags([
+        { name: "Glucose", value: 85, reference_low: 70, reference_high: 100 },
+        {
+          name: "Cholesterol",
+          value: 250,
+          reference_low: 125,
+          reference_high: 200,
+        },
+        {
+          name: "TSH",
+          value: 4.2,
+          reference_low: 0.4,
+          reference_high: 4.0,
+        },
+      ]);
+
+      expect(results).toHaveLength(3);
+      expect(results[0].flag).toBe("green"); // 85 in [70, 100]
+      expect(results[1].flag).toBe("red"); // 250 far above 200
+      expect(results[2].flag).toBe("yellow"); // 4.2 slightly above 4.0
+    });
+
+    it("returns correct structure for each result", async () => {
+      const { calculateRiskFlags } = await import("@/lib/risk/calculator");
+
+      const results = calculateRiskFlags([
+        { name: "Glucose", value: 85, reference_low: 70, reference_high: 100 },
+      ]);
+
+      expect(results[0]).toEqual({
+        biomarker_name: "Glucose",
+        value: 85,
+        reference_low: 70,
+        reference_high: 100,
+        flag: "green",
+      });
+    });
+  });
+});
+
+// ── Risk Flags API Route ────────────────────────────────────────────
+
+describe("Risk Flags API Route", () => {
+  it("exports a GET handler", async () => {
+    const mod = await import("@/app/api/risk-flags/route");
+    expect(mod.GET).toBeDefined();
+    expect(typeof mod.GET).toBe("function");
+  });
+});
+
+describe("Risk Flags API Contract", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+      }),
+    }));
+  });
+
+  function buildRequest(reportId?: string): Request {
+    const url = reportId
+      ? `http://localhost:3000/api/risk-flags?report_id=${reportId}`
+      : "http://localhost:3000/api/risk-flags";
+    return new Request(url, { method: "GET" });
+  }
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { GET } = await import("@/app/api/risk-flags/route");
+    const response = await GET(buildRequest("report-123"));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when report_id is missing", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const { GET } = await import("@/app/api/risk-flags/route");
+    const response = await GET(buildRequest());
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("report_id");
+  });
+
+  it("returns 403 when user does not own the report", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { id: "report-123", user_id: "other-user" },
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/risk-flags/route");
+    const response = await GET(buildRequest("report-123"));
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 200 with risk flags and summary for valid request", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const mockFlags = [
+      {
+        id: "f1",
+        biomarker_name: "Glucose",
+        value: 85,
+        reference_low: 70,
+        reference_high: 100,
+        flag: "green",
+        trend: "stable",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "f2",
+        biomarker_name: "Cholesterol",
+        value: 250,
+        reference_low: 125,
+        reference_high: 200,
+        flag: "red",
+        trend: "worsening",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // reports table
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: "report-123", user_id: "user-1" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (callCount === 2) {
+        // parsed_results table
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: "pr-1" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      // risk_flags table
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({
+              data: mockFlags,
+              error: null,
+            }),
+          }),
+        }),
+      };
+    });
+
+    const { GET } = await import("@/app/api/risk-flags/route");
+    const response = await GET(buildRequest("report-123"));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.risk_flags).toHaveLength(2);
+    expect(body.summary.green).toBe(1);
+    expect(body.summary.red).toBe(1);
+    expect(body.summary.total).toBe(2);
+    expect(body.disclaimer).toContain("informational purposes only");
+  });
+});
+
+// ── Risk Components ─────────────────────────────────────────────────
+
+describe("Risk Components", () => {
+  it("RiskIndicator exports a default component", async () => {
+    const mod = await import("@/components/reports/RiskIndicator");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+
+  it("RiskDashboard exports a default component", async () => {
+    const mod = await import("@/components/reports/RiskDashboard");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+});

--- a/app/api/risk-flags/route.ts
+++ b/app/api/risk-flags/route.ts
@@ -1,0 +1,90 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const supabase = await createClient();
+
+  // Verify authentication
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Get report_id from query params
+  const { searchParams } = new URL(request.url);
+  const reportId = searchParams.get("report_id");
+
+  if (!reportId) {
+    return NextResponse.json(
+      { error: "report_id query parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  // Fetch report and verify ownership
+  const { data: report, error: reportError } = await supabase
+    .from("reports")
+    .select("id, user_id")
+    .eq("id", reportId)
+    .single();
+
+  if (reportError || !report) {
+    return NextResponse.json({ error: "Report not found" }, { status: 404 });
+  }
+
+  if (report.user_id !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Fetch parsed result for this report
+  const { data: parsedResult, error: parsedError } = await supabase
+    .from("parsed_results")
+    .select("id")
+    .eq("report_id", reportId)
+    .single();
+
+  if (parsedError || !parsedResult) {
+    return NextResponse.json(
+      { error: "No parsed results found. Parse the report first." },
+      { status: 404 }
+    );
+  }
+
+  // Fetch risk flags for this parsed result
+  const { data: riskFlags, error: flagsError } = await supabase
+    .from("risk_flags")
+    .select(
+      "id, biomarker_name, value, reference_low, reference_high, flag, trend, created_at"
+    )
+    .eq("parsed_result_id", parsedResult.id)
+    .order("created_at", { ascending: true });
+
+  if (flagsError) {
+    return NextResponse.json(
+      { error: "Failed to fetch risk flags" },
+      { status: 500 }
+    );
+  }
+
+  // Build summary counts
+  const summary = {
+    total: riskFlags.length,
+    green: riskFlags.filter((f) => f.flag === "green").length,
+    yellow: riskFlags.filter((f) => f.flag === "yellow").length,
+    red: riskFlags.filter((f) => f.flag === "red").length,
+  };
+
+  return NextResponse.json(
+    {
+      report_id: reportId,
+      risk_flags: riskFlags,
+      summary,
+      disclaimer:
+        "These indicators are for informational purposes only. They are not medical diagnoses. Please consult your doctor about your results.",
+    },
+    { status: 200 }
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -658,3 +658,231 @@ button[type="submit"]:disabled {
   line-height: 1.5;
   color: #333;
 }
+
+/* =========================
+   Risk Indicator Styles
+   ========================= */
+
+.risk-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+  background: #fff;
+}
+
+.risk-indicator--green {
+  border-left: 4px solid #22c55e;
+}
+
+.risk-indicator--yellow {
+  border-left: 4px solid #eab308;
+}
+
+.risk-indicator--red {
+  border-left: 4px solid #ef4444;
+}
+
+.risk-indicator--sm {
+  padding: 0.5rem 0.75rem;
+}
+
+.risk-indicator--lg {
+  padding: 1rem 1.25rem;
+}
+
+.risk-indicator__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.risk-indicator__dot--green {
+  background: #22c55e;
+}
+
+.risk-indicator__dot--yellow {
+  background: #eab308;
+}
+
+.risk-indicator__dot--red {
+  background: #ef4444;
+}
+
+.risk-indicator__info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.risk-indicator__name {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #1a1a1a;
+}
+
+.risk-indicator__value {
+  font-size: 0.8rem;
+  color: #666;
+  font-family: monospace;
+}
+
+.risk-indicator__badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.2rem 0.5rem;
+  border-radius: 12px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.risk-indicator__badge--green {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.risk-indicator__badge--yellow {
+  background: #fef9c3;
+  color: #854d0e;
+}
+
+.risk-indicator__badge--red {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+/* =========================
+   Risk Dashboard Styles
+   ========================= */
+
+.risk-dashboard {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.risk-dashboard--loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  color: #666;
+}
+
+.risk-dashboard__spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #e0e0e0;
+  border-top-color: #0066ff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-bottom: 1rem;
+}
+
+.risk-dashboard--error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.risk-dashboard__error {
+  color: #dc2626;
+  font-size: 0.95rem;
+}
+
+.risk-dashboard__retry {
+  padding: 0.5rem 1.5rem;
+  background: #0066ff;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.risk-dashboard__retry:hover {
+  background: #0052cc;
+}
+
+.risk-dashboard--empty {
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+}
+
+.risk-dashboard__disclaimer {
+  background: #fff9e6;
+  border: 1px solid #ffd700;
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.85rem;
+  color: #856404;
+  line-height: 1.5;
+}
+
+.risk-dashboard__summary {
+  margin-bottom: 2rem;
+}
+
+.risk-dashboard__summary h2 {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+  color: #1a1a1a;
+}
+
+.risk-dashboard__counts {
+  display: flex;
+  gap: 1rem;
+}
+
+.risk-dashboard__count {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem;
+  border-radius: 10px;
+  border: 1px solid #e0e0e0;
+}
+
+.risk-dashboard__count--green {
+  background: #f0fdf4;
+  border-color: #bbf7d0;
+}
+
+.risk-dashboard__count--yellow {
+  background: #fefce8;
+  border-color: #fef08a;
+}
+
+.risk-dashboard__count--red {
+  background: #fef2f2;
+  border-color: #fecaca;
+}
+
+.risk-dashboard__count-number {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #1a1a1a;
+}
+
+.risk-dashboard__count-label {
+  font-size: 0.8rem;
+  color: #555;
+  margin-top: 0.25rem;
+}
+
+.risk-dashboard__flags h2 {
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
+  color: #1a1a1a;
+}

--- a/components/reports/RiskDashboard.tsx
+++ b/components/reports/RiskDashboard.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import RiskIndicator from "./RiskIndicator";
+
+interface RiskFlagData {
+  id: string;
+  biomarker_name: string;
+  value: number;
+  reference_low: number | null;
+  reference_high: number | null;
+  flag: "green" | "yellow" | "red";
+  trend: string;
+}
+
+interface RiskSummary {
+  total: number;
+  green: number;
+  yellow: number;
+  red: number;
+}
+
+interface RiskDashboardProps {
+  reportId: string;
+}
+
+export default function RiskDashboard({ reportId }: RiskDashboardProps) {
+  const [riskFlags, setRiskFlags] = useState<RiskFlagData[]>([]);
+  const [summary, setSummary] = useState<RiskSummary | null>(null);
+  const [disclaimer, setDisclaimer] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRiskFlags = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(
+        `/api/risk-flags?report_id=${reportId}`
+      );
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to load risk flags");
+      }
+
+      const data = await response.json();
+      setRiskFlags(data.risk_flags);
+      setSummary(data.summary);
+      setDisclaimer(data.disclaimer);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load risk flags"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [reportId]);
+
+  useEffect(() => {
+    fetchRiskFlags();
+  }, [fetchRiskFlags]);
+
+  if (loading) {
+    return (
+      <div className="risk-dashboard risk-dashboard--loading">
+        <div
+          className="risk-dashboard__spinner"
+          aria-label="Loading risk flags"
+          role="status"
+        />
+        <p>Analyzing your results...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="risk-dashboard risk-dashboard--error">
+        <p className="risk-dashboard__error">{error}</p>
+        <button onClick={fetchRiskFlags} className="risk-dashboard__retry">
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  if (riskFlags.length === 0) {
+    return (
+      <div className="risk-dashboard risk-dashboard--empty">
+        <p>No risk flags available for this report.</p>
+      </div>
+    );
+  }
+
+  // Sort: red first, then yellow, then green
+  const sortedFlags = [...riskFlags].sort((a, b) => {
+    const order = { red: 0, yellow: 1, green: 2 };
+    return order[a.flag] - order[b.flag];
+  });
+
+  return (
+    <div className="risk-dashboard">
+      {disclaimer && (
+        <div className="risk-dashboard__disclaimer" role="alert">
+          {disclaimer}
+        </div>
+      )}
+
+      {summary && (
+        <div className="risk-dashboard__summary">
+          <h2>Risk Overview</h2>
+          <div className="risk-dashboard__counts">
+            <div className="risk-dashboard__count risk-dashboard__count--green">
+              <span className="risk-dashboard__count-number">
+                {summary.green}
+              </span>
+              <span className="risk-dashboard__count-label">Normal</span>
+            </div>
+            <div className="risk-dashboard__count risk-dashboard__count--yellow">
+              <span className="risk-dashboard__count-number">
+                {summary.yellow}
+              </span>
+              <span className="risk-dashboard__count-label">Borderline</span>
+            </div>
+            <div className="risk-dashboard__count risk-dashboard__count--red">
+              <span className="risk-dashboard__count-number">
+                {summary.red}
+              </span>
+              <span className="risk-dashboard__count-label">
+                Needs Attention
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="risk-dashboard__flags">
+        <h2>Your Results</h2>
+        {sortedFlags.map((flag) => (
+          <RiskIndicator
+            key={flag.id}
+            flag={flag.flag}
+            biomarkerName={flag.biomarker_name}
+            value={Number(flag.value)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/reports/RiskIndicator.tsx
+++ b/components/reports/RiskIndicator.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+interface RiskIndicatorProps {
+  flag: "green" | "yellow" | "red";
+  biomarkerName: string;
+  value: number;
+  unit?: string;
+  size?: "sm" | "md" | "lg";
+}
+
+const FLAG_LABELS: Record<string, string> = {
+  green: "Normal",
+  yellow: "Borderline",
+  red: "Needs Attention",
+};
+
+export default function RiskIndicator({
+  flag,
+  biomarkerName,
+  value,
+  unit,
+  size = "md",
+}: RiskIndicatorProps) {
+  return (
+    <div
+      className={`risk-indicator risk-indicator--${flag} risk-indicator--${size}`}
+      role="status"
+      aria-label={`${biomarkerName}: ${FLAG_LABELS[flag]}`}
+    >
+      <div className={`risk-indicator__dot risk-indicator__dot--${flag}`} />
+      <div className="risk-indicator__info">
+        <span className="risk-indicator__name">{biomarkerName}</span>
+        <span className="risk-indicator__value">
+          {value}
+          {unit ? ` ${unit}` : ""}
+        </span>
+      </div>
+      <span
+        className={`risk-indicator__badge risk-indicator__badge--${flag}`}
+      >
+        {FLAG_LABELS[flag]}
+      </span>
+    </div>
+  );
+}

--- a/lib/risk/calculator.ts
+++ b/lib/risk/calculator.ts
@@ -1,0 +1,99 @@
+export type RiskFlag = "green" | "yellow" | "red";
+
+export interface RiskCalculationInput {
+  name: string;
+  value: number;
+  reference_low: number | null;
+  reference_high: number | null;
+}
+
+export interface RiskCalculationResult {
+  biomarker_name: string;
+  value: number;
+  reference_low: number | null;
+  reference_high: number | null;
+  flag: RiskFlag;
+}
+
+/**
+ * Calculates a deterministic risk flag for a biomarker value.
+ *
+ * - Green: value is within the reference range
+ * - Yellow: value is within 10% outside the reference range boundary
+ * - Red: value is more than 10% outside the reference range
+ *
+ * If no reference range is provided, defaults to green.
+ */
+export function calculateRiskFlag(
+  value: number,
+  referenceLow: number | null,
+  referenceHigh: number | null
+): RiskFlag {
+  // No reference range — cannot assess risk
+  if (referenceLow == null && referenceHigh == null) {
+    return "green";
+  }
+
+  // Only low bound available
+  if (referenceLow != null && referenceHigh == null) {
+    if (value >= referenceLow) {
+      return "green";
+    }
+    const threshold = referenceLow * 0.1;
+    if (value >= referenceLow - threshold) {
+      return "yellow";
+    }
+    return "red";
+  }
+
+  // Only high bound available
+  if (referenceLow == null && referenceHigh != null) {
+    if (value <= referenceHigh) {
+      return "green";
+    }
+    const threshold = referenceHigh * 0.1;
+    if (value <= referenceHigh + threshold) {
+      return "yellow";
+    }
+    return "red";
+  }
+
+  // Both bounds available
+  const low = referenceLow!;
+  const high = referenceHigh!;
+
+  if (value >= low && value <= high) {
+    return "green";
+  }
+
+  // Check below low bound
+  if (value < low) {
+    const threshold = low * 0.1;
+    if (value >= low - threshold) {
+      return "yellow";
+    }
+    return "red";
+  }
+
+  // Check above high bound
+  const threshold = high * 0.1;
+  if (value <= high + threshold) {
+    return "yellow";
+  }
+  return "red";
+}
+
+/**
+ * Calculates risk flags for an array of biomarkers.
+ */
+export function calculateRiskFlags(
+  biomarkers: RiskCalculationInput[]
+): RiskCalculationResult[] {
+  return biomarkers.map((b) => ({
+    biomarker_name: b.name,
+    value: b.value,
+    reference_low: b.reference_low,
+    reference_high: b.reference_high,
+    flag: calculateRiskFlag(b.value, b.reference_low, b.reference_high),
+  }));
+}


### PR DESCRIPTION
## Summary
- Adds deterministic risk flag calculator (`lib/risk/calculator.ts`) — Green/Yellow/Red based on value vs reference range (no AI, pure math)
- Creates `GET /api/risk-flags?report_id=xxx` endpoint with auth, ownership checks, and summary counts
- Adds `RiskIndicator` component with colored dots, badges, and left-border accents
- Adds `RiskDashboard` component with summary cards (Normal/Borderline/Needs Attention counts), sorted display (red first), and disclaimer
- 28 new tests covering calculator logic (boundary cases, single bounds, null ranges), API contract (401/400/403/200), and component exports

## New Files
- `lib/risk/calculator.ts` — `calculateRiskFlag()` and `calculateRiskFlags()` functions
- `app/api/risk-flags/route.ts` — GET endpoint with summary counts and disclaimer
- `components/reports/RiskIndicator.tsx` — Individual biomarker risk display
- `components/reports/RiskDashboard.tsx` — Full dashboard with overview and sorted list
- `__tests__/risk-flagging.test.ts` — 28 test cases

## Modified Files
- `app/globals.css` — Risk indicator and dashboard styles

## Flag Logic
- **Green:** value within reference range [low, high]
- **Yellow:** value within 10% outside either boundary
- **Red:** value more than 10% outside range

## Test plan
- [ ] Green flag for values within range (including boundaries)
- [ ] Yellow flag for values within 10% of boundaries
- [ ] Red flag for values >10% outside range
- [ ] Handles single-bound ranges (only low or only high)
- [ ] Defaults to green when no reference range provided
- [ ] GET `/api/risk-flags` returns 401 for unauthenticated users
- [ ] GET `/api/risk-flags` returns 400 without report_id
- [ ] GET `/api/risk-flags` returns 403 for wrong user
- [ ] GET `/api/risk-flags` returns 200 with flags, summary, and disclaimer
- [ ] All 101 tests pass

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)