### PR TITLE
fix(health): deterministic biomarker risk flagging with reference ranges

### DIFF
--- a/__tests__/reference-ranges.test.ts
+++ b/__tests__/reference-ranges.test.ts
@@ -1,0 +1,516 @@
+import { describe, it, expect } from "vitest";
+import { flagBiomarker, applyServerSideFlags } from "@/lib/health/flag-biomarker";
+import {
+  calculateBMI,
+  calculateCholesterolHDLRatio,
+  calculateWaistHeightRatio,
+} from "@/lib/health/calculated-metrics";
+
+// ---------------------------------------------------------------------------
+// flagBiomarker — lower-is-better biomarkers
+// ---------------------------------------------------------------------------
+
+describe("flagBiomarker", () => {
+  describe("Blood Pressure Systolic", () => {
+    it("flags 119 as green", () => {
+      expect(flagBiomarker("Blood Pressure Systolic", 119)).toBe("green");
+    });
+    it("flags 120 as yellow", () => {
+      expect(flagBiomarker("Blood Pressure Systolic", 120)).toBe("yellow");
+    });
+    it("flags 139 as yellow", () => {
+      expect(flagBiomarker("Blood Pressure Systolic", 139)).toBe("yellow");
+    });
+    it("flags 140 as red", () => {
+      expect(flagBiomarker("Blood Pressure Systolic", 140)).toBe("red");
+    });
+    it("flags 190 as red (the bug scenario)", () => {
+      expect(flagBiomarker("Blood Pressure Systolic", 190)).toBe("red");
+    });
+  });
+
+  describe("Blood Pressure Diastolic", () => {
+    it("flags 79 as green", () => {
+      expect(flagBiomarker("Blood Pressure Diastolic", 79)).toBe("green");
+    });
+    it("flags 80 as yellow", () => {
+      expect(flagBiomarker("Blood Pressure Diastolic", 80)).toBe("yellow");
+    });
+    it("flags 89 as yellow", () => {
+      expect(flagBiomarker("Blood Pressure Diastolic", 89)).toBe("yellow");
+    });
+    it("flags 90 as red", () => {
+      expect(flagBiomarker("Blood Pressure Diastolic", 90)).toBe("red");
+    });
+    it("flags 140 as red (the bug scenario)", () => {
+      expect(flagBiomarker("Blood Pressure Diastolic", 140)).toBe("red");
+    });
+  });
+
+  describe("Total Cholesterol", () => {
+    it("flags 199 as green", () => {
+      expect(flagBiomarker("Total Cholesterol", 199)).toBe("green");
+    });
+    it("flags 200 as yellow", () => {
+      expect(flagBiomarker("Total Cholesterol", 200)).toBe("yellow");
+    });
+    it("flags 239 as yellow", () => {
+      expect(flagBiomarker("Total Cholesterol", 239)).toBe("yellow");
+    });
+    it("flags 240 as red", () => {
+      expect(flagBiomarker("Total Cholesterol", 240)).toBe("red");
+    });
+  });
+
+  describe("Triglycerides", () => {
+    it("flags 149 as green", () => {
+      expect(flagBiomarker("Triglycerides", 149)).toBe("green");
+    });
+    it("flags 150 as yellow", () => {
+      expect(flagBiomarker("Triglycerides", 150)).toBe("yellow");
+    });
+    it("flags 200 as red", () => {
+      expect(flagBiomarker("Triglycerides", 200)).toBe("red");
+    });
+  });
+
+  describe("LDL Cholesterol", () => {
+    it("flags 99 as green", () => {
+      expect(flagBiomarker("LDL", 99)).toBe("green");
+    });
+    it("flags 100 as yellow", () => {
+      expect(flagBiomarker("LDL", 100)).toBe("yellow");
+    });
+    it("flags 129 as yellow", () => {
+      expect(flagBiomarker("LDL", 129)).toBe("yellow");
+    });
+    it("flags 130 as red", () => {
+      expect(flagBiomarker("LDL", 130)).toBe("red");
+    });
+  });
+
+  describe("Glucose (Fasting)", () => {
+    it("flags 99 as green", () => {
+      expect(flagBiomarker("Glucose", 99)).toBe("green");
+    });
+    it("flags 100 as yellow", () => {
+      expect(flagBiomarker("Glucose", 100)).toBe("yellow");
+    });
+    it("flags 125 as yellow", () => {
+      expect(flagBiomarker("Glucose", 125)).toBe("yellow");
+    });
+    it("flags 126 as red (the bug scenario)", () => {
+      expect(flagBiomarker("Glucose", 126)).toBe("red");
+    });
+  });
+
+  describe("A1C", () => {
+    it("flags 5.6 as green", () => {
+      expect(flagBiomarker("A1C", 5.6)).toBe("green");
+    });
+    it("flags 5.7 as yellow", () => {
+      expect(flagBiomarker("A1C", 5.7)).toBe("yellow");
+    });
+    it("flags 6.4 as yellow", () => {
+      expect(flagBiomarker("A1C", 6.4)).toBe("yellow");
+    });
+    it("flags 6.5 as red", () => {
+      expect(flagBiomarker("A1C", 6.5)).toBe("red");
+    });
+  });
+
+  describe("Cholesterol/HDL Ratio", () => {
+    it("flags 4.9 as green", () => {
+      expect(flagBiomarker("Cholesterol/HDL Ratio", 4.9)).toBe("green");
+    });
+    it("flags 5.0 as yellow", () => {
+      expect(flagBiomarker("Cholesterol/HDL Ratio", 5.0)).toBe("yellow");
+    });
+    it("flags 6.0 as red", () => {
+      expect(flagBiomarker("Cholesterol/HDL Ratio", 6.0)).toBe("red");
+    });
+  });
+
+  describe("Waist-to-Height Ratio", () => {
+    it("flags 0.49 as green", () => {
+      expect(flagBiomarker("Waist-to-Height Ratio", 0.49)).toBe("green");
+    });
+    it("flags 0.5 as yellow", () => {
+      expect(flagBiomarker("Waist-to-Height Ratio", 0.5)).toBe("yellow");
+    });
+    it("flags 0.61 as red", () => {
+      expect(flagBiomarker("Waist-to-Height Ratio", 0.61)).toBe("red");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // higher-is-better biomarkers
+  // -------------------------------------------------------------------------
+
+  describe("HDL Cholesterol (male)", () => {
+    it("flags 61 as green", () => {
+      expect(flagBiomarker("HDL", 61, "male")).toBe("green");
+    });
+    it("flags 50 as yellow", () => {
+      expect(flagBiomarker("HDL", 50, "male")).toBe("yellow");
+    });
+    it("flags 39 as red", () => {
+      expect(flagBiomarker("HDL", 39, "male")).toBe("red");
+    });
+  });
+
+  describe("HDL Cholesterol (female)", () => {
+    it("flags 61 as green", () => {
+      expect(flagBiomarker("HDL", 61, "female")).toBe("green");
+    });
+    it("flags 55 as yellow", () => {
+      expect(flagBiomarker("HDL", 55, "female")).toBe("yellow");
+    });
+    it("flags 49 as red", () => {
+      expect(flagBiomarker("HDL", 49, "female")).toBe("red");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // range-type biomarkers
+  // -------------------------------------------------------------------------
+
+  describe("Resting Heart Rate", () => {
+    it("flags 70 as green", () => {
+      expect(flagBiomarker("Resting Heart Rate", 70)).toBe("green");
+    });
+    it("flags 110 as yellow", () => {
+      expect(flagBiomarker("Resting Heart Rate", 110)).toBe("yellow");
+    });
+    it("flags 185 as red", () => {
+      expect(flagBiomarker("Resting Heart Rate", 185)).toBe("red");
+    });
+  });
+
+  describe("Hemoglobin (male)", () => {
+    it("flags 15.0 as green", () => {
+      expect(flagBiomarker("Hemoglobin", 15.0, "male")).toBe("green");
+    });
+    it("flags 12.5 as yellow (below normal)", () => {
+      expect(flagBiomarker("Hemoglobin", 12.5, "male")).toBe("yellow");
+    });
+    it("flags 10.0 as red (critically low)", () => {
+      expect(flagBiomarker("Hemoglobin", 10.0, "male")).toBe("red");
+    });
+  });
+
+  describe("Hemoglobin (female)", () => {
+    it("flags 14.0 as green", () => {
+      expect(flagBiomarker("Hemoglobin", 14.0, "female")).toBe("green");
+    });
+    it("flags 10.5 as yellow (low boundary)", () => {
+      expect(flagBiomarker("Hemoglobin", 10.5, "female")).toBe("yellow");
+    });
+    it("flags 9.0 as red (critically low)", () => {
+      expect(flagBiomarker("Hemoglobin", 9.0, "female")).toBe("red");
+    });
+  });
+
+  describe("WBC", () => {
+    it("flags 7000 as green", () => {
+      expect(flagBiomarker("WBC", 7000)).toBe("green");
+    });
+    it("flags 12000 as yellow", () => {
+      expect(flagBiomarker("WBC", 12000)).toBe("yellow");
+    });
+    it("flags 15000 as red", () => {
+      expect(flagBiomarker("WBC", 15000)).toBe("red");
+    });
+  });
+
+  describe("Platelet Count", () => {
+    it("flags 250000 as green", () => {
+      expect(flagBiomarker("Platelet Count", 250000)).toBe("green");
+    });
+    it("flags 130000 as yellow", () => {
+      expect(flagBiomarker("Platelet Count", 130000)).toBe("yellow");
+    });
+    it("flags 100000 as red", () => {
+      expect(flagBiomarker("Platelet Count", 100000)).toBe("red");
+    });
+  });
+
+  describe("Creatinine (gender-specific)", () => {
+    it("flags male 1.0 as green", () => {
+      expect(flagBiomarker("Creatinine", 1.0, "male")).toBe("green");
+    });
+    it("flags female 0.8 as green", () => {
+      expect(flagBiomarker("Creatinine", 0.8, "female")).toBe("green");
+    });
+    it("flags male 1.5 as yellow", () => {
+      expect(flagBiomarker("Creatinine", 1.5, "male")).toBe("yellow");
+    });
+    it("flags female 1.3 as yellow", () => {
+      expect(flagBiomarker("Creatinine", 1.3, "female")).toBe("yellow");
+    });
+  });
+
+  describe("Sodium", () => {
+    it("flags 140 as green", () => {
+      expect(flagBiomarker("Sodium", 140)).toBe("green");
+    });
+    it("flags 132 as yellow", () => {
+      expect(flagBiomarker("Sodium", 132)).toBe("yellow");
+    });
+    it("flags 125 as red", () => {
+      expect(flagBiomarker("Sodium", 125)).toBe("red");
+    });
+  });
+
+  describe("Potassium", () => {
+    it("flags 4.0 as green", () => {
+      expect(flagBiomarker("Potassium", 4.0)).toBe("green");
+    });
+    it("flags 3.2 as yellow", () => {
+      expect(flagBiomarker("Potassium", 3.2)).toBe("yellow");
+    });
+    it("flags 6.0 as red", () => {
+      expect(flagBiomarker("Potassium", 6.0)).toBe("red");
+    });
+  });
+
+  describe("TSH", () => {
+    it("flags 2.0 as green", () => {
+      expect(flagBiomarker("TSH", 2.0)).toBe("green");
+    });
+    it("flags 5.0 as yellow", () => {
+      expect(flagBiomarker("TSH", 5.0)).toBe("yellow");
+    });
+    it("flags 7.0 as red", () => {
+      expect(flagBiomarker("TSH", 7.0)).toBe("red");
+    });
+  });
+
+  describe("ALT", () => {
+    it("flags 30 as green", () => {
+      expect(flagBiomarker("ALT", 30)).toBe("green");
+    });
+    it("flags 65 as yellow", () => {
+      expect(flagBiomarker("ALT", 65)).toBe("yellow");
+    });
+    it("flags 80 as red", () => {
+      expect(flagBiomarker("ALT", 80)).toBe("red");
+    });
+  });
+
+  describe("Vitamin D", () => {
+    it("flags 50 as green", () => {
+      expect(flagBiomarker("Vitamin D", 50)).toBe("green");
+    });
+    it("flags 25 as yellow", () => {
+      expect(flagBiomarker("Vitamin D", 25)).toBe("yellow");
+    });
+    it("flags 10 as red", () => {
+      expect(flagBiomarker("Vitamin D", 10)).toBe("red");
+    });
+  });
+
+  describe("Vitamin B12", () => {
+    it("flags 500 as green", () => {
+      expect(flagBiomarker("Vitamin B12", 500)).toBe("green");
+    });
+    it("flags 160 as yellow", () => {
+      expect(flagBiomarker("Vitamin B12", 160)).toBe("yellow");
+    });
+    it("flags 100 as red", () => {
+      expect(flagBiomarker("Vitamin B12", 100)).toBe("red");
+    });
+  });
+
+  describe("Iron (gender-specific)", () => {
+    it("flags male 100 as green", () => {
+      expect(flagBiomarker("Iron", 100, "male")).toBe("green");
+    });
+    it("flags female 100 as green", () => {
+      expect(flagBiomarker("Iron", 100, "female")).toBe("green");
+    });
+    it("flags male 55 as yellow", () => {
+      expect(flagBiomarker("Iron", 55, "male")).toBe("yellow");
+    });
+  });
+
+  describe("Uric Acid (gender-specific)", () => {
+    it("flags male 5.0 as green", () => {
+      expect(flagBiomarker("Uric Acid", 5.0, "male")).toBe("green");
+    });
+    it("flags female 4.0 as green", () => {
+      expect(flagBiomarker("Uric Acid", 4.0, "female")).toBe("green");
+    });
+    it("flags male 7.5 as yellow", () => {
+      expect(flagBiomarker("Uric Acid", 7.5, "male")).toBe("yellow");
+    });
+    it("flags female 6.5 as yellow", () => {
+      expect(flagBiomarker("Uric Acid", 6.5, "female")).toBe("yellow");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Fuzzy name matching
+  // -------------------------------------------------------------------------
+
+  describe("fuzzy name matching", () => {
+    it("matches 'Fasting Glucose' to glucose range", () => {
+      expect(flagBiomarker("Fasting Glucose", 126)).toBe("red");
+    });
+    it("matches 'fasting blood sugar' to glucose range", () => {
+      expect(flagBiomarker("fasting blood sugar", 99)).toBe("green");
+    });
+    it("matches 'HbA1C' to A1C range", () => {
+      expect(flagBiomarker("HbA1C", 5.6)).toBe("green");
+    });
+    it("matches 'Systolic BP' to blood pressure systolic", () => {
+      expect(flagBiomarker("Systolic BP", 140)).toBe("red");
+    });
+    it("matches 'HDL-C' to HDL", () => {
+      expect(flagBiomarker("HDL-C", 61, "male")).toBe("green");
+    });
+    it("matches 'LDL-C' to LDL", () => {
+      expect(flagBiomarker("LDL-C", 130)).toBe("red");
+    });
+    it("matches 'hgb' to hemoglobin", () => {
+      expect(flagBiomarker("hgb", 15.0, "male")).toBe("green");
+    });
+    it("matches 'Thyroid Stimulating Hormone' to TSH", () => {
+      expect(flagBiomarker("Thyroid Stimulating Hormone", 2.0)).toBe("green");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unknown biomarker fallback
+  // -------------------------------------------------------------------------
+
+  describe("unknown biomarker", () => {
+    it("returns null for unrecognized biomarker", () => {
+      expect(flagBiomarker("Mystery Marker XYZ", 42)).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyServerSideFlags
+// ---------------------------------------------------------------------------
+
+describe("applyServerSideFlags", () => {
+  it("overrides Claude's green flag with correct red flag", () => {
+    const biomarkers = [
+      { name: "Glucose", value: 126, unit: "mg/dL", flag: "green" as const, reference_low: null, reference_high: null },
+    ];
+    const result = applyServerSideFlags(biomarkers);
+    expect(result[0].flag).toBe("red");
+  });
+
+  it("keeps Claude's flag for unknown biomarkers", () => {
+    const biomarkers = [
+      { name: "Unknown Marker", value: 42, unit: "units", flag: "green" as const, reference_low: null, reference_high: null },
+    ];
+    const result = applyServerSideFlags(biomarkers);
+    expect(result[0].flag).toBe("green");
+  });
+
+  it("skips biomarkers with null value", () => {
+    const biomarkers = [
+      { name: "Glucose", value: null, unit: "mg/dL", flag: "green" as const, reference_low: null, reference_high: null },
+    ];
+    const result = applyServerSideFlags(biomarkers);
+    expect(result[0].flag).toBe("green");
+  });
+
+  it("correctly flags multiple biomarkers in one pass", () => {
+    const biomarkers = [
+      { name: "Glucose", value: 126, unit: "mg/dL", flag: "green" as const, reference_low: null, reference_high: null },
+      { name: "Blood Pressure Systolic", value: 190, unit: "mmHg", flag: "green" as const, reference_low: null, reference_high: null },
+      { name: "Total Cholesterol", value: 180, unit: "mg/dL", flag: "green" as const, reference_low: null, reference_high: null },
+    ];
+    const result = applyServerSideFlags(biomarkers);
+    expect(result[0].flag).toBe("red");  // Glucose 126 = red
+    expect(result[1].flag).toBe("red");  // BP 190 = red
+    expect(result[2].flag).toBe("green"); // Chol 180 = green
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Calculated metrics
+// ---------------------------------------------------------------------------
+
+describe("calculateBMI", () => {
+  it("classifies normal BMI as green", () => {
+    // 70kg, 170cm = ~24.2
+    const result = calculateBMI(70, 170);
+    expect(result.flag).toBe("green");
+    expect(result.value).toBeCloseTo(24.2, 0);
+  });
+
+  it("classifies underweight BMI as yellow", () => {
+    // 45kg, 170cm = ~15.6
+    const result = calculateBMI(45, 170);
+    expect(result.flag).toBe("yellow");
+  });
+
+  it("classifies overweight BMI as yellow", () => {
+    // 85kg, 170cm = ~29.4
+    const result = calculateBMI(85, 170);
+    expect(result.flag).toBe("yellow");
+  });
+
+  it("classifies obese BMI as red", () => {
+    // 100kg, 170cm = ~34.6
+    const result = calculateBMI(100, 170);
+    expect(result.flag).toBe("red");
+  });
+
+  it("returns correct unit", () => {
+    const result = calculateBMI(70, 170);
+    expect(result.unit).toBe("kg/m2");
+    expect(result.name).toBe("BMI");
+  });
+});
+
+describe("calculateCholesterolHDLRatio", () => {
+  it("classifies ratio < 5.0 as green", () => {
+    const result = calculateCholesterolHDLRatio(180, 60); // 3.0
+    expect(result.flag).toBe("green");
+    expect(result.value).toBe(3.0);
+  });
+
+  it("classifies ratio 5.0-5.9 as yellow", () => {
+    const result = calculateCholesterolHDLRatio(250, 45); // ~5.6
+    expect(result.flag).toBe("yellow");
+  });
+
+  it("classifies ratio >= 6.0 as red", () => {
+    const result = calculateCholesterolHDLRatio(300, 40); // 7.5
+    expect(result.flag).toBe("red");
+  });
+
+  it("handles HDL of 0 as red", () => {
+    const result = calculateCholesterolHDLRatio(200, 0);
+    expect(result.flag).toBe("red");
+  });
+});
+
+describe("calculateWaistHeightRatio", () => {
+  it("classifies ratio < 0.5 as green", () => {
+    const result = calculateWaistHeightRatio(80, 180); // ~0.44
+    expect(result.flag).toBe("green");
+  });
+
+  it("classifies ratio 0.5-0.6 as yellow", () => {
+    const result = calculateWaistHeightRatio(95, 175); // ~0.54
+    expect(result.flag).toBe("yellow");
+  });
+
+  it("classifies ratio > 0.6 as red", () => {
+    const result = calculateWaistHeightRatio(115, 170); // ~0.68
+    expect(result.flag).toBe("red");
+  });
+
+  it("handles height of 0 as red", () => {
+    const result = calculateWaistHeightRatio(80, 0);
+    expect(result.flag).toBe("red");
+  });
+});

--- a/app/api/parse/route.ts
+++ b/app/api/parse/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { parseReportWithClaude } from "@/lib/claude/parse-report";
+import { applyServerSideFlags } from "@/lib/health/flag-biomarker";
 import { logAuditEvent, getClientIp } from "@/lib/audit/logger";
 import { NextResponse } from "next/server";
 
@@ -99,14 +100,22 @@ export async function POST(request: Request) {
       mediaType as "application/pdf" | "image/png" | "image/jpeg"
     );
 
-    console.log("[PARSE] Claude returned", parsed.biomarkers.length, "biomarkers. Storing results...");
+    console.log("[PARSE] Claude returned", parsed.biomarkers.length, "biomarkers. Applying server-side risk flags...");
+
+    // Apply deterministic server-side flagging (fixes #87)
+    // This overrides Claude's advisory flags with verified reference ranges.
+    // Claude's flag is kept as fallback only for unrecognized biomarkers.
+    const reflaggedBiomarkers = applyServerSideFlags(parsed.biomarkers);
+    const reflaggedParsed = { ...parsed, biomarkers: reflaggedBiomarkers };
+
+    console.log("[PARSE] Server-side flags applied. Storing results...");
     // Store parsed results
     const { data: parsedResult, error: insertError } = await supabase
       .from("parsed_results")
       .insert({
         report_id: report.id,
-        raw_extraction: parsed,
-        biomarkers: parsed.biomarkers,
+        raw_extraction: reflaggedParsed,
+        biomarkers: reflaggedBiomarkers,
         summary_plain: parsed.summary,
       })
       .select("id")
@@ -125,8 +134,8 @@ export async function POST(request: Request) {
     }
     console.log("[PARSE] Stored parsed_result:", parsedResult.id);
 
-    // Create risk flags for each biomarker
-    const riskFlags = parsed.biomarkers
+    // Create risk flags for each biomarker (using server-side flags)
+    const riskFlags = reflaggedBiomarkers
       .filter((b) => b.flag && b.value != null)
       .map((b) => ({
         parsed_result_id: parsedResult.id,

--- a/lib/claude/prompts.ts
+++ b/lib/claude/prompts.ts
@@ -20,7 +20,7 @@ Respond ONLY with valid JSON in this exact format:
       "unit": "string — unit of measurement (e.g., mg/dL, mmol/L)",
       "reference_low": "number or null — lower bound of normal range",
       "reference_high": "number or null — upper bound of normal range",
-      "flag": "string — 'green' if within range, 'yellow' if borderline (within 10% of boundary), 'red' if outside range, 'green' if no range available"
+      "flag": "string — 'green' if within range, 'yellow' if borderline, 'red' if outside range, 'unknown' if no range available. NOTE: this flag is advisory only; the server applies verified reference ranges after extraction"
     }
   ],
   "summary": "string — 1-3 sentence plain-language summary of the report contents, written at a 5th grade reading level"

--- a/lib/health/calculated-metrics.ts
+++ b/lib/health/calculated-metrics.ts
@@ -1,0 +1,119 @@
+/**
+ * Calculated health metrics derived from raw biomarker values.
+ *
+ * These are computed server-side when component biomarkers are present
+ * in the parsed report (e.g., BMI from weight + height).
+ */
+
+import type { RiskFlag } from "./reference-ranges";
+
+export interface CalculatedMetric {
+  name: string;
+  value: number;
+  unit: string;
+  flag: RiskFlag;
+}
+
+/**
+ * Calculate BMI from weight (kg) and height (cm).
+ * Classification per WHO guidelines:
+ *   <18.5 underweight (yellow), 18.5-24.9 normal (green),
+ *   25-29.9 overweight (yellow), >=30 obese (red)
+ */
+export function calculateBMI(
+  weightKg: number,
+  heightCm: number
+): CalculatedMetric {
+  const heightM = heightCm / 100;
+  const bmi = weightKg / (heightM * heightM);
+  const rounded = Math.round(bmi * 10) / 10;
+
+  let flag: RiskFlag;
+  if (rounded < 18.5) {
+    flag = "yellow";
+  } else if (rounded <= 24.9) {
+    flag = "green";
+  } else if (rounded <= 29.9) {
+    flag = "yellow";
+  } else {
+    flag = "red";
+  }
+
+  return { name: "BMI", value: rounded, unit: "kg/m2", flag };
+}
+
+/**
+ * Calculate Total Cholesterol / HDL ratio.
+ * Classification per AHA guidelines:
+ *   <5.0 desirable (green), 5.0-5.9 borderline (yellow), >=6.0 high risk (red)
+ */
+export function calculateCholesterolHDLRatio(
+  totalCholesterol: number,
+  hdl: number
+): CalculatedMetric {
+  if (hdl === 0) {
+    return {
+      name: "Cholesterol/HDL Ratio",
+      value: 0,
+      unit: "ratio",
+      flag: "red",
+    };
+  }
+
+  const ratio = totalCholesterol / hdl;
+  const rounded = Math.round(ratio * 10) / 10;
+
+  let flag: RiskFlag;
+  if (rounded < 5.0) {
+    flag = "green";
+  } else if (rounded <= 5.9) {
+    flag = "yellow";
+  } else {
+    flag = "red";
+  }
+
+  return {
+    name: "Cholesterol/HDL Ratio",
+    value: rounded,
+    unit: "ratio",
+    flag,
+  };
+}
+
+/**
+ * Calculate Waist-to-Height Ratio.
+ * Classification per WHO guidelines:
+ *   <0.5 low risk (green), 0.5-0.6 moderate (yellow), >0.6 high risk (red)
+ */
+export function calculateWaistHeightRatio(
+  waistCm: number,
+  heightCm: number
+): CalculatedMetric {
+  if (heightCm === 0) {
+    return {
+      name: "Waist-to-Height Ratio",
+      value: 0,
+      unit: "ratio",
+      flag: "red",
+    };
+  }
+
+  const ratio = waistCm / heightCm;
+  const rounded = Math.round(ratio * 100) / 100;
+
+  let flag: RiskFlag;
+  if (rounded < 0.5) {
+    flag = "green";
+  } else if (rounded <= 0.6) {
+    flag = "yellow";
+  } else {
+    flag = "red";
+  }
+
+  return {
+    name: "Waist-to-Height Ratio",
+    value: rounded,
+    unit: "ratio",
+    flag,
+  };
+}

--- a/lib/health/flag-biomarker.ts
+++ b/lib/health/flag-biomarker.ts
@@ -1,0 +1,220 @@
+/**
+ * Server-side biomarker flagging using deterministic reference ranges.
+ *
+ * Replaces Claude's advisory flag with a verified risk classification.
+ * Fixes #87: Claude was marking everything green when lab reports
+ * didn't include reference ranges.
+ */
+
+import { REFERENCE_RANGES, type RiskFlag, type ReferenceRange } from "./reference-ranges";
+
+/**
+ * Normalize a biomarker name for matching:
+ * - lowercase
+ * - strip parentheses content
+ * - collapse whitespace
+ * - trim
+ */
+function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\(.*?\)/g, "")
+    .replace(/[^a-z0-9/\-+ ]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Score how well a normalized name matches a normalized alias.
+ * Returns a score >= 0 (higher = better). Returns 0 if no match.
+ */
+function matchScore(normalized: string, normalizedAlias: string): number {
+  // Exact match is best
+  if (normalized === normalizedAlias) return 100;
+
+  // Full alias appears as a word boundary in the name (e.g., "fasting glucose" contains "glucose")
+  // Only match if the alias is at least 3 characters to avoid spurious short matches
+  if (normalizedAlias.length >= 3 && normalized.includes(normalizedAlias)) {
+    return 50 + normalizedAlias.length;
+  }
+
+  // Full name appears in the alias (e.g., "hdl" is contained in "hdl cholesterol")
+  if (normalized.length >= 3 && normalizedAlias.includes(normalized)) {
+    return 50 + normalized.length;
+  }
+
+  return 0;
+}
+
+/**
+ * Find the best matching reference range for a biomarker name.
+ * Uses scored matching to prefer more specific matches.
+ * Returns matching ranges filtered by gender when provided.
+ */
+function findMatchingRange(
+  name: string,
+  gender?: "male" | "female"
+): ReferenceRange | null {
+  const normalized = normalizeName(name);
+
+  // Score all ranges and pick the best match
+  let bestScore = 0;
+  let bestCandidates: ReferenceRange[] = [];
+
+  for (const range of REFERENCE_RANGES) {
+    let rangeScore = 0;
+    for (const alias of range.aliases) {
+      const score = matchScore(normalized, normalizeName(alias));
+      rangeScore = Math.max(rangeScore, score);
+    }
+    if (rangeScore > 0) {
+      if (rangeScore > bestScore) {
+        bestScore = rangeScore;
+        bestCandidates = [range];
+      } else if (rangeScore === bestScore) {
+        bestCandidates.push(range);
+      }
+    }
+  }
+
+  if (bestCandidates.length === 0) {
+    return null;
+  }
+
+  // If gender is specified, prefer gender-specific range
+  if (gender) {
+    const genderMatch = bestCandidates.find((c) => c.gender === gender);
+    if (genderMatch) return genderMatch;
+  }
+
+  // Fall back to ungendered range, or first candidate
+  const ungenderedMatch = bestCandidates.find((c) => !c.gender);
+  return ungenderedMatch ?? bestCandidates[0];
+}
+
+/**
+ * Classify a value using a "range" direction reference range.
+ * Green if within green band; yellow if within yellow band; red otherwise.
+ */
+function classifyRange(value: number, range: ReferenceRange): RiskFlag {
+  const { green, yellow } = range.ranges;
+
+  // Check green first
+  if (
+    green.low !== null &&
+    green.high !== null &&
+    value >= green.low &&
+    value <= green.high
+  ) {
+    return "green";
+  }
+
+  // Check yellow band
+  if (
+    yellow.low !== null &&
+    yellow.high !== null &&
+    value >= yellow.low &&
+    value <= yellow.high
+  ) {
+    return "yellow";
+  }
+
+  // Outside both bands = red
+  return "red";
+}
+
+/**
+ * Classify a value using a "lower-is-better" direction.
+ * Value below green.high is green, within yellow range is yellow, else red.
+ */
+function classifyLowerIsBetter(value: number, range: ReferenceRange): RiskFlag {
+  const { green, yellow } = range.ranges;
+
+  if (green.high !== null && value <= green.high) {
+    return "green";
+  }
+  if (
+    yellow.low !== null &&
+    yellow.high !== null &&
+    value >= yellow.low &&
+    value <= yellow.high
+  ) {
+    return "yellow";
+  }
+  return "red";
+}
+
+/**
+ * Classify a value using a "higher-is-better" direction.
+ * Value above green.low is green, within yellow range is yellow, else red.
+ */
+function classifyHigherIsBetter(value: number, range: ReferenceRange): RiskFlag {
+  const { green, yellow } = range.ranges;
+
+  if (green.low !== null && value >= green.low) {
+    return "green";
+  }
+  if (
+    yellow.low !== null &&
+    yellow.high !== null &&
+    value >= yellow.low &&
+    value <= yellow.high
+  ) {
+    return "yellow";
+  }
+  return "red";
+}
+
+/**
+ * Flag a biomarker value using server-side reference ranges.
+ *
+ * @param name - The biomarker name as extracted by Claude
+ * @param value - The numeric value
+ * @param gender - Optional patient gender for gender-specific ranges
+ * @returns The risk flag color, or null if no matching range is found
+ */
+export function flagBiomarker(
+  name: string,
+  value: number,
+  gender?: "male" | "female"
+): RiskFlag | null {
+  const range = findMatchingRange(name, gender);
+
+  if (!range) {
+    return null;
+  }
+
+  switch (range.direction) {
+    case "lower-is-better":
+      return classifyLowerIsBetter(value, range);
+    case "higher-is-better":
+      return classifyHigherIsBetter(value, range);
+    case "range":
+      return classifyRange(value, range);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Apply server-side flagging to an array of biomarkers parsed by Claude.
+ * Overrides Claude's flag with a deterministic one when a reference range
+ * is available; keeps Claude's flag as fallback when no range matches.
+ */
+export function applyServerSideFlags<
+  T extends { name: string; value: number | null; flag: RiskFlag },
+>(
+  biomarkers: T[],
+  gender?: "male" | "female"
+): T[] {
+  return biomarkers.map((b) => {
+    if (b.value == null) return b;
+
+    const serverFlag = flagBiomarker(b.name, b.value, gender);
+    if (serverFlag) {
+      return { ...b, flag: serverFlag };
+    }
+    // Keep Claude's flag as fallback for unrecognized biomarkers
+    return b;
+  });
+}

--- a/lib/health/index.ts
+++ b/lib/health/index.ts
@@ -1,0 +1,8 @@
+export { REFERENCE_RANGES, type RiskFlag, type ReferenceRange, type RangeThreshold } from "./reference-ranges";
+export { flagBiomarker, applyServerSideFlags } from "./flag-biomarker";
+export {
+  calculateBMI,
+  calculateCholesterolHDLRatio,
+  calculateWaistHeightRatio,
+  type CalculatedMetric,
+} from "./calculated-metrics";

--- a/lib/health/reference-ranges.ts
+++ b/lib/health/reference-ranges.ts
@@ -1,0 +1,742 @@
+/**
+ * Server-side reference ranges for biomarker risk flagging.
+ *
+ * Sources: AHA, ADA, ACC/AHA, WHO, and standard clinical laboratory ranges.
+ * These ranges are used to deterministically flag biomarker values instead
+ * of relying on Claude's judgment (fixes #87).
+ */
+
+export type RiskFlag = "green" | "yellow" | "red";
+
+export interface RangeThreshold {
+  low: number | null;
+  high: number | null;
+}
+
+export interface ReferenceRange {
+  /** Canonical display name */
+  name: string;
+  /** Lowercase aliases for fuzzy matching */
+  aliases: string[];
+  /** Expected unit of measurement */
+  unit: string;
+  /** Risk thresholds — value is green/yellow/red based on direction logic */
+  ranges: {
+    green: RangeThreshold;
+    yellow: RangeThreshold;
+    red: RangeThreshold;
+  };
+  /**
+   * How to interpret values:
+   * - "lower-is-better": lower values are healthier (e.g., LDL cholesterol)
+   * - "higher-is-better": higher values are healthier (e.g., HDL cholesterol)
+   * - "range": a specific band is normal; too high or too low is bad
+   */
+  direction: "lower-is-better" | "higher-is-better" | "range";
+  /** Gender-specific range; undefined means applies to all */
+  gender?: "male" | "female";
+  /** Guideline source */
+  source: string;
+}
+
+// ---------------------------------------------------------------------------
+// Cardiovascular & metabolic biomarkers (from user-provided chart)
+// ---------------------------------------------------------------------------
+
+const CARDIOVASCULAR_RANGES: ReferenceRange[] = [
+  {
+    name: "Blood Pressure Systolic",
+    aliases: [
+      "blood pressure systolic",
+      "systolic blood pressure",
+      "systolic bp",
+      "systolic",
+      "sbp",
+      "bp systolic",
+    ],
+    unit: "mmHg",
+    ranges: {
+      green: { low: null, high: 119 },
+      yellow: { low: 120, high: 139 },
+      red: { low: 140, high: null },
+    },
+    direction: "lower-is-better",
+    source: "AHA",
+  },
+  {
+    name: "Blood Pressure Diastolic",
+    aliases: [
+      "blood pressure diastolic",
+      "diastolic blood pressure",
+      "diastolic bp",
+      "diastolic",
+      "dbp",
+      "bp diastolic",
+    ],
+    unit: "mmHg",
+    ranges: {
+      green: { low: null, high: 79 },
+      yellow: { low: 80, high: 89 },
+      red: { low: 90, high: null },
+    },
+    direction: "lower-is-better",
+    source: "AHA",
+  },
+  {
+    name: "Total Cholesterol",
+    aliases: [
+      "total cholesterol",
+      "cholesterol total",
+      "cholesterol",
+      "tc",
+      "total chol",
+    ],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: null, high: 199 },
+      yellow: { low: 200, high: 239 },
+      red: { low: 240, high: null },
+    },
+    direction: "lower-is-better",
+    source: "ACC/AHA",
+  },
+  {
+    name: "Triglycerides",
+    aliases: [
+      "triglycerides",
+      "triglyceride",
+      "trigs",
+      "trig",
+      "tg",
+    ],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: null, high: 149 },
+      yellow: { low: 150, high: 199 },
+      red: { low: 200, high: null },
+    },
+    direction: "lower-is-better",
+    source: "ACC/AHA",
+  },
+  // HDL — male
+  {
+    name: "HDL Cholesterol",
+    aliases: [
+      "hdl cholesterol",
+      "hdl",
+      "hdl-c",
+      "high density lipoprotein",
+      "hdl chol",
+    ],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: 61, high: null },
+      yellow: { low: 40, high: 60 },
+      red: { low: null, high: 39 },
+    },
+    direction: "higher-is-better",
+    gender: "male",
+    source: "AHA",
+  },
+  // HDL — female
+  {
+    name: "HDL Cholesterol",
+    aliases: [
+      "hdl cholesterol",
+      "hdl",
+      "hdl-c",
+      "high density lipoprotein",
+      "hdl chol",
+    ],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: 61, high: null },
+      yellow: { low: 50, high: 60 },
+      red: { low: null, high: 49 },
+    },
+    direction: "higher-is-better",
+    gender: "female",
+    source: "AHA",
+  },
+  {
+    name: "LDL Cholesterol",
+    aliases: [
+      "ldl cholesterol",
+      "ldl",
+      "ldl-c",
+      "low density lipoprotein",
+      "ldl chol",
+    ],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: null, high: 99 },
+      yellow: { low: 100, high: 129 },
+      red: { low: 130, high: null },
+    },
+    direction: "lower-is-better",
+    source: "ACC/AHA",
+  },
+  {
+    name: "Cholesterol/HDL Ratio",
+    aliases: [
+      "cholesterol/hdl ratio",
+      "chol/hdl ratio",
+      "cholesterol hdl ratio",
+      "tc/hdl ratio",
+      "total cholesterol/hdl",
+      "chol hdl ratio",
+    ],
+    unit: "ratio",
+    ranges: {
+      green: { low: null, high: 4.9 },
+      yellow: { low: 5.0, high: 5.9 },
+      red: { low: 6.0, high: null },
+    },
+    direction: "lower-is-better",
+    source: "AHA",
+  },
+  {
+    name: "Resting Heart Rate",
+    aliases: [
+      "resting heart rate",
+      "heart rate",
+      "pulse",
+      "rhr",
+      "hr",
+      "pulse rate",
+    ],
+    unit: "bpm",
+    ranges: {
+      green: { low: 60, high: 100 },
+      yellow: { low: 101, high: 180 },
+      red: { low: 181, high: null },
+    },
+    direction: "range",
+    source: "AHA",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Glucose & diabetes markers
+// ---------------------------------------------------------------------------
+
+const GLUCOSE_RANGES: ReferenceRange[] = [
+  {
+    name: "Glucose (Fasting)",
+    aliases: [
+      "glucose",
+      "fasting glucose",
+      "blood glucose",
+      "blood sugar",
+      "fbs",
+      "fasting blood sugar",
+      "fasting blood glucose",
+      "fbg",
+      "glucose fasting",
+      "serum glucose",
+      "plasma glucose",
+    ],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: null, high: 99 },
+      yellow: { low: 100, high: 125 },
+      red: { low: 126, high: null },
+    },
+    direction: "lower-is-better",
+    source: "ADA",
+  },
+  {
+    name: "Hemoglobin A1C",
+    aliases: [
+      "a1c",
+      "hba1c",
+      "hemoglobin a1c",
+      "glycated hemoglobin",
+      "glycosylated hemoglobin",
+      "hb a1c",
+      "ha1c",
+    ],
+    unit: "%",
+    ranges: {
+      green: { low: null, high: 5.6 },
+      yellow: { low: 5.7, high: 6.4 },
+      red: { low: 6.5, high: null },
+    },
+    direction: "lower-is-better",
+    source: "ADA",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Complete blood count (CBC)
+// ---------------------------------------------------------------------------
+
+const CBC_RANGES: ReferenceRange[] = [
+  // Hemoglobin — male
+  {
+    name: "Hemoglobin",
+    aliases: ["hemoglobin", "hgb", "hb"],
+    unit: "g/dL",
+    ranges: {
+      green: { low: 13.5, high: 17.5 },
+      yellow: { low: 12.0, high: 18.5 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    gender: "male",
+    source: "WHO",
+  },
+  // Hemoglobin — female
+  {
+    name: "Hemoglobin",
+    aliases: ["hemoglobin", "hgb", "hb"],
+    unit: "g/dL",
+    ranges: {
+      green: { low: 12.0, high: 16.0 },
+      yellow: { low: 10.5, high: 17.0 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    gender: "female",
+    source: "WHO",
+  },
+  // Hematocrit — male
+  {
+    name: "Hematocrit",
+    aliases: ["hematocrit", "hct", "packed cell volume", "pcv"],
+    unit: "%",
+    ranges: {
+      green: { low: 38.3, high: 48.6 },
+      yellow: { low: 35.0, high: 52.0 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    gender: "male",
+    source: "WHO",
+  },
+  // Hematocrit — female
+  {
+    name: "Hematocrit",
+    aliases: ["hematocrit", "hct", "packed cell volume", "pcv"],
+    unit: "%",
+    ranges: {
+      green: { low: 35.5, high: 44.9 },
+      yellow: { low: 32.0, high: 48.0 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    gender: "female",
+    source: "WHO",
+  },
+  {
+    name: "White Blood Cell Count",
+    aliases: [
+      "white blood cell count",
+      "wbc",
+      "white blood cells",
+      "white cell count",
+      "leukocytes",
+      "leukocyte count",
+    ],
+    unit: "/mcL",
+    ranges: {
+      green: { low: 4500, high: 11000 },
+      yellow: { low: 3500, high: 13000 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "WHO",
+  },
+  {
+    name: "Platelet Count",
+    aliases: [
+      "platelet count",
+      "platelets",
+      "plt",
+      "thrombocytes",
+      "thrombocyte count",
+    ],
+    unit: "/mcL",
+    ranges: {
+      green: { low: 150000, high: 400000 },
+      yellow: { low: 120000, high: 450000 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "WHO",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Kidney function
+// ---------------------------------------------------------------------------
+
+const KIDNEY_RANGES: ReferenceRange[] = [
+  // Creatinine — male
+  {
+    name: "Creatinine",
+    aliases: ["creatinine", "creat", "serum creatinine", "cr"],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: 0.7, high: 1.3 },
+      yellow: { low: 0.5, high: 1.6 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    gender: "male",
+    source: "AHA",
+  },
+  // Creatinine — female
+  {
+    name: "Creatinine",
+    aliases: ["creatinine", "creat", "serum creatinine", "cr"],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: 0.6, high: 1.1 },
+      yellow: { low: 0.4, high: 1.4 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    gender: "female",
+    source: "AHA",
+  },
+  {
+    name: "BUN",
+    aliases: [
+      "bun",
+      "blood urea nitrogen",
+      "urea nitrogen",
+      "urea",
+    ],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: 7, high: 20 },
+      yellow: { low: 5, high: 25 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "AHA",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Electrolytes
+// ---------------------------------------------------------------------------
+
+const ELECTROLYTE_RANGES: ReferenceRange[] = [
+  {
+    name: "Sodium",
+    aliases: ["sodium", "na", "na+", "serum sodium"],
+    unit: "mEq/L",
+    ranges: {
+      green: { low: 136, high: 145 },
+      yellow: { low: 130, high: 150 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "AHA",
+  },
+  {
+    name: "Potassium",
+    aliases: ["potassium", "k", "k+", "serum potassium"],
+    unit: "mEq/L",
+    ranges: {
+      green: { low: 3.5, high: 5.0 },
+      yellow: { low: 3.0, high: 5.5 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "AHA",
+  },
+  {
+    name: "Calcium",
+    aliases: ["calcium", "ca", "ca2+", "serum calcium", "total calcium"],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: 8.5, high: 10.5 },
+      yellow: { low: 7.5, high: 11.5 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "AHA",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Thyroid
+// ---------------------------------------------------------------------------
+
+const THYROID_RANGES: ReferenceRange[] = [
+  {
+    name: "TSH",
+    aliases: [
+      "tsh",
+      "thyroid stimulating hormone",
+      "thyrotropin",
+      "thyroid-stimulating hormone",
+    ],
+    unit: "mIU/L",
+    ranges: {
+      green: { low: 0.4, high: 4.0 },
+      yellow: { low: 0.2, high: 6.0 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "AHA",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Liver function
+// ---------------------------------------------------------------------------
+
+const LIVER_RANGES: ReferenceRange[] = [
+  {
+    name: "ALT",
+    aliases: [
+      "alt",
+      "alanine aminotransferase",
+      "sgpt",
+      "alanine transaminase",
+    ],
+    unit: "U/L",
+    ranges: {
+      green: { low: 7, high: 56 },
+      yellow: { low: 4, high: 70 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "AHA",
+  },
+  {
+    name: "AST",
+    aliases: [
+      "ast",
+      "aspartate aminotransferase",
+      "sgot",
+      "aspartate transaminase",
+    ],
+    unit: "U/L",
+    ranges: {
+      green: { low: 10, high: 40 },
+      yellow: { low: 6, high: 55 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "AHA",
+  },
+  {
+    name: "Alkaline Phosphatase",
+    aliases: [
+      "alkaline phosphatase",
+      "alp",
+      "alk phos",
+      "alkp",
+    ],
+    unit: "U/L",
+    ranges: {
+      green: { low: 44, high: 147 },
+      yellow: { low: 30, high: 170 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "AHA",
+  },
+  {
+    name: "Bilirubin Total",
+    aliases: [
+      "bilirubin total",
+      "bilirubin",
+      "total bilirubin",
+      "tbili",
+      "t. bilirubin",
+    ],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: 0.1, high: 1.2 },
+      yellow: { low: 0.0, high: 1.8 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "AHA",
+  },
+  {
+    name: "Albumin",
+    aliases: ["albumin", "alb", "serum albumin"],
+    unit: "g/dL",
+    ranges: {
+      green: { low: 3.5, high: 5.0 },
+      yellow: { low: 3.0, high: 5.5 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "AHA",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Vitamins & minerals
+// ---------------------------------------------------------------------------
+
+const VITAMIN_RANGES: ReferenceRange[] = [
+  {
+    name: "Vitamin D",
+    aliases: [
+      "vitamin d",
+      "vit d",
+      "25-hydroxyvitamin d",
+      "25-oh vitamin d",
+      "25(oh)d",
+      "calcidiol",
+    ],
+    unit: "ng/mL",
+    ranges: {
+      green: { low: 30, high: 100 },
+      yellow: { low: 20, high: 120 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "WHO",
+  },
+  {
+    name: "Vitamin B12",
+    aliases: [
+      "vitamin b12",
+      "vit b12",
+      "b12",
+      "cobalamin",
+    ],
+    unit: "pg/mL",
+    ranges: {
+      green: { low: 200, high: 900 },
+      yellow: { low: 150, high: 1000 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    source: "WHO",
+  },
+  // Iron — male
+  {
+    name: "Iron",
+    aliases: ["iron", "serum iron", "fe"],
+    unit: "mcg/dL",
+    ranges: {
+      green: { low: 65, high: 175 },
+      yellow: { low: 50, high: 200 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    gender: "male",
+    source: "WHO",
+  },
+  // Iron — female
+  {
+    name: "Iron",
+    aliases: ["iron", "serum iron", "fe"],
+    unit: "mcg/dL",
+    ranges: {
+      green: { low: 50, high: 170 },
+      yellow: { low: 35, high: 200 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    gender: "female",
+    source: "WHO",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Uric acid
+// ---------------------------------------------------------------------------
+
+const URIC_ACID_RANGES: ReferenceRange[] = [
+  // Uric acid — male
+  {
+    name: "Uric Acid",
+    aliases: ["uric acid", "urate", "serum uric acid"],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: 3.4, high: 7.0 },
+      yellow: { low: 2.5, high: 8.0 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    gender: "male",
+    source: "AHA",
+  },
+  // Uric acid — female
+  {
+    name: "Uric Acid",
+    aliases: ["uric acid", "urate", "serum uric acid"],
+    unit: "mg/dL",
+    ranges: {
+      green: { low: 2.4, high: 6.0 },
+      yellow: { low: 1.8, high: 7.0 },
+      red: { low: null, high: null },
+    },
+    direction: "range",
+    gender: "female",
+    source: "AHA",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// BMI (body composition, used by calculated-metrics)
+// ---------------------------------------------------------------------------
+
+const BMI_RANGES: ReferenceRange[] = [
+  {
+    name: "BMI",
+    aliases: ["bmi", "body mass index"],
+    unit: "kg/m2",
+    ranges: {
+      green: { low: 18.5, high: 24.9 },
+      yellow: { low: 25.0, high: 29.9 },
+      red: { low: 30.0, high: null },
+    },
+    direction: "range",
+    source: "WHO",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Waist-to-Height Ratio
+// ---------------------------------------------------------------------------
+
+const WAIST_HEIGHT_RANGES: ReferenceRange[] = [
+  {
+    name: "Waist-to-Height Ratio",
+    aliases: [
+      "waist-to-height ratio",
+      "waist to height ratio",
+      "whtr",
+      "waist height ratio",
+    ],
+    unit: "ratio",
+    ranges: {
+      green: { low: null, high: 0.49 },
+      yellow: { low: 0.5, high: 0.6 },
+      red: { low: 0.61, high: null },
+    },
+    direction: "lower-is-better",
+    source: "WHO",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Exported composite array
+// ---------------------------------------------------------------------------
+
+export const REFERENCE_RANGES: ReferenceRange[] = [
+  ...CARDIOVASCULAR_RANGES,
+  ...GLUCOSE_RANGES,
+  ...CBC_RANGES,
+  ...KIDNEY_RANGES,
+  ...ELECTROLYTE_RANGES,
+  ...THYROID_RANGES,
+  ...LIVER_RANGES,
+  ...VITAMIN_RANGES,
+  ...URIC_ACID_RANGES,
+  ...BMI_RANGES,
+  ...WAIST_HEIGHT_RANGES,
+];


### PR DESCRIPTION
## Summary

Fixes #87 — **Critical safety fix**. Claude was marking all biomarker values green when lab reports didn't include printed reference ranges (e.g., blood pressure 190/140 or glucose 126 flagged as green/normal).

- Added server-side reference range table (`lib/health/reference-ranges.ts`) with 30+ biomarkers from AHA, ADA, ACC/AHA, and WHO guidelines
- Added deterministic flagging engine (`lib/health/flag-biomarker.ts`) with scored fuzzy name matching and gender-aware classification
- Added calculated metrics module (`lib/health/calculated-metrics.ts`) for BMI, cholesterol/HDL ratio, and waist-to-height ratio
- Updated parse API route to apply server-side flags after Claude extraction, overriding Claude's advisory flags
- Updated Claude prompt to mark its flag field as advisory only (server takes precedence)
- Added 111 comprehensive tests covering every biomarker boundary, fuzzy matching, and calculated metrics

## Key Design Decisions

- **Server-side flagging overrides Claude's flags** — Claude still extracts values and provides an advisory flag, but the server applies verified reference ranges deterministically
- **Fallback preserved** — for biomarkers not in our reference table, Claude's original flag is kept
- **Scored fuzzy matching** — "Fasting Glucose", "fasting blood sugar", "FBS" all match the glucose range correctly; longer/more specific matches are preferred to avoid false positives
- **Gender-aware ranges** — HDL, hemoglobin, hematocrit, creatinine, iron, and uric acid use gender-specific thresholds

## Test Plan

- [x] 111 unit tests covering all biomarker boundaries (green/yellow/red thresholds)
- [x] Fuzzy name matching tests (e.g., "Fasting Glucose" -> glucose, "HbA1C" -> A1C)
- [x] Gender-specific range tests (HDL male vs female, hemoglobin, creatinine, iron, uric acid)
- [x] Calculated metrics tests (BMI, cholesterol/HDL ratio, waist-to-height ratio)
- [x] Integration test: `applyServerSideFlags` correctly overrides Claude's green flags to red for dangerous values
- [x] Unknown biomarker fallback test: unrecognized markers keep Claude's flag
- [x] All 349 existing tests still pass
- [x] Lint and typecheck clean