### PR TITLE
feat(profile): add profile picture upload with avatar component

### DIFF
--- a/__tests__/avatar.test.ts
+++ b/__tests__/avatar.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// ── Avatar Component ───────────────────────────────────────────────
+
+describe("Avatar Component", () => {
+  it("exports a default component and getInitials helper", async () => {
+    const mod = await import("@/components/ui/Avatar");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+    expect(mod.getInitials).toBeDefined();
+    expect(typeof mod.getInitials).toBe("function");
+  });
+
+  it("renders initials when no avatar URL is provided", async () => {
+    const { default: Avatar } = await import("@/components/ui/Avatar");
+    render(React.createElement(Avatar, { displayName: "Jane Doe", size: "md" }));
+    expect(screen.getByText("JD")).toBeDefined();
+  });
+
+  it("renders single initial for single-word name", async () => {
+    const { default: Avatar } = await import("@/components/ui/Avatar");
+    render(React.createElement(Avatar, { displayName: "Alice", size: "md" }));
+    expect(screen.getByText("A")).toBeDefined();
+  });
+
+  it("renders '?' when no display name is provided", async () => {
+    const { default: Avatar } = await import("@/components/ui/Avatar");
+    render(React.createElement(Avatar, { displayName: null, size: "md" }));
+    expect(screen.getByText("?")).toBeDefined();
+  });
+
+  it("renders image when avatar URL is provided", async () => {
+    const { default: Avatar } = await import("@/components/ui/Avatar");
+    render(
+      React.createElement(Avatar, {
+        avatarUrl: "https://example.com/avatar.png",
+        displayName: "Jane Doe",
+        size: "lg",
+      })
+    );
+    const img = screen.getByRole("img");
+    expect(img).toBeDefined();
+    expect(img.getAttribute("src")).toBe("https://example.com/avatar.png");
+  });
+
+  it("applies size class correctly", async () => {
+    const { default: Avatar } = await import("@/components/ui/Avatar");
+    const { container } = render(
+      React.createElement(Avatar, { displayName: "Test", size: "sm" })
+    );
+    const el = container.querySelector(".avatar--sm");
+    expect(el).not.toBeNull();
+  });
+});
+
+// ── getInitials Helper ─────────────────────────────────────────────
+
+describe("getInitials", () => {
+  it("returns first and last initials for multi-word name", async () => {
+    const { getInitials } = await import("@/components/ui/Avatar");
+    expect(getInitials("John Smith")).toBe("JS");
+  });
+
+  it("returns single initial for single name", async () => {
+    const { getInitials } = await import("@/components/ui/Avatar");
+    expect(getInitials("Alice")).toBe("A");
+  });
+
+  it("returns ? for null", async () => {
+    const { getInitials } = await import("@/components/ui/Avatar");
+    expect(getInitials(null)).toBe("?");
+  });
+
+  it("returns ? for empty string", async () => {
+    const { getInitials } = await import("@/components/ui/Avatar");
+    expect(getInitials("")).toBe("?");
+  });
+
+  it("returns ? for whitespace-only string", async () => {
+    const { getInitials } = await import("@/components/ui/Avatar");
+    expect(getInitials("   ")).toBe("?");
+  });
+
+  it("handles three-word names (first + last)", async () => {
+    const { getInitials } = await import("@/components/ui/Avatar");
+    expect(getInitials("Mary Jane Watson")).toBe("MW");
+  });
+
+  it("uppercases initials", async () => {
+    const { getInitials } = await import("@/components/ui/Avatar");
+    expect(getInitials("jane doe")).toBe("JD");
+  });
+});
+
+// ── Avatar API Route ───────────────────────────────────────────────
+
+describe("Avatar API Route", () => {
+  it("exports POST and DELETE handlers", async () => {
+    const mod = await import("@/app/api/profile/avatar/route");
+    expect(mod.POST).toBeDefined();
+    expect(mod.DELETE).toBeDefined();
+    expect(typeof mod.POST).toBe("function");
+    expect(typeof mod.DELETE).toBe("function");
+  });
+});
+
+describe("Avatar API — POST", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+  let mockStorage: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+    mockStorage = {
+      from: vi.fn(),
+    };
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+        storage: mockStorage,
+      }),
+    }));
+  });
+
+  function createUploadRequest(
+    fileName: string,
+    fileSize: number,
+    fileType: string
+  ): Request {
+    const buffer = new ArrayBuffer(fileSize);
+    const file = new File([buffer], fileName, { type: fileType });
+    const formData = new FormData();
+    formData.append("file", file);
+    return new Request("http://localhost:3000/api/profile/avatar", {
+      method: "POST",
+      body: formData,
+    });
+  }
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { POST } = await import("@/app/api/profile/avatar/route");
+    const response = await POST(createUploadRequest("avatar.png", 1024, "image/png"));
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 for invalid request body (no formData)", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const { POST } = await import("@/app/api/profile/avatar/route");
+    const response = await POST(
+      new Request("http://localhost:3000/api/profile/avatar", {
+        method: "POST",
+        body: "not form data",
+        headers: { "Content-Type": "text/plain" },
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 200 with avatar_url on successful upload", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    // Mock storage list (no existing files)
+    const listMock = vi.fn().mockResolvedValue({ data: [], error: null });
+    // Mock storage upload
+    const uploadMock = vi.fn().mockResolvedValue({ error: null });
+    // Mock storage getPublicUrl
+    const getPublicUrlMock = vi.fn().mockReturnValue({
+      data: { publicUrl: "https://storage.example.com/avatars/user-1/avatar.png" },
+    });
+
+    mockStorage.from = vi.fn().mockReturnValue({
+      list: listMock,
+      remove: vi.fn(),
+      upload: uploadMock,
+      getPublicUrl: getPublicUrlMock,
+    });
+
+    // Mock profile upsert
+    mockFrom.mockReturnValue({
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    });
+
+    const { POST } = await import("@/app/api/profile/avatar/route");
+
+    // Create request with mocked formData to avoid JSDOM serialization issues
+    const mockFile = new File([new ArrayBuffer(1024)], "avatar.png", { type: "image/png" });
+    const mockFormData = new FormData();
+    mockFormData.append("file", mockFile);
+    const request = new Request("http://localhost:3000/api/profile/avatar", {
+      method: "POST",
+    });
+    // Override formData method to return our mock
+    vi.spyOn(request, "formData").mockResolvedValue(mockFormData);
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.avatar_url).toBe("https://storage.example.com/avatars/user-1/avatar.png");
+  });
+
+  it("deletes existing avatar before uploading new one", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const removeMock = vi.fn().mockResolvedValue({ error: null });
+    const listMock = vi.fn().mockResolvedValue({
+      data: [{ name: "avatar.jpg" }],
+      error: null,
+    });
+
+    mockStorage.from = vi.fn().mockReturnValue({
+      list: listMock,
+      remove: removeMock,
+      upload: vi.fn().mockResolvedValue({ error: null }),
+      getPublicUrl: vi.fn().mockReturnValue({
+        data: { publicUrl: "https://storage.example.com/avatars/user-1/avatar.png" },
+      }),
+    });
+
+    mockFrom.mockReturnValue({
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    });
+
+    const { POST } = await import("@/app/api/profile/avatar/route");
+
+    // Create request with mocked formData
+    const mockFile = new File([new ArrayBuffer(1024)], "avatar.png", { type: "image/png" });
+    const mockFormData = new FormData();
+    mockFormData.append("file", mockFile);
+    const request = new Request("http://localhost:3000/api/profile/avatar", {
+      method: "POST",
+    });
+    vi.spyOn(request, "formData").mockResolvedValue(mockFormData);
+
+    await POST(request);
+
+    expect(removeMock).toHaveBeenCalledWith(["user-1/avatar.jpg"]);
+  });
+});
+
+describe("Avatar API — DELETE", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+  let mockStorage: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+    mockStorage = {
+      from: vi.fn(),
+    };
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+        storage: mockStorage,
+      }),
+    }));
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { DELETE } = await import("@/app/api/profile/avatar/route");
+    const response = await DELETE();
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 200 and clears avatar_url on successful delete", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    mockStorage.from = vi.fn().mockReturnValue({
+      list: vi.fn().mockResolvedValue({
+        data: [{ name: "avatar.png" }],
+        error: null,
+      }),
+      remove: vi.fn().mockResolvedValue({ error: null }),
+    });
+
+    mockFrom.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    });
+
+    const { DELETE } = await import("@/app/api/profile/avatar/route");
+    const response = await DELETE();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.avatar_url).toBeNull();
+  });
+});

