### PR TITLE
feat(api): add doctor question generation API (#29)

### DIFF
--- a/__tests__/doctor-questions.test.ts
+++ b/__tests__/doctor-questions.test.ts
@@ -1,0 +1,508 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Doctor Question Prompts ─────────────────────────────────────────
+
+describe("Doctor Question Prompts", () => {
+  it("exports system prompt, user prompt, and formatter", async () => {
+    const mod = await import("@/lib/claude/doctor-prompts");
+    expect(mod.DOCTOR_QUESTIONS_SYSTEM_PROMPT).toBeDefined();
+    expect(mod.DOCTOR_QUESTIONS_USER_PROMPT).toBeDefined();
+    expect(mod.formatDataForDoctorQuestions).toBeDefined();
+  });
+
+  it("system prompt requires patient-to-doctor phrasing", async () => {
+    const { DOCTOR_QUESTIONS_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain("PATIENT to ask their DOCTOR");
+  });
+
+  it("system prompt prohibits assuming diagnoses", async () => {
+    const { DOCTOR_QUESTIONS_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain("Do NOT generate questions that assume a diagnosis");
+  });
+
+  it("system prompt limits to 10 questions", async () => {
+    const { DOCTOR_QUESTIONS_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain("MAXIMUM of 10 questions");
+  });
+
+  it("system prompt requires all four categories", async () => {
+    const { DOCTOR_QUESTIONS_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain('"clarifying"');
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain('"follow_up"');
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain('"lifestyle"');
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain('"medication"');
+  });
+
+  it("system prompt requires all three priority levels", async () => {
+    const { DOCTOR_QUESTIONS_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain('"high"');
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain('"medium"');
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain('"low"');
+  });
+
+  it("system prompt includes disclaimer text", async () => {
+    const { DOCTOR_QUESTIONS_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain("suggestions to help guide");
+  });
+
+  it("formatDataForDoctorQuestions formats biomarkers and risk flags", async () => {
+    const { formatDataForDoctorQuestions } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+
+    const result = formatDataForDoctorQuestions(
+      [
+        {
+          name: "Glucose",
+          value: 85,
+          unit: "mg/dL",
+          reference_low: 70,
+          reference_high: 100,
+          flag: "green",
+        },
+        {
+          name: "Cholesterol",
+          value: 250,
+          unit: "mg/dL",
+          reference_low: 125,
+          reference_high: 200,
+          flag: "red",
+        },
+      ],
+      [
+        { biomarker_name: "Cholesterol", flag: "red", trend: "worsening" },
+        { biomarker_name: "Glucose", flag: "green", trend: "stable" },
+      ]
+    );
+
+    expect(result).toContain("Glucose: 85 mg/dL");
+    expect(result).toContain("Cholesterol: 250 mg/dL");
+    expect(result).toContain("Abnormal Results:");
+    expect(result).toContain("Cholesterol: red flag, trend: worsening");
+    // Green flags should NOT appear in abnormal results section
+    expect(result).not.toContain("Glucose: green flag");
+  });
+
+  it("formatDataForDoctorQuestions omits abnormal section when all green", async () => {
+    const { formatDataForDoctorQuestions } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+
+    const result = formatDataForDoctorQuestions(
+      [
+        {
+          name: "Glucose",
+          value: 85,
+          unit: "mg/dL",
+          reference_low: 70,
+          reference_high: 100,
+          flag: "green",
+        },
+      ],
+      [{ biomarker_name: "Glucose", flag: "green", trend: "stable" }]
+    );
+
+    expect(result).toContain("Biomarkers:");
+    expect(result).not.toContain("Abnormal Results:");
+  });
+});
+
+// ── Doctor Questions API Route ──────────────────────────────────────
+
+describe("Doctor Questions API Route", () => {
+  it("exports a POST handler", async () => {
+    const mod = await import("@/app/api/doctor-questions/route");
+    expect(mod.POST).toBeDefined();
+    expect(typeof mod.POST).toBe("function");
+  });
+});
+
+// ── Doctor Questions API Contract ───────────────────────────────────
+
+describe("Doctor Questions API Contract", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+  let mockMessagesCreate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+    mockMessagesCreate = vi.fn();
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+      }),
+    }));
+
+    vi.doMock("@/lib/claude/client", () => ({
+      getClaudeClient: vi.fn().mockReturnValue({
+        messages: { create: mockMessagesCreate },
+      }),
+    }));
+  });
+
+  function buildRequest(body?: Record<string, unknown>): Request {
+    return new Request("http://localhost:3000/api/doctor-questions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: body ? JSON.stringify(body) : "invalid",
+    });
+  }
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { POST } = await import("@/app/api/doctor-questions/route");
+    const response = await POST(
+      buildRequest({ parsed_result_id: "pr-1" })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 for invalid request body", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const { POST } = await import("@/app/api/doctor-questions/route");
+    const response = await POST(
+      new Request("http://localhost:3000/api/doctor-questions", {
+        method: "POST",
+        body: "not json",
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when parsed_result_id is missing", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const { POST } = await import("@/app/api/doctor-questions/route");
+    const response = await POST(buildRequest({}));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("parsed_result_id");
+  });
+
+  it("returns 403 when user does not own the report", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // parsed_results
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: "pr-1", report_id: "report-1", biomarkers: [] },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      // reports — owned by different user
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { id: "report-1", user_id: "other-user" },
+              error: null,
+            }),
+          }),
+        }),
+      };
+    });
+
+    const { POST } = await import("@/app/api/doctor-questions/route");
+    const response = await POST(
+      buildRequest({ parsed_result_id: "pr-1" })
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns cached questions when they already exist", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const cachedQuestions = [
+      {
+        id: "q1",
+        question: "What does my cholesterol level mean?",
+        category: "clarifying",
+        priority: "high",
+      },
+    ];
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // parsed_results
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: "pr-1", report_id: "report-1", biomarkers: [] },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (callCount === 2) {
+        // reports
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: "report-1", user_id: "user-1" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      // doctor_questions — cached
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({
+            data: cachedQuestions,
+            error: null,
+          }),
+        }),
+      };
+    });
+
+    const { POST } = await import("@/app/api/doctor-questions/route");
+    const response = await POST(
+      buildRequest({ parsed_result_id: "pr-1" })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.cached).toBe(true);
+    expect(body.questions).toHaveLength(1);
+    expect(body.disclaimer).toContain("suggestions to help guide");
+    expect(mockMessagesCreate).not.toHaveBeenCalled();
+  });
+
+  it("calls Claude and returns questions with max 10 limit", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    // Generate 12 questions to test the limit
+    const generatedQuestions = Array.from({ length: 12 }, (_, i) => ({
+      question: `Question ${i + 1}?`,
+      category: "clarifying" as const,
+      priority: "medium" as const,
+    }));
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // parsed_results
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: "pr-1",
+                  report_id: "report-1",
+                  biomarkers: [
+                    {
+                      name: "Glucose",
+                      value: 85,
+                      unit: "mg/dL",
+                      reference_low: 70,
+                      reference_high: 100,
+                      flag: "green",
+                    },
+                  ],
+                },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (callCount === 2) {
+        // reports
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: "report-1", user_id: "user-1" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (callCount === 3) {
+        // doctor_questions — empty (no cache)
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+          }),
+        };
+      }
+      if (callCount === 4) {
+        // risk_flags
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({
+              data: [],
+              error: null,
+            }),
+          }),
+        };
+      }
+      // doctor_questions insert
+      return {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      };
+    });
+
+    mockMessagesCreate.mockResolvedValue({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            questions: generatedQuestions,
+            disclaimer: "These are suggestions.",
+          }),
+        },
+      ],
+    });
+
+    const { POST } = await import("@/app/api/doctor-questions/route");
+    const response = await POST(
+      buildRequest({ parsed_result_id: "pr-1" })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.cached).toBe(false);
+    // Should be capped at 10 even though Claude returned 12
+    expect(body.questions.length).toBeLessThanOrEqual(10);
+    expect(body.disclaimer).toContain("suggestions to help guide");
+    expect(mockMessagesCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates question categories and priorities", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const mixedQuestions = [
+      { question: "Valid question?", category: "clarifying", priority: "high" },
+      { question: "Invalid cat", category: "invalid_cat", priority: "high" },
+      { question: "Invalid pri", category: "clarifying", priority: "invalid" },
+    ];
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: "pr-1",
+                  report_id: "report-1",
+                  biomarkers: [
+                    { name: "Glucose", value: 85, unit: "mg/dL", reference_low: 70, reference_high: 100, flag: "green" },
+                  ],
+                },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (callCount === 2) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: "report-1", user_id: "user-1" },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      if (callCount === 3) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        };
+      }
+      if (callCount === 4) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        };
+      }
+      return {
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      };
+    });
+
+    mockMessagesCreate.mockResolvedValue({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ questions: mixedQuestions, disclaimer: "Test." }),
+        },
+      ],
+    });
+
+    const { POST } = await import("@/app/api/doctor-questions/route");
+    const response = await POST(
+      buildRequest({ parsed_result_id: "pr-1" })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    // Only the valid question should be included
+    expect(body.questions).toHaveLength(1);
+    expect(body.questions[0].question).toBe("Valid question?");
+  });
+});

