### PR TITLE
fix(reports): align UI status values with database enum + parse logging

### DIFF
--- a/app/api/parse/route.ts
+++ b/app/api/parse/route.ts
@@ -113,6 +113,7 @@ export async function POST(request: Request) {
       .single();
 
     if (insertError || !parsedResult) {
+      console.error("[PARSE] Failed to store parsed results. insertError:", insertError?.message ?? "none", "parsedResult:", parsedResult);
       await supabase
         .from("reports")
         .update({ status: "error" })
@@ -122,6 +123,7 @@ export async function POST(request: Request) {
         { status: 500 }
       );
     }
+    console.log("[PARSE] Stored parsed_result:", parsedResult.id);
 
     // Create risk flags for each biomarker
     const riskFlags = parsed.biomarkers


### PR DESCRIPTION
## Summary
- **Bug fix**: Report detail page and ReportList used wrong status values (`completed`/`processing`/`pending`) that don't match the database enum (`parsed`/`parsing`/`uploaded`). Reports that were successfully parsed showed as "Error" because `"parsed" !== "completed"`.
- **Diagnostic**: Adds logging for `parsed_results` insert step in parse route to diagnose silent store failures.

## Changes
- `app/reports/[id]/page.tsx` — Fix status checks: `completed` → `parsed`, `processing` → `parsing`, `pending` → `uploaded`
- `components/reports/ReportList.tsx` — Fix `statusLabel` mapping to match database enum
- `app/api/parse/route.ts` — Add log for insert success/failure
- `__tests__/report-results.test.ts` — Update test mock data to use correct status values

## Test plan
- [x] All 208 tests pass
- [ ] Old reports with status "parsed" should now show "Analyzed" instead of "Error"
- [ ] New upload + parse flow will show diagnostic logs in Render

🤖 Generated with [Claude Code](https://claude.com/claude-code)