--- a/__tests__/report-results.test.ts
+++ b/__tests__/report-results.test.ts
@@ -27,10 +27,32 @@ describe("Single Report API Route", () => {
 describe("Report Results Page", () => {
   const mockFetch = vi.fn();
 
+  // Profile API response for NavHeader avatar fetch
+  const profileResponse = {
+    ok: true,
+    json: async () => ({
+      profile: {
+        id: "user-1",
+        display_name: null,
+        avatar_url: null,
+        updated_at: null,
+      },
+    }),
+  };
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    vi.spyOn(globalThis, "fetch").mockImplementation(mockFetch);
+    // Wrap mockFetch to auto-handle NavHeader's /api/profile calls
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (input: string | URL | Request, ...args: unknown[]) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        if (url === "/api/profile") {
+          return Promise.resolve(profileResponse as Response);
+        }
+        return mockFetch(input, ...args);
+      }
+    );
 
     vi.doMock("next/navigation", () => ({
       useParams: () => ({ id: "report-abc" }),
@@ -236,10 +258,32 @@ describe("Report Results Layout", () => {
 describe("ReportList Component", () => {
   const mockFetch = vi.fn();
 
+  // Profile API response for NavHeader avatar fetch
+  const profileResponse = {
+    ok: true,
+    json: async () => ({
+      profile: {
+        id: "user-1",
+        display_name: null,
+        avatar_url: null,
+        updated_at: null,
+      },
+    }),
+  };
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    vi.spyOn(globalThis, "fetch").mockImplementation(mockFetch);
+    // Wrap mockFetch to auto-handle NavHeader's /api/profile calls
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (input: string | URL | Request, ...args: unknown[]) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        if (url === "/api/profile") {
+          return Promise.resolve(profileResponse as Response);
+        }
+        return mockFetch(input, ...args);
+      }
+    );
   });
 
   it("renders reports with file names and status badges", async () => {

--- a/__tests__/upload.test.ts
+++ b/__tests__/upload.test.ts
@@ -115,10 +115,32 @@ describe("Upload Page — auto-parse flow", () => {
   const mockFetch = vi.fn();
   const mockPush = vi.fn();
 
+  // Profile API response for NavHeader avatar fetch
+  const profileResponse = {
+    ok: true,
+    json: async () => ({
+      profile: {
+        id: "user-1",
+        display_name: null,
+        avatar_url: null,
+        updated_at: null,
+      },
+    }),
+  };
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    vi.spyOn(globalThis, "fetch").mockImplementation(mockFetch);
+    // Wrap mockFetch to auto-handle NavHeader's /api/profile calls
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (input: string | URL | Request, ...args: unknown[]) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        if (url === "/api/profile") {
+          return Promise.resolve(profileResponse as Response);
+        }
+        return mockFetch(input, ...args);
+      }
+    );
 
     vi.doMock("next/navigation", () => ({
       useRouter: () => ({ push: mockPush }),

--- a/app/api/profile/avatar/route.ts
+++ b/app/api/profile/avatar/route.ts
@@ -1,0 +1,152 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
+const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/webp"];
+
+function getExtension(mimeType: string): string {
+  const map: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp",
+  };
+  return map[mimeType] || "png";
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Parse multipart form data
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid form data" },
+      { status: 400 }
+    );
+  }
+
+  const file = formData.get("file");
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json(
+      { error: "No file provided" },
+      { status: 400 }
+    );
+  }
+
+  // Validate file type
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      { error: "Invalid file type. Accepted: PNG, JPEG, WebP" },
+      { status: 400 }
+    );
+  }
+
+  // Validate file size
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { error: "File too large. Maximum size is 2MB" },
+      { status: 413 }
+    );
+  }
+
+  const ext = getExtension(file.type);
+  const filePath = `${user.id}/avatar.${ext}`;
+
+  // Delete any existing avatar files for this user
+  const { data: existingFiles } = await supabase.storage
+    .from("avatars")
+    .list(user.id);
+
+  if (existingFiles && existingFiles.length > 0) {
+    const filesToDelete = existingFiles.map((f) => `${user.id}/${f.name}`);
+    await supabase.storage.from("avatars").remove(filesToDelete);
+  }
+
+  // Upload new avatar
+  const { error: uploadError } = await supabase.storage
+    .from("avatars")
+    .upload(filePath, file, {
+      cacheControl: "3600",
+      upsert: true,
+    });
+
+  if (uploadError) {
+    return NextResponse.json(
+      { error: "Failed to upload avatar" },
+      { status: 500 }
+    );
+  }
+
+  // Build public URL using request origin (no hardcoded URLs)
+  const {
+    data: { publicUrl },
+  } = supabase.storage.from("avatars").getPublicUrl(filePath);
+
+  // Update profile with avatar URL
+  const { error: updateError } = await supabase
+    .from("profiles")
+    .upsert(
+      {
+        id: user.id,
+        avatar_url: publicUrl,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "id" }
+    );
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: "Failed to update profile" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ avatar_url: publicUrl }, { status: 200 });
+}
+
+export async function DELETE() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // List and delete all avatar files for this user
+  const { data: existingFiles } = await supabase.storage
+    .from("avatars")
+    .list(user.id);
+
+  if (existingFiles && existingFiles.length > 0) {
+    const filesToDelete = existingFiles.map((f) => `${user.id}/${f.name}`);
+    await supabase.storage.from("avatars").remove(filesToDelete);
+  }
+
+  // Clear avatar_url in profile
+  const { error: updateError } = await supabase
+    .from("profiles")
+    .update({ avatar_url: null, updated_at: new Date().toISOString() })
+    .eq("id", user.id);
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: "Failed to update profile" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ avatar_url: null }, { status: 200 });
+}

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -15,7 +15,7 @@ export async function GET() {
   // Fetch profile — RLS ensures only own profile is accessible
   const { data: profile, error } = await supabase
     .from("profiles")
-    .select("id, display_name, date_of_birth, gender, updated_at")
+    .select("id, display_name, date_of_birth, gender, avatar_url, updated_at")
     .eq("id", user.id)
     .single();
 
@@ -34,6 +34,7 @@ export async function GET() {
         display_name: null,
         date_of_birth: null,
         gender: null,
+        avatar_url: null,
         updated_at: null,
       },
     },
