### PR TITLE
feat(chat): stream Claude responses via SSE for real-time UX

### DIFF
--- a/__tests__/chat-ui.test.ts
+++ b/__tests__/chat-ui.test.ts
@@ -9,24 +9,22 @@ describe("Chat UI", () => {
   });
 
   describe("useChat hook", () => {
-    it("sends message and receives response", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          message: { role: "assistant", content: "Your glucose is normal." },
-          session_id: "session-123",
-        }),
-      });
-
+    it("exports useChat function", async () => {
       const { useChat } = await import("@/hooks/useChat");
-      // We can't directly test hooks outside React, so we test the fetch call
       expect(useChat).toBeDefined();
       expect(typeof useChat).toBe("function");
     });
 
-    it("exports required interface", async () => {
+    it("exports ChatMessage type with isStreaming field", async () => {
+      // Verify the module exports the type by checking the hook interface
       const mod = await import("@/hooks/useChat");
       expect(mod.useChat).toBeDefined();
+      expect(mod.parseSSEChunk).toBeDefined();
+    });
+
+    it("exports parseSSEChunk utility", async () => {
+      const { parseSSEChunk } = await import("@/hooks/useChat");
+      expect(typeof parseSSEChunk).toBe("function");
     });
   });
 
@@ -51,13 +49,22 @@ describe("Chat UI", () => {
     });
   });
 
-  describe("Chat API contract", () => {
+  describe("Chat Streaming API contract", () => {
     it("sends correct request shape to /api/chat", async () => {
+      // Create a mock SSE stream response
+      const sseData =
+        'data: {"type":"session_id","session_id":"sess-1"}\n\n' +
+        'data: {"type":"text_delta","text":"Hello!"}\n\n' +
+        'data: {"type":"done"}\n\n';
+
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          message: { role: "assistant", content: "Hello!" },
-          session_id: "sess-1",
+        headers: new Headers({ "Content-Type": "text/event-stream" }),
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(sseData));
+            controller.close();
+          },
         }),
       });
 
@@ -83,11 +90,15 @@ describe("Chat UI", () => {
     });
 
     it("calls /api/chat endpoint with POST method", async () => {
+      const sseData = 'data: {"type":"done"}\n\n';
+
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          message: { role: "assistant", content: "Hello" },
-          session_id: "sess-1",
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(sseData));
+            controller.close();
+          },
         }),
       });
 
@@ -104,11 +115,15 @@ describe("Chat UI", () => {
     });
 
     it("includes session_id for continued conversations", async () => {
+      const sseData = 'data: {"type":"done"}\n\n';
+
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => ({
-          message: { role: "assistant", content: "Follow up." },
-          session_id: "sess-1",
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(sseData));
+            controller.close();
+          },
         }),
       });
 
@@ -126,6 +141,49 @@ describe("Chat UI", () => {
         mockFetch.mock.calls[0][1].body as string
       );
       expect(callBody.session_id).toBe("sess-1");
+    });
+
+    it("returns a streaming SSE response", async () => {
+      const sseData =
+        'data: {"type":"session_id","session_id":"sess-1"}\n\n' +
+        'data: {"type":"text_delta","text":"Your "}\n\n' +
+        'data: {"type":"text_delta","text":"glucose "}\n\n' +
+        'data: {"type":"text_delta","text":"is normal."}\n\n' +
+        'data: {"type":"done"}\n\n';
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(sseData));
+            controller.close();
+          },
+        }),
+      });
+
+      const response = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: "What is glucose?" }),
+      });
+
+      expect(response.ok).toBe(true);
+      expect(response.body).toBeDefined();
+
+      // Read the stream and verify SSE events
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let fullText = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        fullText += decoder.decode(value, { stream: true });
+      }
+
+      expect(fullText).toContain('"type":"session_id"');
+      expect(fullText).toContain('"type":"text_delta"');
+      expect(fullText).toContain('"type":"done"');
     });
   });
 });

--- a/__tests__/chat.test.ts
+++ b/__tests__/chat.test.ts
@@ -3,13 +3,16 @@ import {
   CHAT_SYSTEM_PROMPT,
   buildReportContext,
 } from "@/lib/claude/chat-prompts";
+import { parseSSEChunk } from "@/hooks/useChat";
 
 // Mock Anthropic SDK
 const mockCreate = vi.fn();
