### PR TITLE
fix(ui): green/orange/red risk colors + skip height/weight flagging

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -37,8 +37,14 @@
   --color-gray-900: #111827;
 
   /* Status colors */
+  --color-orange-100: #ffedd5;
+  --color-orange-500: #f97316;
+  --color-orange-600: #ea580c;
+  --color-orange-700: #c2410c;
   --color-yellow-500: #eab308;
+  --color-red-100: #fee2e2;
   --color-red-500: #ef4444;
+  --color-red-600: #dc2626;
 
   /* Shadows */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
@@ -781,7 +787,7 @@ button.chat-send-button[type="submit"]:disabled {
 }
 
 .health-summary__biomarker--yellow {
-  border-left: 4px solid var(--color-yellow-500);
+  border-left: 4px solid var(--color-orange-500);
 }
 
 .health-summary__biomarker--red {
@@ -831,8 +837,8 @@ button.chat-send-button[type="submit"]:disabled {
 }
 
 .health-summary__flag--yellow {
-  background: #fef9c3;
-  color: #854d0e;
+  background: var(--color-orange-100);
+  color: var(--color-orange-700);
 }
 
 .health-summary__flag--red {
@@ -885,7 +891,7 @@ button.chat-send-button[type="submit"]:disabled {
 }
 
 .risk-indicator--yellow {
-  border-left: 4px solid var(--color-yellow-500);
+  border-left: 4px solid var(--color-orange-500);
 }
 
 .risk-indicator--red {
@@ -912,7 +918,7 @@ button.chat-send-button[type="submit"]:disabled {
 }
 
 .risk-indicator__dot--yellow {
-  background: var(--color-yellow-500);
+  background: var(--color-orange-500);
 }
 
 .risk-indicator__dot--red {
@@ -953,13 +959,13 @@ button.chat-send-button[type="submit"]:disabled {
 }
 
 .risk-indicator__badge--yellow {
-  background: #fef9c3;
-  color: #854d0e;
+  background: var(--color-orange-100);
+  color: var(--color-orange-700);
 }
 
 .risk-indicator__badge--red {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--color-red-100);
+  color: var(--color-red-600);
 }
 
 /* =========================
@@ -1072,13 +1078,13 @@ button.chat-send-button[type="submit"]:disabled {
 }
 
 .risk-dashboard__count--yellow {
-  background: #fefce8;
-  border-color: #fef08a;
+  background: var(--color-orange-100);
+  border-color: var(--color-orange-500);
 }
 
 .risk-dashboard__count--red {
-  background: #fef2f2;
-  border-color: #fecaca;
+  background: var(--color-red-100);
+  border-color: var(--color-red-500);
 }
 
 .risk-dashboard__count-number {
@@ -1440,7 +1446,7 @@ button.chat-send-button[type="submit"]:disabled {
 }
 
 .question-card--medium {
-  border-left-color: #f59e0b;
+  border-left-color: var(--color-orange-500);
 }
 
 .question-card--low {
@@ -1749,8 +1755,8 @@ button.chat-send-button[type="submit"]:disabled {
 }
 
 .report-results__status--pending {
-  background: #fef9c3;
-  color: #854d0e;
+  background: var(--color-orange-100);
+  color: var(--color-orange-700);
 }
 
 .report-results__status--error {
@@ -1961,8 +1967,8 @@ button.chat-send-button[type="submit"]:disabled {
 }
 
 .report-list__item-status--pending {
-  background: #fef9c3;
-  color: #854d0e;
+  background: var(--color-orange-100);
+  color: var(--color-orange-700);
 }
 
 .report-list__item-status--error {

--- a/lib/health/flag-biomarker.ts
+++ b/lib/health/flag-biomarker.ts
@@ -9,6 +9,20 @@
 import { REFERENCE_RANGES, type RiskFlag, type ReferenceRange } from "./reference-ranges";
 
 /**
+ * Measurements that should NOT be flagged as risk indicators.
+ * These are raw data points used for calculations (BMI, etc.)
+ * but have no inherent "healthy" or "unhealthy" range on their own.
+ */
+const SKIP_FLAG_NAMES = [
+  "height",
+  "weight",
+  "waist",
+  "waist circumference",
+  "hip",
+  "hip circumference",
+];
+
+/**
  * Normalize a biomarker name for matching:
  * - lowercase
  * - strip parentheses content
@@ -178,6 +192,12 @@ export function flagBiomarker(
   value: number,
   gender?: "male" | "female"
 ): RiskFlag | null {
+  // Skip measurements that aren't risk indicators on their own
+  const normalized = normalizeName(name);
+  if (SKIP_FLAG_NAMES.some((skip) => normalized === skip)) {
+    return "green";
+  }
+
   const range = findMatchingRange(name, gender);
 
   if (!range) {


### PR DESCRIPTION
## Summary
- **Color scheme**: Moderate risk changed from yellow to **light orange** (#f97316) — green=Normal, orange=Borderline, red=Needs Attention
- **Height/weight fix**: Raw measurements (height, weight, waist, hip) no longer get flagged as risk indicators. Height 66 inches was showing red "NEEDS ATTENTION" — now shows green.
- All hardcoded yellow hex values replaced with CSS variables throughout

## Test plan
- [x] All 361 tests pass
- [ ] Re-upload a report — height/weight should show green
- [ ] Borderline values should appear in orange, not yellow

Quick fix — no linked ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)