@@ -139,7 +140,7 @@ export async function PUT(request: Request) {
   const { data: profile, error } = await supabase
     .from("profiles")
     .upsert(updateData, { onConflict: "id" })
-    .select("id, display_name, date_of_birth, gender, updated_at")
+    .select("id, display_name, date_of_birth, gender, avatar_url, updated_at")
     .single();
 
   if (error) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1291,6 +1291,119 @@ button.chat-send-button[type="submit"]:disabled {
   text-align: center;
 }
 
+/* ── Avatar Component ────────────────────────────────────── */
+
+.avatar {
+  border-radius: 50%;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-green-100);
+  color: var(--color-green-700);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.avatar--sm {
+  width: 32px;
+  height: 32px;
+  font-size: 0.75rem;
+}
+
+.avatar--md {
+  width: 48px;
+  height: 48px;
+  font-size: 1rem;
+}
+
+.avatar--lg {
+  width: 80px;
+  height: 80px;
+  font-size: 1.5rem;
+}
+
+.avatar__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.avatar__initials {
+  user-select: none;
+}
+
+/* ── Profile Avatar Section ──────────────────────────────── */
+
+.profile-avatar {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+  padding: 1.25rem;
+  background: var(--color-gray-50);
+  border-radius: var(--radius-md);
+}
+
+.profile-avatar__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.profile-avatar__input {
+  display: none;
+}
+
+.profile-avatar__upload-btn {
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  background: var(--color-green-600);
+  color: white;
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+}
+
+.profile-avatar__upload-btn:hover {
+  background: var(--color-green-700);
+}
+
+.profile-avatar__remove-btn {
+  padding: 0.4rem 1rem;
+  background: none;
+  border: 1px solid var(--color-gray-300);
+  color: var(--color-gray-600);
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.profile-avatar__remove-btn:hover {
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
+.profile-avatar__remove-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.profile-avatar__hint {
+  font-size: 0.75rem;
+  color: var(--color-gray-400);
+}
+
+/* ── NavHeader Profile Link with Avatar ──────────────────── */
+
+.nav-header__profile-link {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
 /* ── Doctor Prep Page ─────────────────────────────────────── */
 
 .doctor-prep {

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import Link from "next/link";
+import { useState, useEffect, useCallback, useRef } from "react";
 import NavHeader from "@/components/ui/NavHeader";
+import Avatar from "@/components/ui/Avatar";
 
 interface ProfileData {
   id: string;
   display_name: string | null;
   date_of_birth: string | null;
   gender: string | null;
+  avatar_url: string | null;
   updated_at: string | null;
 }
 
@@ -17,10 +18,13 @@ export default function ProfilePage() {
   const [displayName, setDisplayName] = useState("");
   const [dateOfBirth, setDateOfBirth] = useState("");
   const [gender, setGender] = useState("");
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [uploadingAvatar, setUploadingAvatar] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const fetchProfile = useCallback(async () => {
     try {
@@ -33,6 +37,7 @@ export default function ProfilePage() {
       setDisplayName(data.profile.display_name || "");
       setDateOfBirth(data.profile.date_of_birth || "");
       setGender(data.profile.gender || "");
+      setAvatarUrl(data.profile.avatar_url || null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load profile");
     } finally {
@@ -43,6 +48,77 @@ export default function ProfilePage() {
   useEffect(() => {
     fetchProfile();
   }, [fetchProfile]);
+
+  const handleAvatarUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Client-side validation
+    const allowedTypes = ["image/png", "image/jpeg", "image/webp"];
+    if (!allowedTypes.includes(file.type)) {
+      setError("Invalid file type. Accepted: PNG, JPEG, WebP");
+      return;
+    }
+    if (file.size > 2 * 1024 * 1024) {
+      setError("File too large. Maximum size is 2MB");
+      return;
+    }
+
+    setUploadingAvatar(true);
+    setError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const response = await fetch("/api/profile/avatar", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to upload avatar");
+      }
+
+      const data = await response.json();
+      setAvatarUrl(data.avatar_url);
+      setSuccess(true);
+      setTimeout(() => setSuccess(false), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to upload avatar");
+    } finally {
+      setUploadingAvatar(false);
+      // Reset file input so same file can be selected again
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  };
+
+  const handleAvatarRemove = async () => {
+    setUploadingAvatar(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/profile/avatar", {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to remove avatar");
+      }
+
+      setAvatarUrl(null);
+      setSuccess(true);
+      setTimeout(() => setSuccess(false), 3000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to remove avatar");
+    } finally {
+      setUploadingAvatar(false);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -105,6 +181,40 @@ export default function ProfilePage() {
           Profile saved successfully!
         </div>
       )}
+
+      <div className="profile-avatar">
+        <Avatar avatarUrl={avatarUrl} displayName={displayName} size="lg" />
+        <div className="profile-avatar__actions">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            onChange={handleAvatarUpload}
+            className="profile-avatar__input"
+            id="avatar-upload"
+            aria-label="Upload avatar"
+          />
+          <label
+            htmlFor="avatar-upload"
+            className="profile-avatar__upload-btn"
+          >
+            {uploadingAvatar ? "Uploading..." : "Change Photo"}
+          </label>
+          {avatarUrl && (
+            <button
+              type="button"
+              onClick={handleAvatarRemove}
+              className="profile-avatar__remove-btn"
+              disabled={uploadingAvatar}
+            >
+              Remove
+            </button>
+          )}
+          <span className="profile-avatar__hint">
+            PNG, JPEG, or WebP. Max 2MB.
+          </span>
+        </div>
+      </div>
 
       <form onSubmit={handleSubmit} className="profile-page__form">
         <div className="profile-page__field">

--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+/* eslint-disable @next/next/no-img-element */
+
+interface AvatarProps {
+  avatarUrl?: string | null;
+  displayName?: string | null;
+  size?: "sm" | "md" | "lg";
+}
+
+/**
+ * Reusable avatar component with image or initials fallback.
+ * Sizes: sm=32px, md=48px, lg=80px.
+ */
+export default function Avatar({
+  avatarUrl,
+  displayName,
+  size = "md",
+}: AvatarProps) {
+  const initials = getInitials(displayName);
+
+  return (
+    <div className={`avatar avatar--${size}`} aria-label="User avatar">
+      {avatarUrl ? (
+        <img
+          src={avatarUrl}
+          alt={displayName ? `${displayName}'s avatar` : "User avatar"}
+          className="avatar__image"
+        />
+      ) : (
+        <span className="avatar__initials">{initials}</span>
+      )}
+    </div>
+  );
+}
+
+/** Extract up to 2 initials from a display name. */
+export function getInitials(name?: string | null): string {
+  if (!name || !name.trim()) return "?";
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return parts[0][0].toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}

--- a/components/ui/NavHeader.tsx
+++ b/components/ui/NavHeader.tsx
@@ -1,13 +1,20 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Logo from "./Logo";
+import Avatar from "./Avatar";
 
 interface NavHeaderProps {
   showBack?: boolean;
   backHref?: string;
   backLabel?: string;
+}
+
+interface ProfileInfo {
+  avatar_url: string | null;
+  display_name: string | null;
 }
 
 export default function NavHeader({
@@ -16,6 +23,26 @@ export default function NavHeader({
   backLabel = "Dashboard",
 }: NavHeaderProps) {
   const pathname = usePathname();
+  const [profileInfo, setProfileInfo] = useState<ProfileInfo | null>(null);
+
+  useEffect(() => {
+    fetch("/api/profile")
+      .then((res) => {
+        if (res.ok) return res.json();
+        return null;
+      })
+      .then((data) => {
+        if (data?.profile) {
+          setProfileInfo({
+            avatar_url: data.profile.avatar_url || null,
+            display_name: data.profile.display_name || null,
+          });
+        }
+      })
+      .catch(() => {
+        // Silent fail — avatar is non-critical
+      });
+  }, []);
 
   const linkClass = (href: string) => {
     const isActive = pathname === href || pathname.startsWith(href + "/");
@@ -43,7 +70,16 @@ export default function NavHeader({
           Reports
         </Link>
         <Link href="/profile" className={linkClass("/profile")}>
-          Profile
+          <span className="nav-header__profile-link">
+            {profileInfo && (
+              <Avatar
+                avatarUrl={profileInfo.avatar_url}
+                displayName={profileInfo.display_name}
+                size="sm"
+              />
+            )}
+            Profile
+          </span>
         </Link>
       </nav>
     </header>

--- a/supabase/migrations/006_avatar_url.sql
+++ b/supabase/migrations/006_avatar_url.sql
@@ -1,0 +1,4 @@
+-- HealthChat AI: Add avatar_url column to profiles table
+-- Stores the public URL for user profile pictures.
+
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS avatar_url text;

--- a/supabase/migrations/007_avatars_bucket.sql
+++ b/supabase/migrations/007_avatars_bucket.sql
@@ -1,0 +1,57 @@
+-- HealthChat AI: Avatars Storage Bucket
+-- Creates public bucket for user profile pictures with RLS policies.
+
+-- =============================================================================
+-- STORAGE BUCKET
+-- =============================================================================
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'avatars',
+  'avatars',
+  true,
+  2097152,  -- 2MB
+  ARRAY['image/png', 'image/jpeg', 'image/webp']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- =============================================================================
+-- STORAGE RLS POLICIES
+-- =============================================================================
+
+-- Users can upload their own avatar (folder = userId)
+CREATE POLICY "Users can upload own avatar"
+  ON storage.objects
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Avatars are publicly readable (for display in UI without auth)
+CREATE POLICY "Avatars are publicly readable"
+  ON storage.objects
+  FOR SELECT
+  TO public
+  USING (bucket_id = 'avatars');
+
+-- Users can update their own avatar
+CREATE POLICY "Users can update own avatar"
+  ON storage.objects
+  FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Users can delete their own avatar
+CREATE POLICY "Users can delete own avatar"
+  ON storage.objects
+  FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );


### PR DESCRIPTION
## Summary
Closes #67

- Add avatar upload/remove functionality to the profile page with reusable `Avatar` component (image display or initials fallback)
- Create `POST /api/profile/avatar` and `DELETE /api/profile/avatar` API routes for avatar management via Supabase Storage
- Add database migrations for `avatar_url` column and public `avatars` storage bucket with RLS policies
- Display small avatar in NavHeader next to the Profile link
- 20 new tests covering Avatar component, getInitials helper, and API routes (upload, delete, auth, validation)

## Changes
| File | What |
|------|------|
| `supabase/migrations/006_avatar_url.sql` | Add `avatar_url` column to profiles table |
| `supabase/migrations/007_avatars_bucket.sql` | Create public avatars bucket with RLS policies |
| `components/ui/Avatar.tsx` | Reusable avatar component with sm/md/lg sizes |
| `app/api/profile/avatar/route.ts` | POST (upload) and DELETE (remove) avatar handlers |
| `app/profile/page.tsx` | Avatar section with upload/remove UI |
| `app/api/profile/route.ts` | Include `avatar_url` in GET/PUT select |
| `components/ui/NavHeader.tsx` | Fetch profile and show small avatar |
| `app/globals.css` | Avatar, profile-avatar, and nav-header profile link styles |
| `__tests__/avatar.test.ts` | 20 tests for component, helper, and API |
| `__tests__/upload.test.ts` | Fix fetch mock to handle NavHeader profile call |
| `__tests__/report-results.test.ts` | Fix fetch mock to handle NavHeader profile call |

## Migration Instructions
Run these SQL files in Supabase SQL Editor (in order):
1. `006_avatar_url.sql` -- adds `avatar_url` text column to profiles
2. `007_avatars_bucket.sql` -- creates avatars bucket with RLS policies

## Test plan
- [x] `npm run lint` passes (0 errors)
- [x] `npm run typecheck` passes
- [x] `npx vitest run` passes (381 tests, 20 test files)
- [ ] Manual: Upload PNG/JPEG/WebP avatar on profile page
- [ ] Manual: Verify avatar appears in NavHeader
- [ ] Manual: Remove avatar and verify initials fallback displays
- [ ] Manual: Verify file size (>2MB) and type validation errors