### PR TITLE
feat(upload): auto-parse reports after upload

### DIFF
--- a/__tests__/upload.test.ts
+++ b/__tests__/upload.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import React from "react";
 import {
   validateFile,
   getFileExtension,
@@ -104,5 +106,159 @@ describe("File upload validation", () => {
       const file = createMockFile("scan.jpg", 1024, "image/jpeg");
       expect(getFileType(file)).toBe("image");
     });
+  });
+});
+
+// ── Upload Page — Auto-Parse Flow ────────────────────────────────────
+
+describe("Upload Page — auto-parse flow", () => {
+  const mockFetch = vi.fn();
+  const mockPush = vi.fn();
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.spyOn(globalThis, "fetch").mockImplementation(mockFetch);
+
+    vi.doMock("next/navigation", () => ({
+      useRouter: () => ({ push: mockPush }),
+    }));
+
+    vi.doMock("@/lib/supabase/client", () => ({
+      createClient: () => ({
+        auth: {
+          getUser: async () => ({
+            data: { user: { id: "user-1", email: "test@test.com" } },
+          }),
+        },
+      }),
+    }));
+  });
+
+  it("exports a default page component", async () => {
+    const mod = await import("@/app/upload/page");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+
+  it("renders upload form with file input and submit button", async () => {
+    const { default: UploadPage } = await import("@/app/upload/page");
+    render(React.createElement(UploadPage));
+
+    expect(screen.getByText("Upload Medical Report")).toBeDefined();
+    expect(screen.getByText("Upload Report")).toBeDefined();
+    expect(screen.getByLabelText("Choose a file or drag it here")).toBeDefined();
+  });
+
+  it("shows progress steps during upload and parse", async () => {
+    // Upload succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ report_id: "report-abc" }),
+    });
+    // Parse stays pending
+    mockFetch.mockReturnValueOnce(new Promise(() => {}));
+
+    const { default: UploadPage } = await import("@/app/upload/page");
+    render(React.createElement(UploadPage));
+
+    // Simulate file selection via fireEvent
+    const fileInput = screen.getByLabelText("Choose a file or drag it here");
+    const testFile = new File(["test"], "lab.pdf", {
+      type: "application/pdf",
+    });
+    fireEvent.change(fileInput, { target: { files: [testFile] } });
+
+    // Submit form
+    fireEvent.click(screen.getByText("Upload Report"));
+
+    // After upload succeeds, should show "Analyzing" step
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Analyzing your report with AI... This may take a minute."
+        )
+      ).toBeDefined();
+    });
+
+    // Verify parse was called with the report_id
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const parseCall = mockFetch.mock.calls[1];
+    expect(parseCall[0]).toBe("/api/parse");
+    expect(parseCall[1].method).toBe("POST");
+    const parseBody = JSON.parse(parseCall[1].body);
+    expect(parseBody.report_id).toBe("report-abc");
+  });
+
+  it("shows success state after parse completes", async () => {
+    // Upload succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ report_id: "report-abc" }),
+    });
+    // Parse succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ parsed_result_id: "parsed-1" }),
+    });
+
+    const { default: UploadPage } = await import("@/app/upload/page");
+    render(React.createElement(UploadPage));
+
+    // Simulate file selection
+    const fileInput = screen.getByLabelText("Choose a file or drag it here");
+    const testFile = new File(["test"], "lab.pdf", {
+      type: "application/pdf",
+    });
+    fireEvent.change(fileInput, { target: { files: [testFile] } });
+
+    // Submit form
+    fireEvent.click(screen.getByText("Upload Report"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Analysis complete!")).toBeDefined();
+    });
+
+    expect(
+      screen.getByText("Redirecting to your results...")
+    ).toBeDefined();
+
+    // Verify both fetch calls were made (upload + parse)
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows error with retry when parse fails", async () => {
+    // Upload succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ report_id: "report-abc" }),
+    });
+    // Parse fails
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Parse failed" }),
+    });
+
+    const { default: UploadPage } = await import("@/app/upload/page");
+    render(React.createElement(UploadPage));
+
+    const fileInput = screen.getByLabelText("Choose a file or drag it here");
+    const testFile = new File(["test"], "lab.pdf", {
+      type: "application/pdf",
+    });
+    fireEvent.change(fileInput, { target: { files: [testFile] } });
+
+    fireEvent.click(screen.getByText("Upload Report"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Retry Analysis")).toBeDefined();
+    });
+  });
+
+  it("has a back to dashboard link", async () => {
+    const { default: UploadPage } = await import("@/app/upload/page");
+    render(React.createElement(UploadPage));
+
+    expect(screen.getByText("Back to Dashboard")).toBeDefined();
   });
 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -1322,6 +1322,123 @@ button[type="submit"]:disabled {
   }
 }
 
