### PR TITLE
feat(reports): report results page, report list, and APIs

### DIFF
--- a/__tests__/report-results.test.ts
+++ b/__tests__/report-results.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+// ── Reports List API Route ───────────────────────────────────────────
+
+describe("Reports List API Route", () => {
+  it("exports a GET handler", async () => {
+    const mod = await import("@/app/api/reports/route");
+    expect(mod.GET).toBeDefined();
+    expect(typeof mod.GET).toBe("function");
+  });
+});
+
+// ── Single Report API Route ──────────────────────────────────────────
+
+describe("Single Report API Route", () => {
+  it("exports a GET handler", async () => {
+    const mod = await import("@/app/api/reports/[id]/route");
+    expect(mod.GET).toBeDefined();
+    expect(typeof mod.GET).toBe("function");
+  });
+});
+
+// ── Report Results Page ──────────────────────────────────────────────
+
+describe("Report Results Page", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.spyOn(globalThis, "fetch").mockImplementation(mockFetch);
+
+    vi.doMock("next/navigation", () => ({
+      useParams: () => ({ id: "report-abc" }),
+    }));
+  });
+
+  it("shows loading state initially", async () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+
+    const { default: ReportResultsPage } = await import(
+      "@/app/reports/[id]/page"
+    );
+    render(React.createElement(ReportResultsPage));
+
+    expect(screen.getByText("Loading your report...")).toBeDefined();
+    expect(screen.getByRole("status")).toBeDefined();
+  });
+
+  it("renders report with health summary and risk dashboard when parsed", async () => {
+    // Report API response
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        report: {
+          id: "report-abc",
+          file_name: "lab-results.pdf",
+          file_type: "pdf",
+          status: "completed",
+          created_at: "2026-03-15T10:00:00Z",
+          parsed_result_id: "parsed-1",
+        },
+      }),
+    });
+
+    // Health summary fetch (HealthSummary component)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        summary: {
+          overall: "Your results look good overall.",
+          biomarkers: [
+            {
+              name: "Glucose",
+              value: "95 mg/dL",
+              flag: "green",
+              explanation: "Blood sugar level",
+              importance: "Shows how your body handles sugar",
+              action: "Keep up the good work",
+            },
+          ],
+          disclaimer: "This is for informational purposes only.",
+        },
+        cached: true,
+      }),
+    });
+
+    // Risk flags fetch (RiskDashboard component)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        risk_flags: [
+          {
+            id: "rf-1",
+            biomarker_name: "Glucose",
+            value: 95,
+            reference_low: 70,
+            reference_high: 100,
+            flag: "green",
+            trend: "stable",
+          },
+        ],
+        summary: { total: 1, green: 1, yellow: 0, red: 0 },
+        disclaimer: "These indicators are for informational purposes only.",
+      }),
+    });
+
+    const { default: ReportResultsPage } = await import(
+      "@/app/reports/[id]/page"
+    );
+    render(React.createElement(ReportResultsPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("lab-results.pdf")).toBeDefined();
+    });
+
+    // Status badge
+    expect(screen.getByText("Analyzed")).toBeDefined();
+
+    // Navigation links
+    expect(screen.getByText("Prepare for Doctor Visit")).toBeDefined();
+    expect(screen.getByText("Chat About Results")).toBeDefined();
+    expect(screen.getByText("Back to Dashboard")).toBeDefined();
+  });
+
+  it("shows pending state for reports still processing", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        report: {
+          id: "report-abc",
+          file_name: "lab-results.pdf",
+          file_type: "pdf",
+          status: "processing",
+          created_at: "2026-03-15T10:00:00Z",
+          parsed_result_id: null,
+        },
+      }),
+    });
+
+    const { default: ReportResultsPage } = await import(
+      "@/app/reports/[id]/page"
+    );
+    render(React.createElement(ReportResultsPage));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your report is being analyzed")
+      ).toBeDefined();
+    });
+
+    expect(screen.getByText("Refresh Status")).toBeDefined();
+  });
+
+  it("shows error state for failed reports", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        report: {
+          id: "report-abc",
+          file_name: "lab-results.pdf",
+          file_type: "pdf",
+          status: "error",
+          created_at: "2026-03-15T10:00:00Z",
+          parsed_result_id: null,
+        },
+      }),
+    });
+
+    const { default: ReportResultsPage } = await import(
+      "@/app/reports/[id]/page"
+    );
+    render(React.createElement(ReportResultsPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong")).toBeDefined();
+    });
+
+    expect(screen.getByText("Upload Again")).toBeDefined();
+  });
+
+  it("shows error when report not found", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: "Report not found" }),
+    });
+
+    const { default: ReportResultsPage } = await import(
+      "@/app/reports/[id]/page"
+    );
+    render(React.createElement(ReportResultsPage));
+
+    await waitFor(() => {
+      expect(screen.getByText("Report not found")).toBeDefined();
+    });
+
+    expect(screen.getByText("Try Again")).toBeDefined();
+  });
+
+  it("shows auth error when unauthorized", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: "Unauthorized" }),
+    });
+
+    const { default: ReportResultsPage } = await import(
+      "@/app/reports/[id]/page"
+    );
+    render(React.createElement(ReportResultsPage));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Please log in to view this report")
+      ).toBeDefined();
+    });
+  });
+});
+
+// ── Report Results Layout ────────────────────────────────────────────
+
+describe("Report Results Layout", () => {
+  it("exports force-dynamic", async () => {
+    const mod = await import("@/app/reports/[id]/layout");
+    expect(mod.dynamic).toBe("force-dynamic");
+  });
+});
+
+// ── Report List Component ────────────────────────────────────────────
+
+describe("ReportList Component", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.spyOn(globalThis, "fetch").mockImplementation(mockFetch);
+  });
+
+  it("renders reports with file names and status badges", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        reports: [
+          {
+            id: "r1",
+            file_name: "blood-work.pdf",
+            file_type: "pdf",
+            status: "completed",
+            created_at: "2026-03-15T10:00:00Z",
+          },
+          {
+            id: "r2",
+            file_name: "cbc-results.jpg",
+            file_type: "image",
+            status: "processing",
+            created_at: "2026-03-14T10:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    const { default: ReportList } = await import(
+      "@/components/reports/ReportList"
+    );
+    render(React.createElement(ReportList));
+
+    await waitFor(() => {
+      expect(screen.getByText("blood-work.pdf")).toBeDefined();
+    });
+
+    expect(screen.getByText("cbc-results.jpg")).toBeDefined();
+    expect(screen.getByText("Analyzed")).toBeDefined();
+    expect(screen.getByText("Processing")).toBeDefined();
+    expect(screen.getByText("Your Reports")).toBeDefined();
+  });
+
+  it("shows empty state when no reports exist", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ reports: [] }),
+    });
+
+    const { default: ReportList } = await import(
+      "@/components/reports/ReportList"
+    );
+    render(React.createElement(ReportList));
+
+    await waitFor(() => {
+      expect(screen.getByText("No reports yet.")).toBeDefined();
+    });
+
+    expect(
+      screen.getByText(
+        "Upload your first medical report to get started"
+      )
+    ).toBeDefined();
+  });
+
+  it("shows loading state", async () => {
+    mockFetch.mockReturnValue(new Promise(() => {}));
+
+    const { default: ReportList } = await import(
+      "@/components/reports/ReportList"
+    );
+    render(React.createElement(ReportList));
+
+    expect(screen.getByText("Loading your reports...")).toBeDefined();
+    expect(screen.getByRole("status")).toBeDefined();
+  });
+
+  it("shows error state on fetch failure", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "Server error" }),
+    });
+
+    const { default: ReportList } = await import(
+      "@/components/reports/ReportList"
+    );
+    render(React.createElement(ReportList));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load reports")).toBeDefined();
+    });
+
+    expect(screen.getByText("Try Again")).toBeDefined();
+  });
+});

