### PR TITLE
feat(auth): add in-memory rate limiting to auth endpoints

### DIFF
--- a/__tests__/rate-limit.test.ts
+++ b/__tests__/rate-limit.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createRateLimiter, isAuthRoute } from "@/lib/rate-limit";
+
+describe("createRateLimiter", () => {
+  const maxAttempts = 5;
+  const windowMs = 60_000;
+  let limiter: ReturnType<typeof createRateLimiter>;
+
+  beforeEach(() => {
+    limiter = createRateLimiter({ maxAttempts, windowMs });
+  });
+
+  it("allows requests under the limit", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < maxAttempts; i++) {
+      const result = limiter.check("192.168.1.1", now + i);
+      expect(result.allowed).toBe(true);
+      expect(result.remaining).toBe(maxAttempts - (i + 1));
+    }
+  });
+
+  it("returns 429 after exceeding the rate limit", () => {
+    const now = 1_000_000;
+    // Exhaust all attempts
+    for (let i = 0; i < maxAttempts; i++) {
+      limiter.check("192.168.1.1", now);
+    }
+
+    // Next request should be denied
+    const result = limiter.check("192.168.1.1", now);
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+  });
+
+  it("includes Retry-After seconds on rate-limited responses", () => {
+    const now = 1_000_000;
+    // Exhaust all attempts
+    for (let i = 0; i < maxAttempts; i++) {
+      limiter.check("192.168.1.1", now);
+    }
+
+    const result = limiter.check("192.168.1.1", now + 1_000);
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterSeconds).toBeGreaterThan(0);
+    // Should be roughly (windowMs - 1000) / 1000 = 59 seconds
+    expect(result.retryAfterSeconds).toBeLessThanOrEqual(60);
+  });
+
+  it("allows requests again after the window expires", () => {
+    const now = 1_000_000;
+    // Exhaust all attempts
+    for (let i = 0; i < maxAttempts; i++) {
+      limiter.check("192.168.1.1", now);
+    }
+
+    // Should be denied
+    expect(limiter.check("192.168.1.1", now).allowed).toBe(false);
+
+    // After window expires, should be allowed again
+    const result = limiter.check("192.168.1.1", now + windowMs + 1);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(maxAttempts - 1);
+  });
+
+  it("tracks different IPs independently", () => {
+    const now = 1_000_000;
+    // Exhaust attempts for IP A
+    for (let i = 0; i < maxAttempts; i++) {
+      limiter.check("10.0.0.1", now);
+    }
+    expect(limiter.check("10.0.0.1", now).allowed).toBe(false);
+
+    // IP B should still be allowed
+    const result = limiter.check("10.0.0.2", now);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(maxAttempts - 1);
+  });
+
+  it("uses sliding window — old requests expire individually", () => {
+    const now = 1_000_000;
+    // Make requests spread across the window
+    for (let i = 0; i < maxAttempts; i++) {
+      limiter.check("192.168.1.1", now + i * 10_000); // every 10s
+    }
+
+    // At now + 40_000, all 5 are still within window — should be denied
+    const denied = limiter.check("192.168.1.1", now + 40_000);
+    expect(denied.allowed).toBe(false);
+
+    // At now + 60_001, the first request (at now+0) has expired — should be allowed
+    const allowed = limiter.check("192.168.1.1", now + 60_001);
+    expect(allowed.allowed).toBe(true);
+  });
+
+  it("reset clears all tracked data", () => {
+    const now = 1_000_000;
+    for (let i = 0; i < maxAttempts; i++) {
+      limiter.check("192.168.1.1", now);
+    }
+    expect(limiter.check("192.168.1.1", now).allowed).toBe(false);
+
+    limiter.reset();
+
+    const result = limiter.check("192.168.1.1", now);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(maxAttempts - 1);
+  });
+});
+
+describe("isAuthRoute", () => {
+  it("matches /auth/* page routes", () => {
+    expect(isAuthRoute("/auth/login")).toBe(true);
+    expect(isAuthRoute("/auth/signup")).toBe(true);
+    expect(isAuthRoute("/auth/reset-password")).toBe(true);
+  });
+
+  it("matches /api/auth/* API routes", () => {
+    expect(isAuthRoute("/api/auth/callback")).toBe(true);
+    expect(isAuthRoute("/api/auth/confirm")).toBe(true);
+  });
+
+  it("does not match non-auth routes", () => {
+    expect(isAuthRoute("/dashboard")).toBe(false);
+    expect(isAuthRoute("/api/health")).toBe(false);
+    expect(isAuthRoute("/api/chat")).toBe(false);
+    expect(isAuthRoute("/")).toBe(false);
+  });
+});

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,117 @@
+/**
+ * In-memory sliding window rate limiter for auth endpoints.
+ *
+ * Tracks request timestamps per IP using a Map. Old entries are pruned
+ * on each check to prevent unbounded memory growth.
+ *
+ * This is intentionally simple and edge-compatible — no Redis or
+ * external dependencies required. The trade-off is that rate limit
+ * state is per-process and resets on deploy. For a HIPAA-compliant
+ * health app this is acceptable as defense-in-depth alongside
+ * Supabase's own rate limits.
+ */
+
+interface RateLimitEntry {
+  timestamps: number[];
+}
+
+interface RateLimitConfig {
+  /** Maximum number of requests allowed within the window. */
+  maxAttempts: number;
+  /** Time window in milliseconds. */
+  windowMs: number;
+}
+
+interface RateLimitResult {
+  /** Whether the request is allowed. */
+  allowed: boolean;
+  /** Number of remaining attempts in the current window. */
+  remaining: number;
+  /** Seconds until the earliest tracked request expires (for Retry-After). */
+  retryAfterSeconds: number;
+}
+
+const DEFAULT_CONFIG: RateLimitConfig = {
+  maxAttempts: 5,
+  windowMs: 60_000, // 1 minute
+};
+
+/**
+ * Creates a rate limiter instance with its own in-memory store.
+ *
+ * Usage:
+ *   const limiter = createRateLimiter({ maxAttempts: 5, windowMs: 60_000 });
+ *   const result = limiter.check(clientIp);
+ *   if (!result.allowed) { return 429 with Retry-After header }
+ */
+export function createRateLimiter(config: Partial<RateLimitConfig> = {}) {
+  const { maxAttempts, windowMs } = { ...DEFAULT_CONFIG, ...config };
+  const store = new Map<string, RateLimitEntry>();
+
+  function prune(now: number) {
+    const cutoff = now - windowMs;
+    for (const [key, entry] of store) {
+      entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+      if (entry.timestamps.length === 0) {
+        store.delete(key);
+      }
+    }
+  }
+
+  /**
+   * Check whether a request from the given key (typically an IP) is
+   * allowed, and record the attempt.
+   */
+  function check(key: string, now: number = Date.now()): RateLimitResult {
+    prune(now);
+
+    const cutoff = now - windowMs;
+    let entry = store.get(key);
+    if (!entry) {
+      entry = { timestamps: [] };
+      store.set(key, entry);
+    }
+
+    // Filter to only timestamps within the current window
+    entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+
+    if (entry.timestamps.length >= maxAttempts) {
+      // Rate limited — calculate when the oldest request in the window expires
+      const oldestInWindow = entry.timestamps[0];
+      const retryAfterMs = oldestInWindow + windowMs - now;
+      const retryAfterSeconds = Math.ceil(retryAfterMs / 1000);
+
+      return {
+        allowed: false,
+        remaining: 0,
+        retryAfterSeconds: Math.max(1, retryAfterSeconds),
+      };
+    }
+
+    // Allowed — record this attempt
+    entry.timestamps.push(now);
+
+    return {
+      allowed: true,
+      remaining: maxAttempts - entry.timestamps.length,
+      retryAfterSeconds: 0,
+    };
+  }
+
+  /** Reset the store (useful for testing). */
+  function reset() {
+    store.clear();
+  }
+
+  return { check, reset };
+}
+
+/**
+ * Determines whether a request path should be rate-limited.
+ * Matches auth page routes and auth API routes.
+ */
+export function isAuthRoute(pathname: string): boolean {
+  return (
+    pathname.startsWith("/auth/") || pathname.startsWith("/api/auth/")
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,40 @@
 import { updateSession } from "@/lib/supabase/middleware";
-import type { NextRequest } from "next/server";
+import { createRateLimiter, isAuthRoute } from "@/lib/rate-limit";
+import { NextResponse, type NextRequest } from "next/server";
+
+// Single rate limiter instance shared across all requests in this process.
+// 5 attempts per minute per IP for auth endpoints.
+const authRateLimiter = createRateLimiter({
+  maxAttempts: 5,
+  windowMs: 60_000,
+});
 
 export async function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+
+  // Apply rate limiting to auth routes
+  if (isAuthRoute(pathname)) {
+    // Use x-forwarded-for (set by reverse proxies like Render) or fall back
+    // to a generic key. Never log the IP with PHI per guardrails.
+    const clientIp =
+      request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+      "unknown";
+
+    const result = authRateLimiter.check(clientIp);
+
+    if (!result.allowed) {
+      return NextResponse.json(
+        { error: "Too many requests. Please try again later." },
+        {
+          status: 429,
+          headers: {
+            "Retry-After": String(result.retryAfterSeconds),
+          },
+        }
+      );
+    }
+  }
+
   return await updateSession(request);
 }
 


### PR DESCRIPTION
## Summary
- Adds sliding window rate limiter (`lib/rate-limit.ts`) — in-memory, no external dependencies
- Applies rate limiting in `middleware.ts` to `/auth/*` and `/api/auth/*` routes (5 requests/min per IP)
- Returns HTTP 429 with `Retry-After` header when limit exceeded
- Defense-in-depth for HIPAA compliance alongside Supabase's own rate limits

## Changes
| File | Change |
|------|--------|
| `lib/rate-limit.ts` | New sliding window rate limiter utility |
| `middleware.ts` | Integrate rate limiting for auth routes |
| `__tests__/rate-limit.test.ts` | 10 tests covering limits, expiry, per-IP isolation, Retry-After |

## Test plan
- [x] `npm run lint` — zero errors
- [x] `npm run typecheck` — zero errors  
- [x] `npm test` — 218 tests pass (10 new rate-limit tests)
- [ ] Verify 429 response after 5 rapid requests to `/auth/login` in dev
- [ ] Verify `Retry-After` header is present on 429 responses
- [ ] Verify requests from different IPs are tracked independently

Closes #41