### PR TITLE
fix(chat): auto-load user's reports as context for AI chat

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -87,11 +87,13 @@ export async function POST(request: Request) {
     sessionId = newSession.id;
   }
 
-  // Load report context if report_id is provided
+  // Load report context — use specific report_id if provided,
+  // otherwise auto-load ALL parsed reports for this user
   let reportContext = "";
   const reportId = body.report_id;
 
   if (reportId) {
+    // Specific report requested (e.g., from "Chat About Results" link)
     const { data: parsedResult } = await supabase
       .from("parsed_results")
       .select("biomarkers, summary_plain")
@@ -102,6 +104,39 @@ export async function POST(request: Request) {
 
     if (parsedResult && parsedResult.biomarkers) {
       reportContext = buildReportContext(parsedResult);
+    }
+  } else {
+    // No specific report — load all user's parsed reports for context
+    const { data: userReports } = await supabase
+      .from("reports")
+      .select("id, original_filename, created_at, parsed_results(biomarkers, summary_plain)")
+      .eq("status", "parsed")
+      .order("created_at", { ascending: false })
+      .limit(5);
+
+    if (userReports && userReports.length > 0) {
+      const reportSections = userReports
+        .filter((r) => {
+          const pr = Array.isArray(r.parsed_results)
+            ? r.parsed_results[0]
+            : r.parsed_results;
+          return pr && pr.biomarkers;
+        })
+        .map((r) => {
+          const pr = Array.isArray(r.parsed_results)
+            ? r.parsed_results[0]
+            : r.parsed_results;
+          const date = new Date(r.created_at).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          });
+          return `--- Report: ${r.original_filename} (${date}) ---\n${buildReportContext(pr as { biomarkers: Array<{ name: string; value: number; unit: string; reference_low: number | null; reference_high: number | null; flag: string }>; summary_plain: string })}`;
+        });
+
+      if (reportSections.length > 0) {
+        reportContext = `The patient has ${reportSections.length} uploaded report(s). Here is their health data:\n\n${reportSections.join("\n\n")}`;
+      }
     }
   }
 

--- a/app/reports/[id]/page.tsx
+++ b/app/reports/[id]/page.tsx
@@ -172,7 +172,7 @@ export default function ReportResultsPage() {
                 results
               </p>
             </Link>
-            <Link href="/chat" className="report-results__nav-card">
+            <Link href={`/chat?report_id=${reportId}`} className="report-results__nav-card">
               <h3>Chat About Results</h3>
               <p>
                 Ask questions about your health data in plain language


### PR DESCRIPTION
## Summary
The chat AI had no idea what reports the user had uploaded. When users said "this report looks bad" the AI responded "I don't see your report attached."

**Two fixes:**
1. **"Chat About Results" link** now passes `report_id` as query param so the chat gets that specific report's data
2. **Auto-load all reports** — when no specific report_id, the chat loads ALL user's parsed reports (up to 5 most recent) as context. The AI always knows the user's health data.

## Test plan
- [x] All 381 tests pass
- [ ] Click "Chat About Results" from a report → AI references that report's biomarkers
- [ ] Open chat directly from nav → AI has context from all uploaded reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)