--- a/app/api/reports/[id]/route.ts
+++ b/app/api/reports/[id]/route.ts
@@ -1,0 +1,63 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id: reportId } = await params;
+
+  // Suppress unused variable warning
+  void request;
+
+  // Verify authentication
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Fetch report with parsed result ID
+  const { data: report, error: reportError } = await supabase
+    .from("reports")
+    .select(
+      "id, user_id, file_name, file_type, status, created_at, parsed_results(id)"
+    )
+    .eq("id", reportId)
+    .single();
+
+  if (reportError || !report) {
+    return NextResponse.json({ error: "Report not found" }, { status: 404 });
+  }
+
+  // Verify ownership (defense-in-depth — RLS also enforces this)
+  if (report.user_id !== user.id) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Extract parsed_result_id from the joined data
+  const parsedResults = report.parsed_results as
+    | Array<{ id: string }>
+    | { id: string }
+    | null;
+  const parsedResultId = Array.isArray(parsedResults)
+    ? parsedResults[0]?.id ?? null
+    : parsedResults?.id ?? null;
+
+  return NextResponse.json(
+    {
+      report: {
+        id: report.id,
+        file_name: report.file_name,
+        file_type: report.file_type,
+        status: report.status,
+        created_at: report.created_at,
+        parsed_result_id: parsedResultId,
+      },
+    },
+    { status: 200 }
+  );
+}

