### PR TITLE
feat(ui): add user profile management (#22)

### DIFF
--- a/__tests__/profile.test.ts
+++ b/__tests__/profile.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Profile API Route ───────────────────────────────────────────────
+
+describe("Profile API Route", () => {
+  it("exports GET and PUT handlers", async () => {
+    const mod = await import("@/app/api/profile/route");
+    expect(mod.GET).toBeDefined();
+    expect(mod.PUT).toBeDefined();
+    expect(typeof mod.GET).toBe("function");
+    expect(typeof mod.PUT).toBe("function");
+  });
+});
+
+// ── Profile API Contract ────────────────────────────────────────────
+
+describe("Profile API — GET", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+      }),
+    }));
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { GET } = await import("@/app/api/profile/route");
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 200 with profile data for authenticated user", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: {
+              id: "user-1",
+              display_name: "Test User",
+              date_of_birth: "1990-01-15",
+              gender: "male",
+              updated_at: "2026-01-01T00:00:00Z",
+            },
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/profile/route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.profile.display_name).toBe("Test User");
+    expect(body.profile.date_of_birth).toBe("1990-01-15");
+    expect(body.profile.gender).toBe("male");
+  });
+
+  it("returns default profile for new user with no profile row", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: null,
+            error: { code: "PGRST116", message: "no rows" },
+          }),
+        }),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/profile/route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.profile.id).toBe("user-1");
+    expect(body.profile.display_name).toBeNull();
+    expect(body.profile.date_of_birth).toBeNull();
+  });
+});
+
+describe("Profile API — PUT", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+      }),
+    }));
+  });
+
+  function buildRequest(body?: Record<string, unknown>): Request {
+    return new Request("http://localhost:3000/api/profile", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: body ? JSON.stringify(body) : "invalid",
+    });
+  }
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { PUT } = await import("@/app/api/profile/route");
+    const response = await PUT(buildRequest({ display_name: "Test" }));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 for invalid request body", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const { PUT } = await import("@/app/api/profile/route");
+    const response = await PUT(
+      new Request("http://localhost:3000/api/profile", {
+        method: "PUT",
+        body: "not json",
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for display_name over 100 characters", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const { PUT } = await import("@/app/api/profile/route");
+    const response = await PUT(
+      buildRequest({ display_name: "a".repeat(101) })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("display_name");
+  });
+
+  it("returns 400 for invalid date_of_birth format", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const { PUT } = await import("@/app/api/profile/route");
+    const response = await PUT(
+      buildRequest({ date_of_birth: "January 1, 1990" })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("YYYY-MM-DD");
+  });
+
+  it("returns 400 for future date_of_birth", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const { PUT } = await import("@/app/api/profile/route");
+    const response = await PUT(
+      buildRequest({ date_of_birth: "2099-01-01" })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("past");
+  });
+
+  it("returns 400 for invalid gender value", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const { PUT } = await import("@/app/api/profile/route");
+    const response = await PUT(buildRequest({ gender: "invalid" }));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("gender");
+  });
+
+  it("returns 200 with updated profile on valid PUT", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    mockFrom.mockReturnValue({
+      upsert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: {
+              id: "user-1",
+              display_name: "New Name",
+              date_of_birth: "1990-06-15",
+              gender: "female",
+              updated_at: "2026-04-01T00:00:00Z",
+            },
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const { PUT } = await import("@/app/api/profile/route");
+    const response = await PUT(
+      buildRequest({
+        display_name: "New Name",
+        date_of_birth: "1990-06-15",
+        gender: "female",
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.profile.display_name).toBe("New Name");
+    expect(body.profile.date_of_birth).toBe("1990-06-15");
+    expect(body.profile.gender).toBe("female");
+  });
+});
+
+// ── Profile Page Component ──────────────────────────────────────────
+
+describe("Profile Page Component", () => {
+  it("exports a default component", async () => {
+    const mod = await import("@/app/profile/page");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+});

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,0 +1,153 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Fetch profile — RLS ensures only own profile is accessible
+  const { data: profile, error } = await supabase
+    .from("profiles")
+    .select("id, display_name, date_of_birth, gender, updated_at")
+    .eq("id", user.id)
+    .single();
+
+  if (error && error.code !== "PGRST116") {
+    // PGRST116 = no rows found — that's ok for new users
+    return NextResponse.json(
+      { error: "Failed to fetch profile" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      profile: profile || {
+        id: user.id,
+        display_name: null,
+        date_of_birth: null,
+        gender: null,
+        updated_at: null,
+      },
+    },
+    { status: 200 }
+  );
+}
+
+export async function PUT(request: Request) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Parse request body
+  let body: {
+    display_name?: string;
+    date_of_birth?: string;
+    gender?: string;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  // Validate display_name
+  if (body.display_name !== undefined) {
+    if (
+      typeof body.display_name !== "string" ||
+      body.display_name.length > 100
+    ) {
+      return NextResponse.json(
+        { error: "display_name must be a string under 100 characters" },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Validate date_of_birth format (YYYY-MM-DD)
+  if (body.date_of_birth !== undefined && body.date_of_birth !== null) {
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+    if (!dateRegex.test(body.date_of_birth)) {
+      return NextResponse.json(
+        { error: "date_of_birth must be in YYYY-MM-DD format" },
+        { status: 400 }
+      );
+    }
+    // Validate it's a real date
+    const parsed = new Date(body.date_of_birth);
+    if (isNaN(parsed.getTime())) {
+      return NextResponse.json(
+        { error: "date_of_birth is not a valid date" },
+        { status: 400 }
+      );
+    }
+    // Must be in the past
+    if (parsed > new Date()) {
+      return NextResponse.json(
+        { error: "date_of_birth must be in the past" },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Validate gender
+  if (body.gender !== undefined && body.gender !== null) {
+    const validGenders = ["male", "female", "other", "prefer_not_to_say"];
+    if (!validGenders.includes(body.gender)) {
+      return NextResponse.json(
+        {
+          error: `gender must be one of: ${validGenders.join(", ")}`,
+        },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Build update object — only include provided fields
+  const updateData: Record<string, unknown> = {
+    id: user.id,
+    updated_at: new Date().toISOString(),
+  };
+
+  if (body.display_name !== undefined) {
+    updateData.display_name = body.display_name;
+  }
+  if (body.date_of_birth !== undefined) {
+    updateData.date_of_birth = body.date_of_birth;
+  }
+  if (body.gender !== undefined) {
+    updateData.gender = body.gender;
+  }
+
+  // Upsert profile — creates if not exists, updates if exists
+  const { data: profile, error } = await supabase
+    .from("profiles")
+    .upsert(updateData, { onConflict: "id" })
+    .select("id, display_name, date_of_birth, gender, updated_at")
+    .single();
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to update profile" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ profile }, { status: 200 });
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -38,6 +38,10 @@ export default async function DashboardPage() {
           <h3>Chat</h3>
           <p>Ask questions about your health data in plain language</p>
         </Link>
+        <Link href="/profile" className="dashboard-card">
+          <h3>Profile</h3>
+          <p>Manage your personal information for personalized health insights</p>
+        </Link>
       </nav>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -886,3 +886,148 @@ button[type="submit"]:disabled {
   margin-bottom: 1rem;
   color: #1a1a1a;
 }
+
+/* =========================
+   Profile Page Styles
+   ========================= */
+
+.profile-page {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.profile-page--loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  color: #666;
+}
+
+.profile-page__spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #e0e0e0;
+  border-top-color: #0066ff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-bottom: 1rem;
+}
+
+.profile-page__header {
+  margin-bottom: 2rem;
+}
+
+.profile-page__back {
+  display: inline-block;
+  color: #0066ff;
+  text-decoration: none;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.profile-page__back:hover {
+  text-decoration: underline;
+}
+
+.profile-page__header h1 {
+  font-size: 1.5rem;
+  color: #1a1a1a;
+  margin-bottom: 0.5rem;
+}
+
+.profile-page__header p {
+  font-size: 0.9rem;
+  color: #666;
+  line-height: 1.5;
+}
+
+.profile-page__error {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.profile-page__success {
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  color: #166534;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.profile-page__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.profile-page__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.profile-page__field label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #333;
+}
+
+.profile-page__field input,
+.profile-page__field select {
+  padding: 0.65rem 0.75rem;
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  color: #333;
+  background: #fff;
+}
+
+.profile-page__field input:focus,
+.profile-page__field select:focus {
+  outline: none;
+  border-color: #0066ff;
+  box-shadow: 0 0 0 3px rgba(0, 102, 255, 0.1);
+}
+
+.profile-page__hint {
+  font-size: 0.8rem;
+  color: #888;
+}
+
+.profile-page__submit {
+  padding: 0.75rem 1.5rem;
+  background: #0066ff;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+.profile-page__submit:hover {
+  background: #0052cc;
+}
+
+.profile-page__submit:disabled {
+  background: #999;
+  cursor: not-allowed;
+}
+
+.profile-page__updated {
+  margin-top: 1.5rem;
+  font-size: 0.8rem;
+  color: #999;
+  text-align: center;
+}

--- a/app/profile/layout.tsx
+++ b/app/profile/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function ProfileLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+
+interface ProfileData {
+  id: string;
+  display_name: string | null;
+  date_of_birth: string | null;
+  gender: string | null;
+  updated_at: string | null;
+}
+
+export default function ProfilePage() {
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [displayName, setDisplayName] = useState("");
+  const [dateOfBirth, setDateOfBirth] = useState("");
+  const [gender, setGender] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const fetchProfile = useCallback(async () => {
+    try {
+      const response = await fetch("/api/profile");
+      if (!response.ok) {
+        throw new Error("Failed to load profile");
+      }
+      const data = await response.json();
+      setProfile(data.profile);
+      setDisplayName(data.profile.display_name || "");
+      setDateOfBirth(data.profile.date_of_birth || "");
+      setGender(data.profile.gender || "");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load profile");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+
+    try {
+      const response = await fetch("/api/profile", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          display_name: displayName || null,
+          date_of_birth: dateOfBirth || null,
+          gender: gender || null,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to save profile");
+      }
+
+      const data = await response.json();
+      setProfile(data.profile);
+      setSuccess(true);
+      setTimeout(() => setSuccess(false), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save profile");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="profile-page profile-page--loading">
+        <div className="profile-page__spinner" aria-label="Loading profile" />
+        <p>Loading your profile...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="profile-page">
+      <div className="profile-page__header">
+        <Link href="/dashboard" className="profile-page__back">
+          Back to Dashboard
+        </Link>
+        <h1>Your Profile</h1>
+        <p>Manage your personal information. This helps us personalize your health explanations.</p>
+      </div>
+
+      {error && (
+        <div className="profile-page__error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="profile-page__success" role="status">
+          Profile saved successfully!
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="profile-page__form">
+        <div className="profile-page__field">
+          <label htmlFor="display-name">Display Name</label>
+          <input
+            id="display-name"
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="Enter your name"
+            maxLength={100}
+          />
+        </div>
+
+        <div className="profile-page__field">
+          <label htmlFor="date-of-birth">Date of Birth</label>
+          <input
+            id="date-of-birth"
+            type="date"
+            value={dateOfBirth}
+            onChange={(e) => setDateOfBirth(e.target.value)}
+            max={new Date().toISOString().split("T")[0]}
+          />
+          <span className="profile-page__hint">
+            Used to personalize age-appropriate health information.
+          </span>
+        </div>
+
+        <div className="profile-page__field">
+          <label htmlFor="gender">Gender</label>
+          <select
+            id="gender"
+            value={gender}
+            onChange={(e) => setGender(e.target.value)}
+          >
+            <option value="">Select...</option>
+            <option value="male">Male</option>
+            <option value="female">Female</option>
+            <option value="other">Other</option>
+            <option value="prefer_not_to_say">Prefer not to say</option>
+          </select>
+          <span className="profile-page__hint">
+            Some lab reference ranges differ by gender.
+          </span>
+        </div>
+
+        <button
+          type="submit"
+          className="profile-page__submit"
+          disabled={saving}
+        >
+          {saving ? "Saving..." : "Save Profile"}
+        </button>
+      </form>
+
+      {profile?.updated_at && (
+        <p className="profile-page__updated">
+          Last updated: {new Date(profile.updated_at).toLocaleDateString()}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/profile` and `PUT /api/profile` endpoints with upsert support
- Input validation: display name (max 100 chars), date of birth (YYYY-MM-DD, must be past), gender (enum: male/female/other/prefer_not_to_say)
- Creates profile page at `/profile` with form fields and success/error feedback
- Adds force-dynamic layout to prevent prerender errors
- Adds Profile card to dashboard navigation
- 12 new tests (130 total passing)

## New Files
- `app/api/profile/route.ts` — GET + PUT handlers with validation and upsert
- `app/profile/page.tsx` — Profile form with loading/error/success states
- `app/profile/layout.tsx` — Force-dynamic layout
- `__tests__/profile.test.ts` — 12 test cases

## Modified Files
- `app/dashboard/page.tsx` — Added Profile navigation card
- `app/globals.css` — Profile page styles

## Test plan
- [ ] GET `/api/profile` returns 200 with profile data
- [ ] GET `/api/profile` returns default profile for new users
- [ ] PUT `/api/profile` updates display_name, date_of_birth, gender
- [ ] PUT returns 400 for invalid inputs (long name, bad date, future date, invalid gender)
- [ ] Both endpoints return 401 for unauthenticated users
- [ ] Profile page renders form and submits successfully
- [ ] All 130 tests pass

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)