### PR TITLE
fix(chat): fix collapsed chat input text box

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -427,6 +427,8 @@ button[type="submit"]:disabled {
 
 .chat-input {
   flex: 1;
+  min-width: 0;
+  min-height: 40px;
   padding: 0.6rem 0.75rem;
   border: 1px solid #d0d0d0;
   border-radius: 20px;
@@ -444,6 +446,8 @@ button[type="submit"]:disabled {
 }
 
 .chat-send-button {
+  width: auto;
+  flex-shrink: 0;
   padding: 0.6rem 1.2rem;
   background: #0066cc;
   color: white;


### PR DESCRIPTION
## Summary
- Fixes the chat input textarea being collapsed to zero width
- Root cause: global `button[type="submit"] { width: 100% }` was overriding the flex layout, making the Send button take 100% width and squeezing the textarea out
- Fix: `width: auto` + `flex-shrink: 0` on Send button, `min-width: 0` + `min-height: 40px` on textarea

## Test plan
- [x] All 145 tests pass
- [ ] Chat input textarea is visible and properly sized
- [ ] Send button appears next to textarea, not full width
- [ ] Textarea auto-resizes on multiline input

🤖 Generated with [Claude Code](https://claude.com/claude-code)