+const mockStream = vi.fn();
 vi.mock("@anthropic-ai/sdk", () => ({
   default: vi.fn().mockImplementation(() => ({
     messages: {
       create: mockCreate,
+      stream: mockStream,
     },
   })),
 }));
@@ -149,7 +152,6 @@ describe("Chat API", () => {
     });
 
     it("rejects messages over 2000 characters with 400 status", async () => {
-      // Read the route file to verify the limit is enforced
       const fs = await import("fs");
       const path = await import("path");
       const routePath = path.resolve(
@@ -186,52 +188,70 @@ describe("Chat API", () => {
     });
   });
 
-  describe("Claude integration", () => {
-    it("returns assistant response from Claude", async () => {
-      mockCreate.mockResolvedValue({
-        content: [
-          {
-            type: "text",
-            text: "Your glucose level is 95, which is in the normal range. This means your body is handling sugar well.\n\n⚠️ This is not medical advice. Consult your healthcare provider.",
-          },
-        ],
-      });
-
-      const { getClaudeClient } = await import("@/lib/claude/client");
-      const client = getClaudeClient();
-      const response = await client.messages.create({
-        model: "claude-sonnet-4-20250514",
-        max_tokens: 1024,
-        system: CHAT_SYSTEM_PROMPT,
-        messages: [{ role: "user", content: "What does my glucose level mean?" }],
-      });
-
-      const textBlock = response.content.find(
-        (b: { type: string }) => b.type === "text"
+  describe("Claude streaming integration", () => {
+    it("uses claude.messages.stream() for streaming", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/route.ts"
       );
-      expect(textBlock).toBeDefined();
-      if (textBlock && textBlock.type === "text") {
-        expect(textBlock.text).toContain("glucose");
-        expect(textBlock.text).toContain(
-          "This is not medical advice"
-        );
-      }
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("claude.messages.stream(");
     });
 
-    it("handles Claude API errors gracefully", async () => {
-      mockCreate.mockRejectedValue(new Error("API rate limit exceeded"));
+    it("returns SSE content-type header", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
 
-      const { getClaudeClient } = await import("@/lib/claude/client");
-      const client = getClaudeClient();
+      expect(source).toContain("text/event-stream");
+    });
 
-      await expect(
-        client.messages.create({
-          model: "claude-sonnet-4-20250514",
-          max_tokens: 1024,
-          system: CHAT_SYSTEM_PROMPT,
-          messages: [{ role: "user", content: "Hello" }],
-        })
-      ).rejects.toThrow("API rate limit exceeded");
+    it("sends session_id, text_delta, and done events", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain('type: "session_id"');
+      expect(source).toContain('type: "text_delta"');
+      expect(source).toContain('type: "done"');
+    });
+
+    it("sends error events on failure", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain('type: "error"');
+    });
+
+    it("persists messages after stream completes", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      // Persistence happens after finalMessage()
+      expect(source).toContain("await messageStream.finalMessage()");
+      expect(source).toContain('role: "user", content: userMessage');
+      expect(source).toContain('role: "assistant", content: assistantContent');
     });
   });
 
@@ -296,5 +316,75 @@ describe("Chat API", () => {
       expect(source).toContain('feature: "chat"');
       expect(source).toContain('error_type: "persistence_failure"');
     });
+  });
+});
+
+describe("SSE parsing (parseSSEChunk)", () => {
+  it("parses a single complete SSE event", () => {
+    const chunk = 'data: {"type":"text_delta","text":"Hello"}\n\n';
+    const { events, remaining } = parseSSEChunk(chunk, "");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("text_delta");
+    expect(events[0].text).toBe("Hello");
+    expect(remaining).toBe("");
+  });
+
+  it("parses multiple SSE events in a single chunk", () => {
+    const chunk =
+      'data: {"type":"session_id","session_id":"sess-1"}\n\n' +
+      'data: {"type":"text_delta","text":"Hi"}\n\n';
+    const { events, remaining } = parseSSEChunk(chunk, "");
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("session_id");
+    expect(events[1].type).toBe("text_delta");
+    expect(remaining).toBe("");
+  });
+
+  it("handles partial chunks across calls", () => {
+    const chunk1 = 'data: {"type":"text_del';
+    const { events: events1, remaining: rem1 } = parseSSEChunk(chunk1, "");
+    expect(events1).toHaveLength(0);
+    expect(rem1).toBe('data: {"type":"text_del');
+
+    const chunk2 = 'ta","text":"Hi"}\n\n';
+    const { events: events2, remaining: rem2 } = parseSSEChunk(chunk2, rem1);
+    expect(events2).toHaveLength(1);
+    expect(events2[0].text).toBe("Hi");
+    expect(rem2).toBe("");
+  });
+
+  it("parses done events", () => {
+    const chunk = 'data: {"type":"done"}\n\n';
+    const { events } = parseSSEChunk(chunk, "");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("done");
+  });
+
+  it("parses error events", () => {
+    const chunk = 'data: {"type":"error","error":"Chat failed: timeout"}\n\n';
+    const { events } = parseSSEChunk(chunk, "");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("error");
+    expect(events[0].error).toBe("Chat failed: timeout");
+  });
+
+  it("skips malformed JSON lines", () => {
+    const chunk = 'data: not-json\n\ndata: {"type":"done"}\n\n';
+    const { events } = parseSSEChunk(chunk, "");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("done");
+  });
+
+  it("skips empty lines and non-data lines", () => {
+    const chunk = '\n\n: comment\ndata: {"type":"done"}\n\n';
+    const { events } = parseSSEChunk(chunk, "");
+
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("done");
   });
 });

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -126,62 +126,6 @@ export async function POST(request: Request) {
     { role: "user" as const, content: userMessage },
   ];
 