--- a/app/api/doctor-questions/route.ts
+++ b/app/api/doctor-questions/route.ts
@@ -1,0 +1,227 @@
+import { createClient } from "@/lib/supabase/server";
+import { getClaudeClient } from "@/lib/claude/client";
+import {
+  DOCTOR_QUESTIONS_SYSTEM_PROMPT,
+  DOCTOR_QUESTIONS_USER_PROMPT,
+  formatDataForDoctorQuestions,
+} from "@/lib/claude/doctor-prompts";
+import { NextResponse } from "next/server";
+
+const MAX_QUESTIONS = 10;
+
+interface GeneratedQuestion {
+  question: string;
+  category: "clarifying" | "follow_up" | "lifestyle" | "medication";
+  priority: "high" | "medium" | "low";
+}
+
+interface ClaudeQuestionsResponse {
+  questions: GeneratedQuestion[];
+  disclaimer: string;
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  // Verify authentication
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Parse request body
+  let body: { parsed_result_id: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  if (!body.parsed_result_id) {
+    return NextResponse.json(
+      { error: "parsed_result_id is required" },
+      { status: 400 }
+    );
+  }
+
+  // Fetch parsed result and verify ownership through report
+  const { data: parsedResult, error: parsedError } = await supabase
+    .from("parsed_results")
+    .select("id, report_id, biomarkers")
+    .eq("id", body.parsed_result_id)
+    .single();
+
+  if (parsedError || !parsedResult) {
+    return NextResponse.json(
+      { error: "Parsed result not found" },
+      { status: 404 }
+    );
+  }
+
+  // Verify ownership via report
+  const { data: report, error: reportError } = await supabase
+    .from("reports")
+    .select("id, user_id")
+    .eq("id", parsedResult.report_id)
+    .single();
+
+  if (reportError || !report) {
+    return NextResponse.json(
+      { error: "Report not found" },
+      { status: 404 }
+    );
+  }
+
+  if (report.user_id !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Check if questions already exist for this parsed result
+  const { data: existingQuestions } = await supabase
+    .from("doctor_questions")
+    .select("id, question, category, priority")
+    .eq("parsed_result_id", parsedResult.id);
+
+  if (existingQuestions && existingQuestions.length > 0) {
+    return NextResponse.json(
+      {
+        questions: existingQuestions,
+        cached: true,
+        disclaimer:
+          "These questions are suggestions to help guide your conversation with your doctor. They are not medical advice.",
+      },
+      { status: 200 }
+    );
+  }
+
+  // Fetch risk flags for context
+  const { data: riskFlags } = await supabase
+    .from("risk_flags")
+    .select("biomarker_name, flag, trend")
+    .eq("parsed_result_id", parsedResult.id);
+
+  // Validate biomarkers exist
+  const biomarkers = parsedResult.biomarkers as Array<{
+    name: string;
+    value: number;
+    unit: string;
+    reference_low: number | null;
+    reference_high: number | null;
+    flag: string;
+  }>;
+
+  if (!Array.isArray(biomarkers) || biomarkers.length === 0) {
+    return NextResponse.json(
+      { error: "No biomarkers found in parsed results" },
+      { status: 422 }
+    );
+  }
+
+  try {
+    // Build prompt with biomarker and risk flag data
+    const dataText = formatDataForDoctorQuestions(
+      biomarkers,
+      riskFlags || []
+    );
+    const userMessage = `${DOCTOR_QUESTIONS_USER_PROMPT}\n\n${dataText}`;
+
+    // Call Claude for question generation
+    const client = getClaudeClient();
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 4096,
+      system: DOCTOR_QUESTIONS_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: userMessage,
+        },
+      ],
+    });
+
+    // Extract text from response
+    const textBlock = response.content.find((block) => block.type === "text");
+    if (!textBlock || textBlock.type !== "text") {
+      throw new Error("No text response from Claude");
+    }
+
+    // Parse JSON — handle markdown code blocks
+    let jsonStr = textBlock.text.trim();
+    if (jsonStr.startsWith("```")) {
+      jsonStr = jsonStr.replace(/^```(?:json)?\n?/, "").replace(/\n?```$/, "");
+    }
+
+    const generated = JSON.parse(jsonStr) as ClaudeQuestionsResponse;
+
+    // Validate structure
+    if (!Array.isArray(generated.questions)) {
+      throw new Error("Invalid response: questions must be an array");
+    }
+
+    // Enforce maximum question limit
+    const questions = generated.questions.slice(0, MAX_QUESTIONS);
+
+    // Validate categories and priorities
+    const validCategories = ["clarifying", "follow_up", "lifestyle", "medication"];
+    const validPriorities = ["high", "medium", "low"];
+
+    const validatedQuestions = questions.filter(
+      (q) =>
+        typeof q.question === "string" &&
+        validCategories.includes(q.category) &&
+        validPriorities.includes(q.priority)
+    );
+
+    // Store questions in database
+    if (validatedQuestions.length > 0) {
+      const { error: insertError } = await supabase
+        .from("doctor_questions")
+        .insert(
+          validatedQuestions.map((q) => ({
+            parsed_result_id: parsedResult.id,
+            question: q.question,
+            category: q.category,
+            priority: q.priority,
+          }))
+        );
+
+      if (insertError) {
+        // Return questions even if DB persistence fails
+        return NextResponse.json(
+          {
+            questions: validatedQuestions,
+            cached: false,
+            persisted: false,
+            disclaimer:
+              "These questions are suggestions to help guide your conversation with your doctor. They are not medical advice.",
+          },
+          { status: 200 }
+        );
+      }
+    }
+
+    return NextResponse.json(
+      {
+        questions: validatedQuestions,
+        cached: false,
+        persisted: true,
+        disclaimer:
+          "These questions are suggestions to help guide your conversation with your doctor. They are not medical advice.",
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Question generation failed";
+    return NextResponse.json(
+      { error: `Question generation failed: ${message}` },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/claude/doctor-prompts.ts
+++ b/lib/claude/doctor-prompts.ts
@@ -1,0 +1,70 @@
+export const DOCTOR_QUESTIONS_SYSTEM_PROMPT = `You are a health communication assistant that helps patients prepare for doctor visits. Your job is to generate thoughtful questions that patients can ask their doctor based on their lab results.
+
+IMPORTANT RULES:
+- Questions must be phrased for the PATIENT to ask their DOCTOR.
+- Do NOT generate questions that assume a diagnosis.
+- Do NOT provide medical advice — only help patients ask better questions.
+- Keep questions simple and easy to understand (5th grade reading level).
+- Each question must be categorized and prioritized.
+- Generate a MAXIMUM of 10 questions.
+- Focus on abnormal values (yellow/red flags) first, then include general health questions.
+- Prioritize questions about red-flagged biomarkers as "high", yellow as "medium", and general questions as "low".
+
+Categories:
+- "clarifying": Questions to understand what a result means
+- "follow_up": Questions about next steps or additional tests
+- "lifestyle": Questions about diet, exercise, or lifestyle changes
+- "medication": Questions about medications that may be related
+
+Respond ONLY with valid JSON in this exact format:
+{
+  "questions": [
+    {
+      "question": "string — the question the patient should ask their doctor",
+      "category": "string — one of: clarifying, follow_up, lifestyle, medication",
+      "priority": "string — one of: high, medium, low"
+    }
+  ],
+  "disclaimer": "These questions are suggestions to help guide your conversation with your doctor. They are not medical advice."
+}`;
+
+export const DOCTOR_QUESTIONS_USER_PROMPT = `Based on the following lab results and risk flags, generate up to 10 questions that this patient should ask their doctor. Focus on abnormal values first. Here are the results:`;
+
+/**
+ * Formats biomarker and risk flag data for the doctor questions prompt.
+ */
+export function formatDataForDoctorQuestions(
+  biomarkers: Array<{
+    name: string;
+    value: number;
+    unit: string;
+    reference_low: number | null;
+    reference_high: number | null;
+    flag: string;
+  }>,
+  riskFlags: Array<{
+    biomarker_name: string;
+    flag: string;
+    trend: string;
+  }>
+): string {
+  const biomarkerLines = biomarkers.map((b) => {
+    const range =
+      b.reference_low != null && b.reference_high != null
+        ? `Normal range: ${b.reference_low}-${b.reference_high} ${b.unit}`
+        : "Normal range: not available";
+    return `- ${b.name}: ${b.value} ${b.unit} (${range}, Flag: ${b.flag})`;
+  });
+
+  const riskLines = riskFlags
+    .filter((r) => r.flag !== "green")
+    .map((r) => `- ${r.biomarker_name}: ${r.flag} flag, trend: ${r.trend}`);
+
+  let result = "Biomarkers:\n" + biomarkerLines.join("\n");
+
+  if (riskLines.length > 0) {
+    result += "\n\nAbnormal Results:\n" + riskLines.join("\n");
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/doctor-questions` endpoint that generates personalized doctor visit prep questions from parsed biomarker data and risk flags via Claude
- Creates `lib/claude/doctor-prompts.ts` with system/user prompts and data formatter that highlights abnormal values
- Questions are categorized (`clarifying` | `follow_up` | `lifestyle` | `medication`), prioritized (`high` | `medium` | `low`), and capped at 10
- Caches generated questions in `doctor_questions` table — returns cached on subsequent requests
- Validates Claude response categories/priorities, filtering out invalid entries
- Returns questions even if DB persistence fails (graceful degradation)
- 17 new tests (118 total passing)

## New Files
- `lib/claude/doctor-prompts.ts` — System/user prompts + biomarker/risk flag formatter
- `app/api/doctor-questions/route.ts` — POST endpoint with auth, ownership, caching, Claude call, validation
- `__tests__/doctor-questions.test.ts` — 17 test cases

## Test plan
- [ ] POST `/api/doctor-questions` returns categorized, prioritized questions
- [ ] Questions capped at 10 even if Claude returns more
- [ ] Invalid categories/priorities filtered from response
- [ ] Cached questions returned without calling Claude
- [ ] Unauthenticated requests return 401
- [ ] Accessing another user's report returns 403
- [ ] Invalid/missing body returns 400
- [ ] All 118 tests pass

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)