### PR TITLE
feat(ui): restructure dashboard to 4-card grid with Reports card

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,8 +2,8 @@ import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { LogoutButton } from "./logout-button";
-import ReportList from "@/components/reports/ReportList";
 import Logo from "@/components/ui/Logo";
+import { ReportsCardBadge } from "./reports-card-badge";
 
 export const dynamic = "force-dynamic";
 
@@ -54,6 +54,21 @@ export default async function DashboardPage() {
           <h3>Chat</h3>
           <p>Ask questions about your health data in plain language</p>
         </Link>
+        <Link href="/reports" className="dashboard-card dashboard-card--reports">
+          <div className="dashboard-card__icon">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2" />
+              <rect x="9" y="3" width="6" height="4" rx="1" />
+              <line x1="9" y1="12" x2="15" y2="12" />
+              <line x1="9" y1="16" x2="13" y2="16" />
+            </svg>
+          </div>
+          <div className="dashboard-card__title-row">
+            <h3>Your Reports</h3>
+            <ReportsCardBadge />
+          </div>
+          <p>View uploaded reports and analysis results</p>
+        </Link>
         <Link href="/profile" className="dashboard-card dashboard-card--profile">
           <div className="dashboard-card__icon">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -65,10 +80,6 @@ export default async function DashboardPage() {
           <p>Manage your personal information for personalized health insights</p>
         </Link>
       </nav>
-
-      <section className="dashboard-reports">
-        <ReportList />
-      </section>
     </div>
   );
 }

--- a/app/dashboard/reports-card-badge.tsx
+++ b/app/dashboard/reports-card-badge.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function ReportsCardBadge() {
+  const [count, setCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    async function fetchCount() {
+      try {
+        const response = await fetch("/api/reports");
+        if (!response.ok) return;
+        const data = await response.json();
+        const reports = data.reports || [];
+        if (reports.length > 0) {
+          setCount(reports.length);
+        }
+      } catch {
+        // Silently fail — badge is optional
+      }
+    }
+    fetchCount();
+  }, []);
+
+  if (count === null) return null;
+
+  return <span className="dashboard-card__badge">{count}</span>;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -320,6 +320,10 @@ button[type="submit"]:disabled {
   border-left-color: var(--color-green-400);
 }
 
+.dashboard-card--reports {
+  border-left-color: var(--color-blue-500);
+}
+
 .dashboard-card--profile {
   border-left-color: var(--color-green-600);
 }
@@ -336,6 +340,15 @@ button[type="submit"]:disabled {
   color: var(--color-green-600);
 }
 
+.dashboard-card--reports .dashboard-card__icon {
+  background: var(--color-blue-50);
+  color: var(--color-blue-600);
+}
+
+.dashboard-card--reports h3 {
+  color: var(--color-blue-700);
+}
+
 .dashboard-card h3 {
   margin: 0 0 0.25rem 0;
   font-size: 1.1rem;
@@ -346,6 +359,31 @@ button[type="submit"]:disabled {
   margin: 0;
   font-size: 0.85rem;
   color: var(--color-gray-500);
+}
+
+.dashboard-card__title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dashboard-card__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 0.35rem;
+  background: var(--color-blue-500);
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 600;
+  border-radius: 999px;
+}
+
+.reports-page {
+  max-width: 640px;
+  margin: 0 auto;
 }
 
 .logout-button {
@@ -1976,9 +2014,6 @@ button.chat-send-button[type="submit"]:disabled {
   color: #991b1b;
 }
 
-.dashboard-reports {
-  margin-top: 1rem;
-}
 
 /* =========================
    Mobile Responsive

--- a/app/reports/layout.tsx
+++ b/app/reports/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function ReportsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import NavHeader from "@/components/ui/NavHeader";
+import ReportList from "@/components/reports/ReportList";
+
+export default function ReportsPage() {
+  return (
+    <div className="reports-page">
+      <NavHeader backLabel="Dashboard" />
+      <ReportList />
+    </div>
+  );
+}

--- a/components/ui/NavHeader.tsx
+++ b/components/ui/NavHeader.tsx
@@ -39,6 +39,9 @@ export default function NavHeader({
         <Link href="/chat" className={linkClass("/chat")}>
           Chat
         </Link>
+        <Link href="/reports" className={linkClass("/reports")}>
+          Reports
+        </Link>
         <Link href="/profile" className={linkClass("/profile")}>
           Profile
         </Link>


### PR DESCRIPTION
## Summary
- Restructure dashboard from 3 cards + report list to a **4-card 2x2 grid** (Upload, Chat, Reports, Profile)
- Add a dedicated **Reports card** with clipboard icon, blue accent border, and dynamic count badge
- Move the full report list to a new **/reports** page with NavHeader navigation
- Add Reports link to the NavHeader component for consistent navigation

## Changes
| File | Change |
|------|--------|
| `app/dashboard/page.tsx` | Replace ReportList section with Reports card in nav grid |
| `app/dashboard/reports-card-badge.tsx` | New client component fetching report count for badge |
| `app/reports/page.tsx` | New dedicated reports page rendering ReportList |
| `app/reports/layout.tsx` | Force-dynamic layout for reports route |
| `app/globals.css` | Add reports card styles, badge, title-row; remove dashboard-reports |
| `components/ui/NavHeader.tsx` | Add Reports link to navigation |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes  
- [x] All 361 tests pass (`npx vitest run`)
- [ ] Manual: Dashboard shows 4 equal cards in 2x2 grid on desktop
- [ ] Manual: Cards stack to single column on mobile (< 480px)
- [ ] Manual: Reports card shows blue accent and count badge
- [ ] Manual: Clicking Reports card navigates to /reports
- [ ] Manual: /reports page shows full report list with NavHeader

Closes #84