-  // Call Claude
-  const claude = getClaudeClient();
-
-  let assistantContent: string;
-  try {
-    const response = await claude.messages.create({
-      model: "claude-sonnet-4-20250514",
-      max_tokens: 1024,
-      system: systemPrompt,
-      messages,
-    });
-
-    const textBlock = response.content.find((b) => b.type === "text");
-    if (!textBlock || textBlock.type !== "text") {
-      throw new Error("No text response from Claude");
-    }
-
-    assistantContent = textBlock.text;
-  } catch (error) {
-    const message =
-      error instanceof Error ? error.message : "Chat failed";
-    return NextResponse.json(
-      { error: `Chat failed: ${message}` },
-      { status: 500 }
-    );
-  }
-
-  // Persist both messages
-  const { error: insertError } = await supabase
-    .from("chat_messages")
-    .insert([
-      { session_id: sessionId, role: "user", content: userMessage },
-      { session_id: sessionId, role: "assistant", content: assistantContent },
-    ]);
-
-  if (insertError) {
-    // Still return the response even if persistence fails
-    // The user shouldn't lose the answer due to a DB issue
-    // Log to Sentry for ops visibility — NO PHI (no message content)
-    Sentry.captureException(
-      new Error(`Chat persistence failed: ${insertError.message}`),
-      {
-        tags: {
-          feature: "chat",
-          error_type: "persistence_failure",
-        },
-        extra: {
-          session_id: sessionId,
-          message_count: messages.length,
-          has_report_context: !!reportContext,
-          db_error_code: insertError.code,
-        },
-      }
-    );
-  }
-
   // Audit log: chat message (fire-and-forget)
   logAuditEvent({
     userId: user.id,
@@ -191,11 +135,84 @@ export async function POST(request: Request) {
     ipAddress: getClientIp(request),
   });
 
-  return NextResponse.json(
-    {
-      message: { role: "assistant", content: assistantContent },
-      session_id: sessionId,
+  // Stream Claude response via SSE
+  const claude = getClaudeClient();
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      let assistantContent = "";
+
+      try {
+        // Send session_id as the first SSE event so client knows it
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify({ type: "session_id", session_id: sessionId })}\n\n`)
+        );
+
+        const messageStream = claude.messages.stream({
+          model: "claude-sonnet-4-20250514",
+          max_tokens: 1024,
+          system: systemPrompt,
+          messages,
+        });
+
+        // Listen for text deltas
+        messageStream.on("text", (text) => {
+          assistantContent += text;
+          controller.enqueue(
+            encoder.encode(`data: ${JSON.stringify({ type: "text_delta", text })}\n\n`)
+          );
+        });
+
+        // Wait for the stream to complete
+        await messageStream.finalMessage();
+
+        // Send done event
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "done" })}\n\n`));
+
+        // Persist both messages after stream completes
+        const { error: insertError } = await supabase
+          .from("chat_messages")
+          .insert([
+            { session_id: sessionId, role: "user", content: userMessage },
+            { session_id: sessionId, role: "assistant", content: assistantContent },
+          ]);
+
+        if (insertError) {
+          // Log to Sentry for ops visibility — NO PHI (no message content)
+          Sentry.captureException(
+            new Error(`Chat persistence failed: ${insertError.message}`),
+            {
+              tags: {
+                feature: "chat",
+                error_type: "persistence_failure",
+              },
+              extra: {
+                session_id: sessionId,
+                message_count: messages.length,
+                has_report_context: !!reportContext,
+                db_error_code: insertError.code,
+              },
+            }
+          );
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Chat failed";
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify({ type: "error", error: `Chat failed: ${message}` })}\n\n`)
+        );
+      } finally {
+        controller.close();
+      }
     },
-    { status: 200 }
-  );
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -588,6 +588,22 @@ button[type="submit"]:disabled {
   40% { transform: scale(1); opacity: 1; }
 }
 
+/* Streaming cursor */
+.streaming-cursor {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  background: var(--color-green-500);
+  margin-left: 2px;
+  vertical-align: text-bottom;
+  animation: cursor-blink 0.8s step-end infinite;
+}
+
+@keyframes cursor-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+
 /* Chat input */
 .chat-input-form {
   display: flex;

--- a/components/chat/MessageBubble.tsx
+++ b/components/chat/MessageBubble.tsx
@@ -30,6 +30,7 @@ export function BotAvatar() {
 
 export function MessageBubble({ message }: MessageBubbleProps) {
   const isUser = message.role === "user";
+  const isStreaming = message.isStreaming ?? false;
 
   return (
     <div
@@ -41,13 +42,18 @@ export function MessageBubble({ message }: MessageBubbleProps) {
           {message.content.split("\n").map((line, i) => (
             <p key={i}>{line || "\u00A0"}</p>
           ))}
+          {isStreaming && (
+            <span className="streaming-cursor" aria-hidden="true" />
+          )}
         </div>
-        <span className="message-time">
-          {message.timestamp.toLocaleTimeString([], {
-            hour: "2-digit",
-            minute: "2-digit",
-          })}
-        </span>
+        {!isStreaming && (
+          <span className="message-time">
+            {message.timestamp.toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -1,16 +1,53 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 
 export interface ChatMessage {
   id: string;
   role: "user" | "assistant";
   content: string;
   timestamp: Date;
+  isStreaming?: boolean;
 }
 
 interface UseChatOptions {
   reportId?: string;
+}
+
+interface SSEEvent {
+  type: "session_id" | "text_delta" | "done" | "error";
+  session_id?: string;
+  text?: string;
+  error?: string;
+}
+
+/**
+ * Parse SSE lines from a text chunk. Returns parsed events and any
+ * remaining partial line that hasn't been terminated yet.
+ */
+export function parseSSEChunk(
+  chunk: string,
+  buffer: string
+): { events: SSEEvent[]; remaining: string } {
+  const events: SSEEvent[] = [];
+  const text = buffer + chunk;
+  const lines = text.split("\n");
+
+  // The last element may be an incomplete line — keep it as the remainder
+  const remaining = lines.pop() ?? "";
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || !trimmed.startsWith("data: ")) continue;
+    try {
+      const data = JSON.parse(trimmed.slice(6)) as SSEEvent;
+      events.push(data);
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  return { events, remaining };
 }
 
 export function useChat(options: UseChatOptions = {}) {
@@ -18,6 +55,7 @@ export function useChat(options: UseChatOptions = {}) {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const sendMessage = useCallback(
     async (content: string) => {
@@ -32,8 +70,13 @@ export function useChat(options: UseChatOptions = {}) {
         content: content.trim(),
         timestamp: new Date(),
       };
+
+      const assistantMessageId = `assistant-${Date.now()}`;
       setMessages((prev) => [...prev, userMessage]);
       setIsLoading(true);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
 
       try {
         const response = await fetch("/api/chat", {
@@ -44,40 +87,98 @@ export function useChat(options: UseChatOptions = {}) {
             session_id: sessionId,
             report_id: options.reportId,
           }),
+          signal: controller.signal,
         });
 
         if (!response.ok) {
-          const data = await response.json();
-          throw new Error(data.error || "Failed to send message");
+          let errorMessage = "Failed to send message";
+          try {
+            const data = await response.json();
+            errorMessage = data.error || errorMessage;
+          } catch {
+            // Response may not be JSON for SSE errors
+          }
+          throw new Error(errorMessage);
         }
 
-        const data = await response.json();
-
-        // Update session ID
-        if (data.session_id) {
-          setSessionId(data.session_id);
+        if (!response.body) {
+          throw new Error("No response body");
         }
 
-        // Add assistant message
-        const assistantMessage: ChatMessage = {
-          id: `assistant-${Date.now()}`,
-          role: "assistant",
-          content: data.message.content,
-          timestamp: new Date(),
-        };
-        setMessages((prev) => [...prev, assistantMessage]);
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let sseBuffer = "";
+        let streamingStarted = false;
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          const chunk = decoder.decode(value, { stream: true });
+          const { events, remaining } = parseSSEChunk(chunk, sseBuffer);
+          sseBuffer = remaining;
+
+          for (const event of events) {
+            if (event.type === "session_id" && event.session_id) {
+              setSessionId(event.session_id);
+            } else if (event.type === "text_delta" && event.text) {
+              if (!streamingStarted) {
+                streamingStarted = true;
+                setIsLoading(false);
+                // Add the assistant message with first chunk
+                setMessages((prev) => [
+                  ...prev,
+                  {
+                    id: assistantMessageId,
+                    role: "assistant",
+                    content: event.text!,
+                    timestamp: new Date(),
+                    isStreaming: true,
+                  },
+                ]);
+              } else {
+                // Append text to existing assistant message
+                setMessages((prev) =>
+                  prev.map((msg) =>
+                    msg.id === assistantMessageId
+                      ? { ...msg, content: msg.content + event.text! }
+                      : msg
+                  )
+                );
+              }
+            } else if (event.type === "done") {
+              // Mark streaming as complete
+              setMessages((prev) =>
+                prev.map((msg) =>
+                  msg.id === assistantMessageId
+                    ? { ...msg, isStreaming: false }
+                    : msg
+                )
+              );
+            } else if (event.type === "error" && event.error) {
+              throw new Error(event.error);
+            }
+          }
+        }
       } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          // User cancelled — not an error
+          return;
+        }
         const message =
           err instanceof Error ? err.message : "Something went wrong";
         setError(message);
       } finally {
         setIsLoading(false);
+        abortRef.current = null;
       }
     },
     [isLoading, sessionId, options.reportId]
   );
 
   const clearChat = useCallback(() => {
+    // Abort any in-flight stream
+    abortRef.current?.abort();
     setMessages([]);
     setSessionId(null);
     setError(null);


### PR DESCRIPTION
## Summary
- Switches the chat API route from single-payload JSON to Server-Sent Events streaming using `claude.messages.stream()`
- Updates the `useChat` hook to read SSE chunks progressively, rendering text as it arrives with a blinking cursor indicator
- Buffers the full response server-side and persists to `chat_messages` after the stream completes, preserving audit logging and Sentry error tracking

Closes #47

## Changes
| File | What changed |
|------|-------------|
| `app/api/chat/route.ts` | Replaced `messages.create()` with `messages.stream()`, returns SSE ReadableStream with session_id/text_delta/done/error events |
| `hooks/useChat.ts` | Added SSE parsing with `parseSSEChunk()`, progressive message rendering, AbortController support |
| `components/chat/MessageBubble.tsx` | Added streaming cursor indicator, hide timestamp during streaming |
| `app/globals.css` | Added `.streaming-cursor` blinking animation |
| `__tests__/chat.test.ts` | Added streaming integration tests and SSE parsing unit tests |
| `__tests__/chat-ui.test.ts` | Updated API contract tests for SSE response format |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (250/250 tests)
- [ ] Manual test: send a chat message and verify text streams in progressively
- [ ] Manual test: verify typing indicator shows until first token arrives
- [ ] Manual test: verify full response is persisted to database after stream completes
- [ ] Manual test: verify error handling when connection drops mid-stream