--- a/app/api/reports/route.ts
+++ b/app/api/reports/route.ts
@@ -1,0 +1,31 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const supabase = await createClient();
+
+  // Verify authentication
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Fetch user's reports (RLS enforces ownership)
+  const { data: reports, error } = await supabase
+    .from("reports")
+    .select("id, file_name, file_type, status, created_at")
+    .order("created_at", { ascending: false })
+    .limit(20);
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch reports" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ reports: reports ?? [] }, { status: 200 });
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { LogoutButton } from "./logout-button";
+import ReportList from "@/components/reports/ReportList";
 
 export const dynamic = "force-dynamic";
 
@@ -43,6 +44,10 @@ export default async function DashboardPage() {
           <p>Manage your personal information for personalized health insights</p>
         </Link>
       </nav>
+
+      <section className="dashboard-reports">
+        <ReportList />
+      </section>
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -1317,3 +1317,323 @@ button[type="submit"]:disabled {
     border: 1px solid #ccc;
   }
 }
+
+/* ── Report Results Page ──────────────────────────────────────────── */
+
+.report-results {
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.report-results--loading,
+.report-results--error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  gap: 1rem;
+}
+
+.report-results__spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid #e5e7eb;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.report-results__error {
+  color: #dc2626;
+  font-weight: 500;
+}
+
+.report-results__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.report-results__retry,
+.report-results__refresh {
+  padding: 0.5rem 1rem;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.report-results__retry:hover,
+.report-results__refresh:hover {
+  background: #2563eb;
+}
+
+.report-results__back {
+  color: #3b82f6;
+  text-decoration: none;
+  font-size: 0.875rem;
+}
+
+.report-results__back:hover {
+  text-decoration: underline;
+}
+
+.report-results__header {
+  margin-bottom: 1.5rem;
+}
+
+.report-results__header h1 {
+  margin-top: 0.75rem;
+}
+
+.report-results__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #6b7280;
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.report-results__status {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.report-results__status--completed {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.report-results__status--processing {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.report-results__status--pending {
+  background: #fef9c3;
+  color: #854d0e;
+}
+
+.report-results__status--error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.report-results__pending {
+  text-align: center;
+  padding: 2rem 1rem;
+  background: #f0f9ff;
+  border-radius: 8px;
+  border: 1px solid #bae6fd;
+}
+
+.report-results__pending h2 {
+  margin-top: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.report-results__pending p {
+  color: #6b7280;
+  margin-bottom: 1rem;
+}
+
+.report-results__failed {
+  text-align: center;
+  padding: 2rem 1rem;
+  background: #fef2f2;
+  border-radius: 8px;
+  border: 1px solid #fecaca;
+}
+
+.report-results__failed h2 {
+  color: #991b1b;
+  margin-bottom: 0.5rem;
+}
+
+.report-results__failed p {
+  color: #6b7280;
+  margin-bottom: 1rem;
+}
+
+.report-results__upload-link {
+  color: #3b82f6;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.report-results__upload-link:hover {
+  text-decoration: underline;
+}
+
+.report-results__section {
+  margin-top: 1.5rem;
+}
+
+.report-results__nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.report-results__nav-card {
+  display: block;
+  padding: 1.25rem;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.report-results__nav-card:hover {
+  border-color: #3b82f6;
+  box-shadow: 0 1px 4px rgba(59, 130, 246, 0.15);
+}
+
+.report-results__nav-card h3 {
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.report-results__nav-card p {
+  font-size: 0.8125rem;
+  color: #6b7280;
+}
+
+/* ── Report List (Dashboard) ──────────────────────────────────────── */
+
+.report-list {
+  margin-top: 1.5rem;
+}
+
+.report-list--loading,
+.report-list--error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.5rem;
+}
+
+.report-list__spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid #e5e7eb;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.report-list__error {
+  color: #dc2626;
+  font-size: 0.875rem;
+}
+
+.report-list__retry {
+  padding: 0.375rem 0.75rem;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8125rem;
+}
+
+.report-list--empty {
+  text-align: center;
+  padding: 1.5rem;
+  color: #6b7280;
+}
+
+.report-list__upload-link {
+  display: block;
+  margin-top: 0.5rem;
+  color: #3b82f6;
+  text-decoration: none;
+}
+
+.report-list__upload-link:hover {
+  text-decoration: underline;
+}
+
+.report-list__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.report-list__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.report-list__item:hover {
+  border-color: #3b82f6;
+  box-shadow: 0 1px 3px rgba(59, 130, 246, 0.1);
+}
+
+.report-list__item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.report-list__item-name {
+  font-weight: 500;
+  font-size: 0.9375rem;
+}
+
+.report-list__item-date {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.report-list__item-status {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.report-list__item-status--completed {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.report-list__item-status--processing {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.report-list__item-status--pending {
+  background: #fef9c3;
+  color: #854d0e;
+}
+
+.report-list__item-status--error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.dashboard-reports {
+  margin-top: 1rem;
+}

--- a/app/reports/[id]/layout.tsx
+++ b/app/reports/[id]/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function ReportLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/reports/[id]/page.tsx
+++ b/app/reports/[id]/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import HealthSummary from "@/components/reports/HealthSummary";
+import RiskDashboard from "@/components/reports/RiskDashboard";
+
+interface ReportData {
+  id: string;
+  file_name: string;
+  file_type: string;
+  status: string;
+  created_at: string;
+  parsed_result_id: string | null;
+}
+
+export default function ReportResultsPage() {
+  const params = useParams();
+  const reportId = params.id as string;
+
+  const [report, setReport] = useState<ReportData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchReport = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/reports/${reportId}`);
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          throw new Error("Please log in to view this report");
+        }
+        if (response.status === 404) {
+          throw new Error("Report not found");
+        }
+        throw new Error("Failed to load report");
+      }
+
+      const data = await response.json();
+      setReport(data.report);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load report"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [reportId]);
+
+  useEffect(() => {
+    fetchReport();
+  }, [fetchReport]);
+
+  if (loading) {
+    return (
+      <div className="report-results report-results--loading">
+        <div
+          className="report-results__spinner"
+          aria-label="Loading report"
+          role="status"
+        />
+        <p>Loading your report...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="report-results report-results--error">
+        <p className="report-results__error" role="alert">
+          {error}
+        </p>
+        <div className="report-results__actions">
+          <button onClick={fetchReport} className="report-results__retry">
+            Try Again
+          </button>
+          <Link href="/dashboard" className="report-results__back">
+            Back to Dashboard
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (!report) {
+    return null;
+  }
+
+  const isParsed = report.status === "completed" && report.parsed_result_id;
+  const isPending = report.status === "pending" || report.status === "processing";
+  const isFailed = report.status === "error";
+
+  return (
+    <div className="report-results">
+      <div className="report-results__header">
+        <Link href="/dashboard" className="report-results__back">
+          Back to Dashboard
+        </Link>
+        <h1>{report.file_name}</h1>
+        <p className="report-results__meta">
+          Uploaded {new Date(report.created_at).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+          <span
+            className={`report-results__status report-results__status--${report.status}`}
+          >
+            {report.status === "completed"
+              ? "Analyzed"
+              : report.status === "processing"
+                ? "Processing"
+                : report.status === "pending"
+                  ? "Pending"
+                  : "Error"}
+          </span>
+        </p>
+      </div>
+
+      {isPending && (
+        <div className="report-results__pending">
+          <div
+            className="report-results__spinner"
+            aria-label="Processing report"
+            role="status"
+          />
+          <h2>Your report is being analyzed</h2>
+          <p>
+            This usually takes a minute or two. Refresh the page to check
+            progress.
+          </p>
+          <button onClick={fetchReport} className="report-results__refresh">
+            Refresh Status
+          </button>
+        </div>
+      )}
+
+      {isFailed && (
+        <div className="report-results__failed" role="alert">
+          <h2>Something went wrong</h2>
+          <p>
+            We were unable to analyze this report. Please try uploading it
+            again or contact support if the problem persists.
+          </p>
+          <Link href="/upload" className="report-results__upload-link">
+            Upload Again
+          </Link>
+        </div>
+      )}
+
+      {isParsed && (
+        <>
+          <section className="report-results__section">
+            <HealthSummary reportId={reportId} />
+          </section>
+
+          <section className="report-results__section">
+            <RiskDashboard reportId={reportId} />
+          </section>
+
+          <nav className="report-results__nav">
+            <Link
+              href={`/reports/${reportId}/doctor-prep`}
+              className="report-results__nav-card"
+            >
+              <h3>Prepare for Doctor Visit</h3>
+              <p>
+                Get personalized questions to ask your doctor about these
+                results
+              </p>
+            </Link>
+            <Link href="/chat" className="report-results__nav-card">
+              <h3>Chat About Results</h3>
+              <p>
+                Ask questions about your health data in plain language
+              </p>
+            </Link>
+          </nav>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/reports/ReportList.tsx
+++ b/components/reports/ReportList.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+
+interface Report {
+  id: string;
+  file_name: string;
+  file_type: string;
+  status: string;
+  created_at: string;
+}
+
+export default function ReportList() {
+  const [reports, setReports] = useState<Report[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchReports = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/reports");
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          throw new Error("Please log in to view reports");
+        }
+        throw new Error("Failed to load reports");
+      }
+
+      const data = await response.json();
+      setReports(data.reports || []);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load reports"
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchReports();
+  }, [fetchReports]);
+
+  if (loading) {
+    return (
+      <div className="report-list report-list--loading">
+        <div
+          className="report-list__spinner"
+          aria-label="Loading reports"
+          role="status"
+        />
+        <p>Loading your reports...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="report-list report-list--error">
+        <p className="report-list__error">{error}</p>
+        <button onClick={fetchReports} className="report-list__retry">
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  if (reports.length === 0) {
+    return (
+      <div className="report-list report-list--empty">
+        <p>No reports yet.</p>
+        <Link href="/upload" className="report-list__upload-link">
+          Upload your first medical report to get started
+        </Link>
+      </div>
+    );
+  }
+
+  const statusLabel: Record<string, string> = {
+    completed: "Analyzed",
+    processing: "Processing",
+    pending: "Pending",
+    error: "Error",
+  };
+
+  return (
+    <div className="report-list">
+      <h2>Your Reports</h2>
+      <div className="report-list__items">
+        {reports.map((report) => (
+          <Link
+            key={report.id}
+            href={`/reports/${report.id}`}
+            className="report-list__item"
+          >
+            <div className="report-list__item-info">
+              <span className="report-list__item-name">
+                {report.file_name}
+              </span>
+              <span className="report-list__item-date">
+                {new Date(report.created_at).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}
+              </span>
+            </div>
+            <span
+              className={`report-list__item-status report-list__item-status--${report.status}`}
+            >
+              {statusLabel[report.status] || report.status}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Closes #61** — Report results page that mounts existing HealthSummary and RiskDashboard components
- **Closes #63** — Report list on dashboard showing uploaded reports with status badges
- Adds `GET /api/reports` (list) and `GET /api/reports/[id]` (detail) API endpoints
- Handles all states: loading, parsed results, pending/processing, error, not found
- Navigation links from results page to doctor prep and chat

## Changes
| File | What |
|------|------|
| `app/api/reports/route.ts` | List user's reports (newest first, limit 20) |
| `app/api/reports/[id]/route.ts` | Single report with parsed_result_id |
| `app/reports/[id]/page.tsx` | Report results page — mounts HealthSummary + RiskDashboard |
| `app/reports/[id]/layout.tsx` | force-dynamic layout |
| `components/reports/ReportList.tsx` | Dashboard report list with status badges |
| `app/dashboard/page.tsx` | Added ReportList section |
| `app/globals.css` | Styles for report results page and report list |
| `__tests__/report-results.test.ts` | 13 tests covering all states and components |

## Test plan
- [x] 158 tests pass (14 test files)
- [x] Lint clean
- [x] Typecheck clean
- [ ] Verify report results page renders HealthSummary and RiskDashboard
- [ ] Verify report list on dashboard shows reports with status badges
- [ ] Verify pending/processing/error states display correctly
- [ ] Verify navigation links to doctor prep and chat work

🤖 Generated with [Claude Code](https://claude.com/claude-code)