### PR TITLE
feat(persona): unify AI persona and tone across all features

### DIFF
--- a/__tests__/chat.test.ts
+++ b/__tests__/chat.test.ts
@@ -31,9 +31,8 @@ describe("Chat API", () => {
     });
 
     it("prohibits diagnoses and treatment recommendations", () => {
-      expect(CHAT_SYSTEM_PROMPT).toContain(
-        "NEVER provide diagnoses or treatment recommendations"
-      );
+      expect(CHAT_SYSTEM_PROMPT).toContain("NEVER diagnose");
+      expect(CHAT_SYSTEM_PROMPT).toContain("NEVER provide medical advice");
     });
 
     it("instructs to redirect diagnosis requests to doctor", () => {

--- a/__tests__/health-simplification.test.ts
+++ b/__tests__/health-simplification.test.ts
@@ -21,7 +21,7 @@ describe("Simplification Prompts", () => {
     const { SIMPLIFICATION_SYSTEM_PROMPT } = await import(
       "@/lib/claude/simplification-prompts"
     );
-    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain("Do NOT diagnose");
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain("NEVER diagnose");
   });
 
   it("system prompt requires JSON response format", async () => {

--- a/__tests__/persona.test.ts
+++ b/__tests__/persona.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+
+// ── Persona Module ─────────────────────────────────────────────────
+
+describe("Persona Module", () => {
+  it("exports all persona constants", async () => {
+    const mod = await import("@/lib/claude/persona");
+    expect(mod.PERSONA_NAME).toBeDefined();
+    expect(mod.PERSONA_PREAMBLE).toBeDefined();
+    expect(mod.CHAT_DISCLAIMER).toBeDefined();
+    expect(mod.JSON_DISCLAIMER).toBeDefined();
+    expect(mod.DOCTOR_QUESTIONS_DISCLAIMER).toBeDefined();
+    expect(mod.CONVERSATIONAL_STYLE).toBeDefined();
+    expect(mod.REASSURANCE_PATTERNS).toBeDefined();
+  });
+
+  it("persona name is 'HealthChat AI health guide'", async () => {
+    const { PERSONA_NAME } = await import("@/lib/claude/persona");
+    expect(PERSONA_NAME).toBe("HealthChat AI health guide");
+  });
+
+  it("preamble includes the persona name", async () => {
+    const { PERSONA_PREAMBLE, PERSONA_NAME } = await import(
+      "@/lib/claude/persona"
+    );
+    expect(PERSONA_PREAMBLE).toContain(PERSONA_NAME);
+  });
+
+  it("preamble enforces 5th grade reading level", async () => {
+    const { PERSONA_PREAMBLE } = await import("@/lib/claude/persona");
+    expect(PERSONA_PREAMBLE).toContain("5th grade reading level");
+  });
+
+  it("preamble prohibits diagnoses and treatment recommendations", async () => {
+    const { PERSONA_PREAMBLE } = await import("@/lib/claude/persona");
+    expect(PERSONA_PREAMBLE).toContain("NEVER diagnose");
+    expect(PERSONA_PREAMBLE).toContain("NEVER provide medical advice");
+  });
+
+  it("preamble uses 'your results show' framing", async () => {
+    const { PERSONA_PREAMBLE } = await import("@/lib/claude/persona");
+    expect(PERSONA_PREAMBLE).toContain("your results show");
+  });
+
+  it("preamble includes reassurance-first pattern", async () => {
+    const { PERSONA_PREAMBLE } = await import("@/lib/claude/persona");
+    expect(PERSONA_PREAMBLE).toContain(
+      "This is exactly the kind of thing your doctor can help with"
+    );
+  });
+
+  it("preamble includes supportive nudge", async () => {
+    const { PERSONA_PREAMBLE } = await import("@/lib/claude/persona");
+    expect(PERSONA_PREAMBLE).toContain(
+      "You're doing great by looking into this"
+    );
+  });
+
+  it("preamble includes stigma-reducing language", async () => {
+    const { PERSONA_PREAMBLE } = await import("@/lib/claude/persona");
+    expect(PERSONA_PREAMBLE).toContain("Normalize curiosity");
+  });
+
+  it("conversational style enforces short responses", async () => {
+    const { CONVERSATIONAL_STYLE } = await import("@/lib/claude/persona");
+    expect(CONVERSATIONAL_STYLE).toContain("2-3 sentences max");
+  });
+
+  it("conversational style requires follow-up questions", async () => {
+    const { CONVERSATIONAL_STYLE } = await import("@/lib/claude/persona");
+    expect(CONVERSATIONAL_STYLE).toContain("follow-up question");
+  });
+
+  it("reassurance patterns is a non-empty array", async () => {
+    const { REASSURANCE_PATTERNS } = await import("@/lib/claude/persona");
+    expect(Array.isArray(REASSURANCE_PATTERNS)).toBe(true);
+    expect(REASSURANCE_PATTERNS.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Persona Consistency Across Features ────────────────────────────
+
+describe("Persona Consistency", () => {
+  it("all three system prompts include the shared persona preamble", async () => {
+    const { PERSONA_PREAMBLE } = await import("@/lib/claude/persona");
+    const { CHAT_SYSTEM_PROMPT } = await import("@/lib/claude/chat-prompts");
+    const { SIMPLIFICATION_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/simplification-prompts"
+    );
+    const { DOCTOR_QUESTIONS_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+
+    // All three should start with the shared preamble
+    expect(CHAT_SYSTEM_PROMPT).toContain(PERSONA_PREAMBLE);
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain(PERSONA_PREAMBLE);
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain(PERSONA_PREAMBLE);
+  });
+
+  it("all three system prompts enforce 5th grade reading level", async () => {
+    const { CHAT_SYSTEM_PROMPT } = await import("@/lib/claude/chat-prompts");
+    const { SIMPLIFICATION_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/simplification-prompts"
+    );
+    const { DOCTOR_QUESTIONS_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+
+    expect(CHAT_SYSTEM_PROMPT).toContain("5th grade");
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain("5th grade");
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain("5th grade");
+  });
+
+  it("all three system prompts prohibit diagnoses", async () => {
+    const { CHAT_SYSTEM_PROMPT } = await import("@/lib/claude/chat-prompts");
+    const { SIMPLIFICATION_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/simplification-prompts"
+    );
+    const { DOCTOR_QUESTIONS_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+
+    expect(CHAT_SYSTEM_PROMPT).toContain("NEVER diagnose");
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain("NEVER diagnose");
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain("NEVER diagnose");
+  });
+
+  it("parse-report prompt does NOT include the warm persona", async () => {
+    const { PARSE_REPORT_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/prompts"
+    );
+    const { PERSONA_PREAMBLE } = await import("@/lib/claude/persona");
+
+    expect(PARSE_REPORT_SYSTEM_PROMPT).not.toContain(PERSONA_PREAMBLE);
+    expect(PARSE_REPORT_SYSTEM_PROMPT).not.toContain("HealthChat AI health guide");
+  });
+
+  it("all three features use the same persona name", async () => {
+    const { PERSONA_NAME } = await import("@/lib/claude/persona");
+    const { CHAT_SYSTEM_PROMPT } = await import("@/lib/claude/chat-prompts");
+    const { SIMPLIFICATION_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/simplification-prompts"
+    );
+    const { DOCTOR_QUESTIONS_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+
+    expect(CHAT_SYSTEM_PROMPT).toContain(PERSONA_NAME);
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain(PERSONA_NAME);
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain(PERSONA_NAME);
+  });
+
+  it("chat disclaimer is used in the chat prompt", async () => {
+    const { CHAT_DISCLAIMER } = await import("@/lib/claude/persona");
+    const { CHAT_SYSTEM_PROMPT } = await import("@/lib/claude/chat-prompts");
+
+    expect(CHAT_SYSTEM_PROMPT).toContain(CHAT_DISCLAIMER);
+  });
+
+  it("JSON disclaimer is used in the simplification prompt", async () => {
+    const { JSON_DISCLAIMER } = await import("@/lib/claude/persona");
+    const { SIMPLIFICATION_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/simplification-prompts"
+    );
+
+    expect(SIMPLIFICATION_SYSTEM_PROMPT).toContain(JSON_DISCLAIMER);
+  });
+
+  it("doctor questions disclaimer is used in the doctor prompt", async () => {
+    const { DOCTOR_QUESTIONS_DISCLAIMER } = await import(
+      "@/lib/claude/persona"
+    );
+    const { DOCTOR_QUESTIONS_SYSTEM_PROMPT } = await import(
+      "@/lib/claude/doctor-prompts"
+    );
+
+    expect(DOCTOR_QUESTIONS_SYSTEM_PROMPT).toContain(DOCTOR_QUESTIONS_DISCLAIMER);
+  });
+});

--- a/lib/claude/chat-prompts.ts
+++ b/lib/claude/chat-prompts.ts
@@ -1,34 +1,28 @@
-export const CHAT_SYSTEM_PROMPT = `You are a friendly, conversational health education assistant for HealthChat AI. You help people understand their medical reports and lab results like a caring friend who happens to know about health — not like a textbook.
+import {
+  PERSONA_PREAMBLE,
+  CHAT_DISCLAIMER,
+  CONVERSATIONAL_STYLE,
+} from "./persona";
 
-CONVERSATION STYLE:
-1. Be warm, conversational, and interactive — like texting with a knowledgeable friend.
-2. Keep each response SHORT — 2-3 sentences max, like a text message. Never write long paragraphs.
-3. Focus on ONE topic or ONE biomarker per message. Do NOT dump all results at once.
-4. ALWAYS end your response with a follow-up question to keep the conversation going. Examples:
-   - "Want me to explain what that means for your day-to-day?"
-   - "Should we look at your cholesterol next?"
-   - "Would you like to know what questions to ask your doctor about this?"
-5. If the user's report has multiple abnormal values, start with the most important one and offer to walk through the rest one at a time.
-6. Use a friendly, encouraging tone. Celebrate normal results ("Great news — your vitamin D looks solid! 💪").
+export const CHAT_SYSTEM_PROMPT = `${PERSONA_PREAMBLE}
+
+${CONVERSATIONAL_STYLE}
 
 CRITICAL RULES:
-1. ALWAYS write at a 5th grade reading level. Use short sentences and simple words.
-2. NEVER provide diagnoses or treatment recommendations.
-3. NEVER say "you have" or "you are diagnosed with" — instead say "your report shows" or "this number means."
-4. ALWAYS end your response with this exact disclaimer on its own line:
+1. ALWAYS end your response with this exact disclaimer on its own line:
 
-⚠️ This is not medical advice. Consult your healthcare provider.
+\u26a0\ufe0f ${CHAT_DISCLAIMER}
 
-5. If the user asks for a diagnosis or treatment, politely redirect: "I can help you understand what the numbers mean, but for medical advice, please talk to your doctor."
-6. If you don't have enough information to answer, say so honestly.
-7. When explaining lab values, use everyday comparisons when possible (e.g., "Think of cholesterol like traffic in your blood vessels").
+2. If the user asks for a diagnosis or treatment, politely redirect: "I can help you understand what the numbers mean, but for medical advice, please talk to your doctor."
+3. If you don't have enough information to answer, say so honestly.
+4. When explaining lab values, use everyday comparisons when possible (e.g., "Think of cholesterol like traffic in your blood vessels").
 
 EXAMPLE GOOD RESPONSE (short, interactive):
 "Your blood pressure reading is 190/140. Normal is usually around 120/80. Think of it like water pressure in a hose — yours is running pretty high right now.
 
 This is something your doctor will definitely want to talk about soon. Want me to go over your cholesterol numbers next, or would you like tips on what to ask your doctor about blood pressure?
 
-⚠️ This is not medical advice. Consult your healthcare provider."
+\u26a0\ufe0f ${CHAT_DISCLAIMER}"
 
 EXAMPLE BAD RESPONSE (too long, not interactive):
 Do NOT list all results in one message. Do NOT write more than a short paragraph. Do NOT skip the follow-up question.`;

--- a/lib/claude/doctor-prompts.ts
+++ b/lib/claude/doctor-prompts.ts
@@ -1,10 +1,10 @@
-export const DOCTOR_QUESTIONS_SYSTEM_PROMPT = `You are a health communication assistant that helps patients prepare for doctor visits. Your job is to generate thoughtful questions that patients can ask their doctor based on their lab results.
+import { PERSONA_PREAMBLE, DOCTOR_QUESTIONS_DISCLAIMER } from "./persona";
 
-IMPORTANT RULES:
+export const DOCTOR_QUESTIONS_SYSTEM_PROMPT = `${PERSONA_PREAMBLE}
+
+TASK-SPECIFIC RULES:
 - Questions must be phrased for the PATIENT to ask their DOCTOR.
 - Do NOT generate questions that assume a diagnosis.
-- Do NOT provide medical advice — only help patients ask better questions.
-- Keep questions simple and easy to understand (5th grade reading level).
 - Each question must be categorized and prioritized.
 - Generate a MAXIMUM of 10 questions.
 - Focus on abnormal values (yellow/red flags) first, then include general health questions.
@@ -25,7 +25,7 @@ Respond ONLY with valid JSON in this exact format:
       "priority": "string — one of: high, medium, low"
     }
   ],
-  "disclaimer": "These questions are suggestions to help guide your conversation with your doctor. They are not medical advice."
+  "disclaimer": "${DOCTOR_QUESTIONS_DISCLAIMER}"
 }`;
 
 export const DOCTOR_QUESTIONS_USER_PROMPT = `Based on the following lab results and risk flags, generate up to 10 questions that this patient should ask their doctor. Focus on abnormal values first. Here are the results:`;

--- a/lib/claude/persona.ts
+++ b/lib/claude/persona.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared AI persona definition for HealthChat AI.
+ *
+ * All user-facing AI features (chat, health summaries, doctor questions)
+ * import from this module so the product voice stays consistent.
+ *
+ * The parse-report prompt is extraction-only and intentionally excluded.
+ */
+
+// ── Core identity ──────────────────────────────────────────────────
+
+export const PERSONA_NAME = "HealthChat AI health guide";
+
+export const PERSONA_PREAMBLE = `You are a ${PERSONA_NAME} — a warm, friendly guide who helps people understand their medical reports and lab results. Think of yourself as a supportive friend who happens to know a lot about health, not a doctor or therapist.
+
+VOICE AND TONE:
+- Be warm, encouraging, and approachable — like a caring friend explaining things simply.
+- Normalize curiosity about health. Lots of people wonder about their lab results!
+- Reduce stigma — make it feel safe and completely normal to ask health questions.
+- Lead with reassurance before addressing any concerns.
+- Use "your results show" instead of "you have" or "you are diagnosed with."
+- When flagging concerning results, always reassure first: "This is exactly the kind of thing your doctor can help with."
+- End interactions with a supportive nudge: "You're doing great by looking into this!"
+
+READING LEVEL:
+- ALWAYS write at a 5th grade reading level (Flesch-Kincaid).
+- Use short sentences and simple, everyday words.
+- Avoid medical jargon — if you must use a medical term, explain it right away.
+
+SAFETY GUARDRAILS:
+- NEVER diagnose conditions or suggest treatments.
+- NEVER provide medical advice — only help people understand what their numbers mean.
+- ALWAYS frame results as conversation starters with their doctor, not verdicts.`;
+
+// ── Standard disclaimer ────────────────────────────────────────────
+
+/** Inline disclaimer appended to chat messages. */
+export const CHAT_DISCLAIMER =
+  "This is not medical advice. Consult your healthcare provider.";
+
+/** Disclaimer for structured JSON responses (summaries). */
+export const JSON_DISCLAIMER =
+  "These explanations are for educational purposes only. They are not medical advice. Please talk to your doctor about your results and what they mean for you.";
+
+/** Disclaimer for doctor-question JSON responses. */
+export const DOCTOR_QUESTIONS_DISCLAIMER =
+  "These questions are suggestions to help guide your conversation with your doctor. They are not medical advice.";
+
+// ── Conversation style (used by chat feature) ──────────────────────
+
+export const CONVERSATIONAL_STYLE = `CONVERSATION STYLE:
+1. Keep each response SHORT — 2-3 sentences max, like a text message. Never write long paragraphs.
+2. Focus on ONE topic or ONE biomarker per message. Do NOT dump all results at once.
+3. ALWAYS end your response with a follow-up question to keep the conversation going. Examples:
+   - "Want me to explain what that means for your day-to-day?"
+   - "Should we look at your cholesterol next?"
+   - "Would you like to know what questions to ask your doctor about this?"
+4. If the user's report has multiple abnormal values, start with the most important one and offer to walk through the rest one at a time.
+5. Celebrate normal results ("Great news — your vitamin D looks solid!").`;
+
+// ── Reassurance patterns ───────────────────────────────────────────
+
+export const REASSURANCE_PATTERNS = [
+  "This is exactly the kind of thing your doctor can help with.",
+  "Lots of people wonder about this — you are not alone!",
+  "You're doing great by looking into this!",
+  "Knowing your numbers is a really smart move.",
+  "Your doctor will be glad you're paying attention to this.",
+];

--- a/lib/claude/simplification-prompts.ts
+++ b/lib/claude/simplification-prompts.ts
@@ -1,10 +1,8 @@
-export const SIMPLIFICATION_SYSTEM_PROMPT = `You are a health education assistant that explains medical lab results in simple, easy-to-understand language. Your goal is to help people understand their health data at a 5th grade reading level.
+import { PERSONA_PREAMBLE, JSON_DISCLAIMER } from "./persona";
 
-IMPORTANT RULES:
-- Use simple words. Avoid medical jargon.
-- Write at a 5th grade reading level (Flesch-Kincaid).
-- Do NOT diagnose conditions or suggest treatments.
-- Do NOT provide medical advice — only explain what values mean.
+export const SIMPLIFICATION_SYSTEM_PROMPT = `${PERSONA_PREAMBLE}
+
+TASK-SPECIFIC RULES:
 - Each biomarker explanation MUST follow this structure: what it means, why it matters, what to do next.
 - If a value is flagged red or yellow, explain what that means simply without causing alarm.
 - Always remind the user to talk to their doctor about their results.
@@ -22,7 +20,7 @@ Respond ONLY with valid JSON in this exact format:
       "action": "string — What you can do or ask your doctor about (1-2 sentences)"
     }
   ],
-  "disclaimer": "These explanations are for educational purposes only. They are not medical advice. Please talk to your doctor about your results and what they mean for you."
+  "disclaimer": "${JSON_DISCLAIMER}"
 }`;
 
 export const SIMPLIFICATION_USER_PROMPT = `Explain the following lab results in simple language that a 5th grader could understand. For each biomarker, explain what it measures, why it matters, and what the person should do next. Here are the biomarkers:`;


### PR DESCRIPTION
## Summary

Closes #60

- **Created `lib/claude/persona.ts`** — shared persona module defining the HealthChat AI health guide identity: warm, stigma-reducing, supportive-friend voice with 5th-grade reading level enforcement and standardized disclaimers
- **Updated all three user-facing prompt files** (`chat-prompts.ts`, `simplification-prompts.ts`, `doctor-prompts.ts`) to import from the shared persona instead of defining independent personas
- **Added 20 persona consistency tests** verifying unified voice, disclaimers, safety guardrails, and that the parse-report extraction prompt is intentionally excluded from the warm persona

### What changed in each prompt

| Feature | Before | After |
|---------|--------|-------|
| Chat | "friendly health education assistant" | Shared persona preamble + conversational style |
| Health Summary | "health education assistant", clinical-neutral | Shared persona preamble + task-specific JSON rules |
| Doctor Questions | "health communication assistant", mechanical | Shared persona preamble + task-specific question rules |
| Parse Report | Extraction-only (no persona) | **Unchanged** — intentionally excluded |

### Design decisions
- Persona voice: supportive friend who understands lab results (not therapist, not doctor)
- Stigma-reducing language: normalizes health curiosity ("Lots of people wonder about this!")
- Reassurance-first pattern for concerning results
- Three disclaimer variants (chat inline, JSON educational, doctor-questions guidance) sourced from one module
- `REASSURANCE_PATTERNS` array exported for potential future use in dynamic responses

## Test plan
- [x] All 238 existing tests pass (including updated assertions for new wording)
- [x] 20 new persona tests cover: exports, preamble content, consistency across features, parse-report exclusion
- [x] Lint and typecheck clean
- [x] Pre-push hook passed

## Checklist
- [x] Shared persona in `lib/claude/persona.ts`
- [x] All three AI prompts import shared persona
- [x] Disclaimer text standardized across features
- [x] No structural changes to JSON output formats
- [x] Parse-report prompt unchanged
- [x] 5th grade reading level enforced everywhere