### PR TITLE
fix(chat,reports): report-specific chat + file type icons + status fix

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -87,13 +87,12 @@ export async function POST(request: Request) {
     sessionId = newSession.id;
   }
 
-  // Load report context — use specific report_id if provided,
-  // otherwise auto-load ALL parsed reports for this user
+  // Load report context only for the specific report_id.
+  // Each chat session is tied to one report — results may differ between reports.
   let reportContext = "";
   const reportId = body.report_id;
 
   if (reportId) {
-    // Specific report requested (e.g., from "Chat About Results" link)
     const { data: parsedResult } = await supabase
       .from("parsed_results")
       .select("biomarkers, summary_plain")
@@ -104,39 +103,6 @@ export async function POST(request: Request) {
 
     if (parsedResult && parsedResult.biomarkers) {
       reportContext = buildReportContext(parsedResult);
-    }
-  } else {
-    // No specific report — load all user's parsed reports for context
-    const { data: userReports } = await supabase
-      .from("reports")
-      .select("id, original_filename, created_at, parsed_results(biomarkers, summary_plain)")
-      .eq("status", "parsed")
-      .order("created_at", { ascending: false })
-      .limit(5);
-
-    if (userReports && userReports.length > 0) {
-      const reportSections = userReports
-        .filter((r) => {
-          const pr = Array.isArray(r.parsed_results)
-            ? r.parsed_results[0]
-            : r.parsed_results;
-          return pr && pr.biomarkers;
-        })
-        .map((r) => {
-          const pr = Array.isArray(r.parsed_results)
-            ? r.parsed_results[0]
-            : r.parsed_results;
-          const date = new Date(r.created_at).toLocaleDateString("en-US", {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-          });
-          return `--- Report: ${r.original_filename} (${date}) ---\n${buildReportContext(pr as { biomarkers: Array<{ name: string; value: number; unit: string; reference_low: number | null; reference_high: number | null; flag: string }>; summary_plain: string })}`;
-        });
-
-      if (reportSections.length > 0) {
-        reportContext = `The patient has ${reportSections.length} uploaded report(s). Here is their health data:\n\n${reportSections.join("\n\n")}`;
-      }
     }
   }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -2064,8 +2064,8 @@ button.chat-send-button[type="submit"]:disabled {
 
 .report-list__item {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 0.75rem;
   padding: 0.75rem 1rem;
   background: white;
   border: 1px solid var(--color-gray-200);
@@ -2082,10 +2082,23 @@ button.chat-send-button[type="submit"]:disabled {
   transform: translateY(-1px);
 }
 
+.report-list__item-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: var(--color-gray-50);
+  border-radius: var(--radius-sm);
+}
+
 .report-list__item-info {
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
+  flex: 1;
+  min-width: 0;
 }
 
 .report-list__item-name {
@@ -2104,27 +2117,29 @@ button.chat-send-button[type="submit"]:disabled {
   border-radius: 9999px;
   font-size: 0.6875rem;
   font-weight: 500;
+  flex-shrink: 0;
+  margin-left: auto;
   white-space: nowrap;
 }
 
-.report-list__item-status--completed {
+.report-list__item-status--parsed {
   background: var(--color-green-100);
   color: var(--color-green-800);
 }
 
-.report-list__item-status--processing {
+.report-list__item-status--parsing {
   background: var(--color-blue-100);
   color: #1e40af;
 }
 
-.report-list__item-status--pending {
+.report-list__item-status--uploaded {
   background: var(--color-orange-100);
   color: var(--color-orange-700);
 }
 
 .report-list__item-status--error {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--color-red-100);
+  color: var(--color-red-600);
 }
 
 

--- a/components/reports/ReportList.tsx
+++ b/components/reports/ReportList.tsx
@@ -97,6 +97,22 @@ export default function ReportList() {
             href={`/reports/${report.id}`}
             className="report-list__item"
           >
+            <div className="report-list__item-icon" aria-hidden="true">
+              {report.file_type === "pdf" ? (
+                <svg viewBox="0 0 24 24" width="28" height="28" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M6 2C4.9 2 4 2.9 4 4v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6H6z" fill="#ef4444" opacity="0.15"/>
+                  <path d="M6 2C4.9 2 4 2.9 4 4v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6H6z" stroke="#ef4444" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill="none"/>
+                  <path d="M14 2v6h6" stroke="#ef4444" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                  <text x="12" y="17" textAnchor="middle" fill="#ef4444" fontSize="5" fontWeight="bold" fontFamily="system-ui">PDF</text>
+                </svg>
+              ) : (
+                <svg viewBox="0 0 24 24" width="28" height="28" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <rect x="3" y="3" width="18" height="18" rx="2" fill="#3b82f6" opacity="0.15" stroke="#3b82f6" strokeWidth="1.5"/>
+                  <circle cx="8.5" cy="8.5" r="2" fill="#3b82f6" opacity="0.5"/>
+                  <path d="M21 15l-5-5L5 21" stroke="#3b82f6" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>
+              )}
+            </div>
             <div className="report-list__item-info">
               <span className="report-list__item-name">
                 {report.file_name}


### PR DESCRIPTION
## Summary
- **Chat context**: "Chat About Results" passes report_id — AI gets that specific report's biomarker data
- **General chat**: No auto-loading all reports. Chat asks users to attach a report if they want to discuss specific results
- **Report icons**: PDF files show red PDF icon, images show blue image icon
- **Status CSS fix**: Classes now match database enum (parsed/parsing/uploaded instead of completed/processing/pending)

## Test plan
- [x] All 381 tests pass
- [ ] "Chat About Results" from report → AI references that report's data
- [ ] General chat → AI asks if they want to attach a report
- [ ] Report list shows PDF/image icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)