+/* ── Upload Progress ──────────────────────────────────────────────── */
+
+.upload-back {
+  display: inline-block;
+  color: #3b82f6;
+  text-decoration: none;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.upload-back:hover {
+  text-decoration: underline;
+}
+
+.upload-progress {
+  padding: 1.5rem;
+  background: #f0f9ff;
+  border: 1px solid #bae6fd;
+  border-radius: 8px;
+  margin: 1.5rem 0;
+  text-align: center;
+}
+
+.upload-progress__steps {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.upload-progress__step {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: #9ca3af;
+  font-size: 0.875rem;
+}
+
+.upload-progress__step--active {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+.upload-progress__step--done {
+  color: #16a34a;
+}
+
+.upload-progress__step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 2px solid currentColor;
+}
+
+.upload-progress__step--active .upload-progress__step-number {
+  background: #2563eb;
+  color: white;
+  border-color: #2563eb;
+}
+
+.upload-progress__step--done .upload-progress__step-number {
+  background: #16a34a;
+  color: white;
+  border-color: #16a34a;
+}
+
+.upload-progress__connector {
+  width: 2rem;
+  height: 2px;
+  background: #d1d5db;
+}
+
+.upload-progress__message {
+  color: #4b5563;
+  font-size: 0.9375rem;
+}
+
+.upload-success {
+  padding: 1.5rem;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 8px;
+  margin: 1.5rem 0;
+  text-align: center;
+}
+
+.upload-success h2 {
+  color: #166534;
+  margin-bottom: 0.25rem;
+}
+
+.upload-success p {
+  color: #4b5563;
+}
+
+.upload-retry {
+  display: block;
+  margin-top: 0.75rem;
+  padding: 0.375rem 0.75rem;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.8125rem;
+}
+
+.upload-retry:hover {
+  background: #2563eb;
+}
+
 /* ── Report Results Page ──────────────────────────────────────────── */
 
 .report-results {

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -3,22 +3,25 @@
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
 import { useState, useRef } from "react";
+import Link from "next/link";
 
 const ALLOWED_EXTENSIONS = ".pdf,.png,.jpg,.jpeg";
 const MAX_SIZE_MB = 10;
 
+type UploadStage = "idle" | "uploading" | "parsing" | "complete" | "error";
+
 export default function UploadPage() {
   const [file, setFile] = useState<File | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [uploading, setUploading] = useState(false);
-  const [success, setSuccess] = useState<string | null>(null);
+  const [stage, setStage] = useState<UploadStage>("idle");
+  const [reportId, setReportId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
   const supabase = createClient();
 
   function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
     setError(null);
-    setSuccess(null);
+    setStage("idle");
     const selected = e.target.files?.[0];
     if (!selected) return;
 
@@ -47,8 +50,7 @@ export default function UploadPage() {
     if (!file) return;
 
     setError(null);
-    setSuccess(null);
-    setUploading(true);
+    setStage("uploading");
 
     // Verify we're still authenticated
     const {
@@ -63,65 +65,192 @@ export default function UploadPage() {
     formData.append("file", file);
 
     try {
-      const response = await fetch("/api/upload", {
+      // Step 1: Upload
+      const uploadResponse = await fetch("/api/upload", {
         method: "POST",
         body: formData,
       });
 
-      const data = await response.json();
+      const uploadData = await uploadResponse.json();
 
-      if (!response.ok) {
-        setError(data.error || "Upload failed. Please try again.");
-        setUploading(false);
+      if (!uploadResponse.ok) {
+        setError(uploadData.error || "Upload failed. Please try again.");
+        setStage("error");
         return;
       }
 
-      setSuccess(`Report uploaded successfully! ID: ${data.report_id}`);
+      const newReportId = uploadData.report_id;
+      setReportId(newReportId);
+
+      // Step 2: Auto-parse
+      setStage("parsing");
+
+      const parseResponse = await fetch("/api/parse", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ report_id: newReportId }),
+      });
+
+      const parseData = await parseResponse.json();
+
+      if (!parseResponse.ok) {
+        setError(
+          parseData.error ||
+            "Analysis failed. Your report was uploaded — you can retry analysis from the report page."
+        );
+        setStage("error");
+        return;
+      }
+
+      // Step 3: Success — redirect to results
+      setStage("complete");
       setFile(null);
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
+
+      // Brief delay so user sees the success state before redirect
+      setTimeout(() => {
+        router.push(`/reports/${newReportId}`);
+      }, 1000);
     } catch {
       setError("Network error. Please check your connection and try again.");
-    } finally {
-      setUploading(false);
+      setStage("error");
     }
   }
 
+  async function handleRetryParse() {
+    if (!reportId) return;
+
+    setError(null);
+    setStage("parsing");
+
+    try {
+      const parseResponse = await fetch("/api/parse", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ report_id: reportId }),
+      });
+
+      const parseData = await parseResponse.json();
+
+      if (!parseResponse.ok) {
+        setError(parseData.error || "Analysis failed. Please try again.");
+        setStage("error");
+        return;
+      }
+
+      setStage("complete");
+      setTimeout(() => {
+        router.push(`/reports/${reportId}`);
+      }, 1000);
+    } catch {
+      setError("Network error. Please check your connection and try again.");
+      setStage("error");
+    }
+  }
+
+  const isProcessing = stage === "uploading" || stage === "parsing";
+
   return (
     <div className="upload-container">
+      <Link href="/dashboard" className="upload-back">
+        Back to Dashboard
+      </Link>
       <h1>Upload Medical Report</h1>
       <p>
         Upload your lab results or medical reports. We accept PDF, PNG, and JPG
         files up to 10MB.
       </p>
 
-      <form onSubmit={handleUpload}>
-        <div className="upload-area">
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept={ALLOWED_EXTENSIONS}
-            onChange={handleFileSelect}
-            id="file-input"
-          />
-          <label htmlFor="file-input" className="upload-label">
-            {file ? file.name : "Choose a file or drag it here"}
-          </label>
-          {file && (
-            <p className="file-info">
-              {file.name} ({(file.size / 1024 / 1024).toFixed(1)}MB)
-            </p>
-          )}
+      {/* Progress indicator */}
+      {isProcessing && (
+        <div className="upload-progress" role="status">
+          <div className="upload-progress__steps">
+            <div
+              className={`upload-progress__step ${
+                stage === "uploading"
+                  ? "upload-progress__step--active"
+                  : "upload-progress__step--done"
+              }`}
+            >
+              <span className="upload-progress__step-number">1</span>
+              <span className="upload-progress__step-label">Uploading</span>
+            </div>
+            <div className="upload-progress__connector" />
+            <div
+              className={`upload-progress__step ${
+                stage === "parsing"
+                  ? "upload-progress__step--active"
+                  : ""
+              }`}
+            >
+              <span className="upload-progress__step-number">2</span>
+              <span className="upload-progress__step-label">Analyzing</span>
+            </div>
+            <div className="upload-progress__connector" />
+            <div className="upload-progress__step">
+              <span className="upload-progress__step-number">3</span>
+              <span className="upload-progress__step-label">Done</span>
+            </div>
+          </div>
+          <p className="upload-progress__message">
+            {stage === "uploading"
+              ? "Uploading your file..."
+              : "Analyzing your report with AI... This may take a minute."}
+          </p>
         </div>
+      )}
 
-        {error && <div className="error-message">{error}</div>}
-        {success && <div className="success-message">{success}</div>}
+      {/* Success state */}
+      {stage === "complete" && (
+        <div className="upload-success" role="status">
+          <h2>Analysis complete!</h2>
+          <p>Redirecting to your results...</p>
+        </div>
+      )}
 
-        <button type="submit" disabled={!file || uploading}>
-          {uploading ? "Uploading..." : "Upload Report"}
-        </button>
-      </form>
+      {/* Upload form — hidden during processing/complete */}
+      {!isProcessing && stage !== "complete" && (
+        <form onSubmit={handleUpload}>
+          <div className="upload-area">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ALLOWED_EXTENSIONS}
+              onChange={handleFileSelect}
+              id="file-input"
+            />
+            <label htmlFor="file-input" className="upload-label">
+              {file ? file.name : "Choose a file or drag it here"}
+            </label>
+            {file && (
+              <p className="file-info">
+                {file.name} ({(file.size / 1024 / 1024).toFixed(1)}MB)
+              </p>
+            )}
+          </div>
+
+          {error && (
+            <div className="error-message" role="alert">
+              {error}
+              {reportId && stage === "error" && (
+                <button
+                  type="button"
+                  onClick={handleRetryParse}
+                  className="upload-retry"
+                >
+                  Retry Analysis
+                </button>
+              )}
+            </div>
+          )}
+
+          <button type="submit" disabled={!file || isProcessing}>
+            Upload Report
+          </button>
+        </form>
+      )}
 
       <p className="upload-note">
         Your files are encrypted and stored securely in compliance with HIPAA


### PR DESCRIPTION
## Summary
- **Closes #62** — Upload page now automatically triggers parsing after file upload
- Three-step progress indicator: Uploading → Analyzing → Done
- Redirects to `/reports/[id]` results page on success
- Parse failure shows error with "Retry Analysis" button
- Added "Back to Dashboard" link

## Test plan
- [x] 151 tests pass (13 test files)
- [x] Lint and typecheck clean
- [ ] Upload a file → verify progress steps appear
- [ ] Verify redirect to report results page after parse
- [ ] Verify retry button on parse failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)