### PR TITLE
feat(chat): add chat history sidebar with session list and pagination

### DIFF
--- a/__tests__/chat-sidebar.test.ts
+++ b/__tests__/chat-sidebar.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetch = vi.fn();
+
+describe("Chat Sidebar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(globalThis, "fetch").mockImplementation(mockFetch);
+  });
+
+  describe("Sessions API contract", () => {
+    it("calls GET /api/chat/sessions with pagination params", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sessions: [],
+          pagination: { page: 1, limit: 5, total: 0, totalPages: 0 },
+        }),
+      });
+
+      await fetch("/api/chat/sessions?page=1&limit=5");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/chat/sessions?page=1&limit=5"
+      );
+    });
+
+    it("returns sessions with title, date, and message_count", async () => {
+      const mockSessions = {
+        sessions: [
+          {
+            id: "sess-1",
+            title: "What does my cholesterol level mean?",
+            report_id: "report-1",
+            created_at: "2026-04-01T10:00:00Z",
+            updated_at: "2026-04-01T10:30:00Z",
+            message_count: 4,
+          },
+          {
+            id: "sess-2",
+            title: "Are any of my results outside the normal range?",
+            report_id: null,
+            created_at: "2026-03-31T09:00:00Z",
+            updated_at: "2026-03-31T09:15:00Z",
+            message_count: 2,
+          },
+        ],
+        pagination: { page: 1, limit: 5, total: 2, totalPages: 1 },
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockSessions,
+      });
+
+      const response = await fetch("/api/chat/sessions?page=1&limit=5");
+      const data = await response.json();
+
+      expect(data.sessions).toHaveLength(2);
+      expect(data.sessions[0]).toHaveProperty("id");
+      expect(data.sessions[0]).toHaveProperty("title");
+      expect(data.sessions[0]).toHaveProperty("message_count");
+      expect(data.sessions[0]).toHaveProperty("created_at");
+      expect(data.sessions[0]).toHaveProperty("updated_at");
+    });
+
+    it("supports pagination with page and totalPages", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sessions: [],
+          pagination: { page: 2, limit: 5, total: 12, totalPages: 3 },
+        }),
+      });
+
+      const response = await fetch("/api/chat/sessions?page=2&limit=5");
+      const data = await response.json();
+
+      expect(data.pagination.page).toBe(2);
+      expect(data.pagination.totalPages).toBe(3);
+      expect(data.pagination.total).toBe(12);
+    });
+  });
+
+  describe("Session messages API contract", () => {
+    it("calls GET /api/chat/sessions/:sessionId/messages", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          messages: [
+            {
+              id: "msg-1",
+              role: "user",
+              content: "What is glucose?",
+              created_at: "2026-04-01T10:00:00Z",
+            },
+            {
+              id: "msg-2",
+              role: "assistant",
+              content: "Glucose is a type of sugar.",
+              created_at: "2026-04-01T10:00:05Z",
+            },
+          ],
+          report_id: "report-1",
+        }),
+      });
+
+      const response = await fetch(
+        "/api/chat/sessions/sess-1/messages"
+      );
+      const data = await response.json();
+
+      expect(data.messages).toHaveLength(2);
+      expect(data.messages[0].role).toBe("user");
+      expect(data.messages[1].role).toBe("assistant");
+      expect(data).toHaveProperty("report_id");
+    });
+  });
+
+  describe("Sessions API route source validation", () => {
+    it("exports a GET handler", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/sessions/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("export async function GET");
+    });
+
+    it("verifies authentication", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/sessions/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("auth.getUser()");
+      expect(source).toContain("Unauthorized");
+      expect(source).toContain("status: 401");
+    });
+
+    it("supports page and limit pagination params", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/sessions/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain('"page"');
+      expect(source).toContain('"limit"');
+      expect(source).toContain("offset");
+    });
+
+    it("returns sessions ordered by most recent", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/sessions/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("updated_at");
+      expect(source).toContain("ascending: false");
+    });
+
+    it("generates title from first user message for sessions without title", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/sessions/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("substring(0, 50)");
+      expect(source).toContain('"New Chat"');
+    });
+  });
+
+  describe("Chat API title generation", () => {
+    it("sets title from first user message when creating new session", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      // Title is generated from the first user message
+      expect(source).toContain("userMessage.substring(0, 50)");
+      expect(source).toContain("title");
+    });
+
+    it("updates session updated_at after message persistence", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("updated_at");
+      expect(source).toContain('update({');
+    });
+  });
+
+  describe("ChatSidebar component", () => {
+    it("exports ChatSidebar component", async () => {
+      const mod = await import("@/components/chat/ChatSidebar");
+      expect(mod.ChatSidebar).toBeDefined();
+    });
+
+    it("is a function component", async () => {
+      const mod = await import("@/components/chat/ChatSidebar");
+      expect(typeof mod.ChatSidebar).toBe("function");
+    });
+  });
+
+  describe("useChat hook session switching", () => {
+    it("exports switchSession function from useChat", async () => {
+      const mod = await import("@/hooks/useChat");
+      expect(mod.useChat).toBeDefined();
+    });
+
+    it("useChat source includes switchSession and startNewChat", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const hookPath = path.resolve(
+        __dirname,
+        "../hooks/useChat.ts"
+      );
+      const source = fs.readFileSync(hookPath, "utf-8");
+
+      expect(source).toContain("switchSession");
+      expect(source).toContain("startNewChat");
+    });
+
+    it("switchSession fetches messages for the target session", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const hookPath = path.resolve(
+        __dirname,
+        "../hooks/useChat.ts"
+      );
+      const source = fs.readFileSync(hookPath, "utf-8");
+
+      expect(source).toContain("/api/chat/sessions/");
+      expect(source).toContain("/messages");
+    });
+
+    it("startNewChat clears messages and session", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const hookPath = path.resolve(
+        __dirname,
+        "../hooks/useChat.ts"
+      );
+      const source = fs.readFileSync(hookPath, "utf-8");
+
+      // startNewChat should set messages to empty, sessionId to null
+      expect(source).toContain("setMessages([])");
+      expect(source).toContain("setSessionId(null)");
+    });
+  });
+
+  describe("Session messages route source validation", () => {
+    it("exports a GET handler for session messages", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/sessions/[sessionId]/messages/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("export async function GET");
+    });
+
+    it("verifies authentication for session messages", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/sessions/[sessionId]/messages/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("auth.getUser()");
+      expect(source).toContain("Unauthorized");
+    });
+
+    it("verifies session ownership before returning messages", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/sessions/[sessionId]/messages/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("Session not found");
+      expect(source).toContain("status: 404");
+    });
+
+    it("returns messages ordered by created_at ascending", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/sessions/[sessionId]/messages/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("ascending: true");
+    });
+  });
+
+  describe("Migration for title column", () => {
+    it("adds title column to chat_sessions table", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const migrationPath = path.resolve(
+        __dirname,
+        "../supabase/migrations/008_chat_session_title.sql"
+      );
+      const source = fs.readFileSync(migrationPath, "utf-8");
+
+      expect(source).toContain("ALTER TABLE chat_sessions");
+      expect(source).toContain("ADD COLUMN title text");
+    });
+  });
+});

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -51,7 +51,6 @@ export async function POST(request: Request) {
 
   // Create or load chat session
   let sessionId = body.session_id;
-
   if (sessionId) {
     // Verify session exists and belongs to user (RLS handles this)
     const { data: session } = await supabase
@@ -67,12 +66,16 @@ export async function POST(request: Request) {
       );
     }
   } else {
-    // Create new session
+    // Create new session with title from first message
+    const title =
+      userMessage.substring(0, 50) + (userMessage.length > 50 ? "..." : "");
+
     const { data: newSession, error: sessionError } = await supabase
       .from("chat_sessions")
       .insert({
         user_id: user.id,
         report_id: body.report_id || null,
+        title,
       })
       .select("id")
       .single();
@@ -178,6 +181,12 @@ export async function POST(request: Request) {
             { session_id: sessionId, role: "user", content: userMessage },
             { session_id: sessionId, role: "assistant", content: assistantContent },
           ]);
+
+        // Update session's updated_at timestamp
+        await supabase
+          .from("chat_sessions")
+          .update({ updated_at: new Date().toISOString() })
+          .eq("id", sessionId);
 
         if (insertError) {
           // Log to Sentry for ops visibility — NO PHI (no message content)

--- a/app/api/chat/sessions/[sessionId]/messages/route.ts
+++ b/app/api/chat/sessions/[sessionId]/messages/route.ts
@@ -1,0 +1,52 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ sessionId: string }> }
+) {
+  const { sessionId } = await params;
+  const supabase = await createClient();
+
+  // Verify authentication
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Verify session belongs to user (RLS handles this)
+  const { data: session } = await supabase
+    .from("chat_sessions")
+    .select("id, report_id")
+    .eq("id", sessionId)
+    .single();
+
+  if (!session) {
+    return NextResponse.json(
+      { error: "Session not found" },
+      { status: 404 }
+    );
+  }
+
+  // Load all messages for this session
+  const { data: messages, error: messagesError } = await supabase
+    .from("chat_messages")
+    .select("id, role, content, created_at")
+    .eq("session_id", sessionId)
+    .order("created_at", { ascending: true });
+
+  if (messagesError) {
+    return NextResponse.json(
+      { error: "Failed to load messages" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({
+    messages: messages || [],
+    report_id: session.report_id,
+  });
+}

--- a/app/api/chat/sessions/route.ts
+++ b/app/api/chat/sessions/route.ts
@@ -1,0 +1,116 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 50;
+
+export async function GET(request: Request) {
+  const supabase = await createClient();
+
+  // Verify authentication
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Parse pagination params
+  const url = new URL(request.url);
+  const page = Math.max(1, parseInt(url.searchParams.get("page") || "1", 10));
+  const limit = Math.min(
+    MAX_LIMIT,
+    Math.max(1, parseInt(url.searchParams.get("limit") || String(DEFAULT_LIMIT), 10))
+  );
+  const offset = (page - 1) * limit;
+
+  // Get total count of sessions for this user
+  const { count } = await supabase
+    .from("chat_sessions")
+    .select("id", { count: "exact", head: true })
+    .eq("user_id", user.id);
+
+  // Fetch sessions with message count and first user message for title
+  const { data: sessions, error: sessionsError } = await supabase
+    .from("chat_sessions")
+    .select(`
+      id,
+      title,
+      report_id,
+      created_at,
+      updated_at,
+      chat_messages (
+        id
+      )
+    `)
+    .eq("user_id", user.id)
+    .order("updated_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (sessionsError) {
+    return NextResponse.json(
+      { error: "Failed to fetch sessions" },
+      { status: 500 }
+    );
+  }
+
+  // For sessions without a title, fetch the first user message
+  const sessionIds = (sessions || [])
+    .filter((s) => !s.title)
+    .map((s) => s.id);
+
+  let firstMessages: Record<string, string> = {};
+  if (sessionIds.length > 0) {
+    // Get the first user message for each session that needs a title
+    const { data: messages } = await supabase
+      .from("chat_messages")
+      .select("session_id, content")
+      .in("session_id", sessionIds)
+      .eq("role", "user")
+      .order("created_at", { ascending: true });
+
+    if (messages) {
+      // Keep only the first message per session
+      for (const msg of messages) {
+        if (!firstMessages[msg.session_id]) {
+          firstMessages[msg.session_id] = msg.content;
+        }
+      }
+    }
+  }
+
+  // Build response with derived titles and message counts
+  const formattedSessions = (sessions || []).map((session) => {
+    const messageCount = Array.isArray(session.chat_messages)
+      ? session.chat_messages.length
+      : 0;
+
+    let title = session.title;
+    if (!title) {
+      const firstMsg = firstMessages[session.id];
+      title = firstMsg
+        ? firstMsg.substring(0, 50) + (firstMsg.length > 50 ? "..." : "")
+        : "New Chat";
+    }
+
+    return {
+      id: session.id,
+      title,
+      report_id: session.report_id,
+      created_at: session.created_at,
+      updated_at: session.updated_at,
+      message_count: messageCount,
+    };
+  });
+
+  return NextResponse.json({
+    sessions: formattedSessions,
+    pagination: {
+      page,
+      limit,
+      total: count ?? 0,
+      totalPages: Math.ceil((count ?? 0) / limit),
+    },
+  });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -464,13 +464,227 @@ button[type="submit"]:disabled {
   text-align: center;
 }
 
+/* Chat Layout */
+.chat-layout {
+  display: flex;
+  height: calc(100vh - 4rem);
+  position: relative;
+}
+
+/* Chat Sidebar */
+.chat-sidebar {
+  width: 280px;
+  min-width: 280px;
+  background: var(--color-gray-50);
+  border-right: 1px solid var(--color-gray-200);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.chat-sidebar__header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-gray-200);
+  flex-shrink: 0;
+}
+
+.chat-sidebar__title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-gray-800);
+  margin: 0 0 0.75rem 0;
+}
+
+.chat-sidebar__new-btn {
+  width: 100%;
+  padding: 0.5rem 1rem;
+  background: var(--color-green-600);
+  color: white;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.chat-sidebar__new-btn:hover {
+  background: var(--color-green-700);
+}
+
+.chat-sidebar__list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+.chat-sidebar__loading,
+.chat-sidebar__empty {
+  padding: 1.5rem 1rem;
+  text-align: center;
+  color: var(--color-gray-400);
+  font-size: 0.85rem;
+}
+
+.chat-sidebar__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s;
+}
+
+.chat-sidebar__item:hover {
+  background: var(--color-gray-200);
+}
+
+.chat-sidebar__item--active {
+  background: var(--color-green-100);
+  border-left: 3px solid var(--color-green-600);
+}
+
+.chat-sidebar__item--active:hover {
+  background: var(--color-green-100);
+}
+
+.chat-sidebar__item-title {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-gray-800);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-sidebar__item-meta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.chat-sidebar__item-date {
+  font-size: 0.75rem;
+  color: var(--color-gray-400);
+}
+
+.chat-sidebar__item-count {
+  font-size: 0.7rem;
+  color: var(--color-gray-400);
+  background: var(--color-gray-200);
+  padding: 0.1rem 0.4rem;
+  border-radius: 8px;
+}
+
+.chat-sidebar__pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--color-gray-200);
+  flex-shrink: 0;
+}
+
+.chat-sidebar__page-btn {
+  padding: 0.3rem 0.75rem;
+  background: var(--color-gray-200);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+  cursor: pointer;
+  color: var(--color-gray-700);
+  font-family: inherit;
+}
+
+.chat-sidebar__page-btn:hover:not(:disabled) {
+  background: var(--color-gray-300);
+}
+
+.chat-sidebar__page-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.chat-sidebar__page-info {
+  font-size: 0.8rem;
+  color: var(--color-gray-500);
+}
+
+/* Mobile sidebar toggle */
+.chat-sidebar__toggle {
+  display: none;
+  position: fixed;
+  top: 5rem;
+  left: 0.75rem;
+  z-index: 50;
+  width: 36px;
+  height: 36px;
+  background: var(--color-green-600);
+  color: white;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--shadow-md);
+}
+
+.chat-sidebar__toggle:hover {
+  background: var(--color-green-700);
+}
+
+.chat-sidebar__overlay {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .chat-sidebar {
+    position: fixed;
+    top: 0;
+    left: -280px;
+    height: 100vh;
+    z-index: 100;
+    transition: left 0.25s ease;
+    box-shadow: none;
+  }
+
+  .chat-sidebar--open {
+    left: 0;
+    box-shadow: 4px 0 16px rgba(0, 0, 0, 0.15);
+  }
+
+  .chat-sidebar__toggle {
+    display: flex;
+  }
+
+  .chat-sidebar__overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.3);
+    z-index: 99;
+  }
+
+  .chat-layout {
+    height: calc(100vh - 4rem);
+  }
+}
+
 /* Chat */
 .chat-window {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 4rem);
-  max-width: 700px;
-  margin: 0 auto;
+  height: 100%;
+  flex: 1;
+  min-width: 0;
+  max-width: 100%;
+  padding: 0 1rem;
 }
 
 .chat-disclaimer {

--- a/components/chat/ChatSidebar.tsx
+++ b/components/chat/ChatSidebar.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface ChatSession {
+  id: string;
+  title: string;
+  report_id: string | null;
+  created_at: string;
+  updated_at: string;
+  message_count: number;
+}
+
+interface PaginationInfo {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+interface ChatSidebarProps {
+  activeSessionId: string | null;
+  onSelectSession: (sessionId: string) => void;
+  onNewChat: () => void;
+  /** Incremented by parent to signal the sidebar should refresh */
+  refreshKey?: number;
+}
+
+export function ChatSidebar({
+  activeSessionId,
+  onSelectSession,
+  onNewChat,
+  refreshKey,
+}: ChatSidebarProps) {
+  const [sessions, setSessions] = useState<ChatSession[]>([]);
+  const [pagination, setPagination] = useState<PaginationInfo>({
+    page: 1,
+    limit: 5,
+    total: 0,
+    totalPages: 0,
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const fetchSessions = useCallback(async (page: number) => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(
+        `/api/chat/sessions?page=${page}&limit=5`
+      );
+      if (!response.ok) throw new Error("Failed to load sessions");
+
+      const data = await response.json();
+      setSessions(data.sessions || []);
+      setPagination(data.pagination);
+    } catch {
+      // Silently fail — sidebar is non-critical
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // Load sessions on mount and when refreshKey changes
+  useEffect(() => {
+    fetchSessions(1);
+  }, [fetchSessions, refreshKey]);
+
+  const handlePageChange = (newPage: number) => {
+    fetchSessions(newPage);
+  };
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diff = now.getTime() - date.getTime();
+    const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+    if (days === 0) return "Today";
+    if (days === 1) return "Yesterday";
+    if (days < 7) return `${days} days ago`;
+    return date.toLocaleDateString();
+  };
+
+  return (
+    <>
+      {/* Mobile toggle button */}
+      <button
+        className="chat-sidebar__toggle"
+        onClick={() => setIsOpen(!isOpen)}
+        aria-label={isOpen ? "Close chat history" : "Open chat history"}
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          {isOpen ? (
+            <path
+              d="M6 6L14 14M14 6L6 14"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          ) : (
+            <>
+              <path d="M3 5H17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+              <path d="M3 10H17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+              <path d="M3 15H17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </>
+          )}
+        </svg>
+      </button>
+
+      {/* Overlay for mobile */}
+      {isOpen && (
+        <div
+          className="chat-sidebar__overlay"
+          onClick={() => setIsOpen(false)}
+        />
+      )}
+
+      <aside
+        className={`chat-sidebar ${isOpen ? "chat-sidebar--open" : ""}`}
+        aria-label="Chat history"
+      >
+        <div className="chat-sidebar__header">
+          <h2 className="chat-sidebar__title">Chat History</h2>
+          <button
+            className="chat-sidebar__new-btn"
+            onClick={() => {
+              onNewChat();
+              setIsOpen(false);
+            }}
+          >
+            + New Chat
+          </button>
+        </div>
+
+        <div className="chat-sidebar__list">
+          {isLoading && sessions.length === 0 && (
+            <div className="chat-sidebar__loading">Loading...</div>
+          )}
+
+          {!isLoading && sessions.length === 0 && (
+            <div className="chat-sidebar__empty">
+              No conversations yet. Start a new chat!
+            </div>
+          )}
+
+          {sessions.map((session) => (
+            <button
+              key={session.id}
+              className={`chat-sidebar__item ${
+                activeSessionId === session.id
+                  ? "chat-sidebar__item--active"
+                  : ""
+              }`}
+              onClick={() => {
+                onSelectSession(session.id);
+                setIsOpen(false);
+              }}
+              title={session.title}
+            >
+              <span className="chat-sidebar__item-title">
+                {session.title}
+              </span>
+              <span className="chat-sidebar__item-meta">
+                <span className="chat-sidebar__item-date">
+                  {formatDate(session.updated_at)}
+                </span>
+                {session.message_count > 0 && (
+                  <span className="chat-sidebar__item-count">
+                    {session.message_count} msg{session.message_count !== 1 ? "s" : ""}
+                  </span>
+                )}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        {pagination.totalPages > 1 && (
+          <div className="chat-sidebar__pagination">
+            <button
+              className="chat-sidebar__page-btn"
+              disabled={pagination.page <= 1}
+              onClick={() => handlePageChange(pagination.page - 1)}
+              aria-label="Previous page"
+            >
+              Prev
+            </button>
+            <span className="chat-sidebar__page-info">
+              {pagination.page} / {pagination.totalPages}
+            </span>
+            <button
+              className="chat-sidebar__page-btn"
+              disabled={pagination.page >= pagination.totalPages}
+              onClick={() => handlePageChange(pagination.page + 1)}
+              aria-label="Next page"
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </aside>
+    </>
+  );
+}

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useChat } from "@/hooks/useChat";
 import { MessageBubble, BotAvatar } from "./MessageBubble";
 import { ChatInput } from "./ChatInput";
+import { ChatSidebar } from "./ChatSidebar";
 import NavHeader from "@/components/ui/NavHeader";
 
 interface ChatWindowProps {
@@ -11,69 +12,96 @@ interface ChatWindowProps {
 }
 
 export function ChatWindow({ reportId }: ChatWindowProps) {
-  const { messages, isLoading, error, sendMessage } = useChat({ reportId });
+  const {
+    messages,
+    isLoading,
+    error,
+    sendMessage,
+    sessionId,
+    switchSession,
+    startNewChat,
+  } = useChat({ reportId });
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const [sidebarRefreshKey, setSidebarRefreshKey] = useState(0);
 
   // Auto-scroll to bottom on new messages
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, isLoading]);
 
+  // Refresh sidebar when messages change (new message sent or session loaded)
+  const prevMessageCountRef = useRef(0);
+  useEffect(() => {
+    if (messages.length > prevMessageCountRef.current) {
+      setSidebarRefreshKey((k) => k + 1);
+    }
+    prevMessageCountRef.current = messages.length;
+  }, [messages.length]);
+
   return (
-    <div className="chat-window">
-      <NavHeader backLabel="Dashboard" />
-      <div className="chat-disclaimer">
-        This AI helps you understand your health data in simple language. It
-        does not provide medical advice, diagnoses, or treatment
-        recommendations. Always consult your healthcare provider.
-      </div>
+    <div className="chat-layout">
+      <ChatSidebar
+        activeSessionId={sessionId}
+        onSelectSession={switchSession}
+        onNewChat={startNewChat}
+        refreshKey={sidebarRefreshKey}
+      />
 
-      <div className="chat-messages" role="log" aria-live="polite">
-        {messages.length === 0 && !isLoading && (
-          <div className="chat-welcome">
-            <h2>Welcome to HealthChat AI</h2>
-            <p>
-              Ask me anything about your lab results or medical reports.
-              I&apos;ll explain things in plain, simple language.
-            </p>
-            <div className="chat-suggestions">
-              <p>Try asking:</p>
-              <ul>
-                <li>&quot;What does my cholesterol level mean?&quot;</li>
-                <li>&quot;Are any of my results outside the normal range?&quot;</li>
-                <li>&quot;What questions should I ask my doctor?&quot;</li>
-              </ul>
-            </div>
-          </div>
-        )}
+      <div className="chat-window">
+        <NavHeader backLabel="Dashboard" />
+        <div className="chat-disclaimer">
+          This AI helps you understand your health data in simple language. It
+          does not provide medical advice, diagnoses, or treatment
+          recommendations. Always consult your healthcare provider.
+        </div>
 
-        {messages.map((msg) => (
-          <MessageBubble key={msg.id} message={msg} />
-        ))}
-
-        {isLoading && (
-          <div className="message-bubble-row message-assistant">
-            <BotAvatar />
-            <div className="message-bubble bubble-assistant">
-              <div className="typing-indicator" aria-label="AI is typing">
-                <span></span>
-                <span></span>
-                <span></span>
+        <div className="chat-messages" role="log" aria-live="polite">
+          {messages.length === 0 && !isLoading && (
+            <div className="chat-welcome">
+              <h2>Welcome to HealthChat AI</h2>
+              <p>
+                Ask me anything about your lab results or medical reports.
+                I&apos;ll explain things in plain, simple language.
+              </p>
+              <div className="chat-suggestions">
+                <p>Try asking:</p>
+                <ul>
+                  <li>&quot;What does my cholesterol level mean?&quot;</li>
+                  <li>&quot;Are any of my results outside the normal range?&quot;</li>
+                  <li>&quot;What questions should I ask my doctor?&quot;</li>
+                </ul>
               </div>
             </div>
-          </div>
-        )}
+          )}
 
-        {error && (
-          <div className="chat-error">
-            {error}
-          </div>
-        )}
+          {messages.map((msg) => (
+            <MessageBubble key={msg.id} message={msg} />
+          ))}
 
-        <div ref={messagesEndRef} />
+          {isLoading && (
+            <div className="message-bubble-row message-assistant">
+              <BotAvatar />
+              <div className="message-bubble bubble-assistant">
+                <div className="typing-indicator" aria-label="AI is typing">
+                  <span></span>
+                  <span></span>
+                  <span></span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="chat-error">
+              {error}
+            </div>
+          )}
+
+          <div ref={messagesEndRef} />
+        </div>
+
+        <ChatInput onSend={sendMessage} disabled={isLoading} />
       </div>
-
-      <ChatInput onSend={sendMessage} disabled={isLoading} />
     </div>
   );
 }

--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -184,6 +184,54 @@ export function useChat(options: UseChatOptions = {}) {
     setError(null);
   }, []);
 
+  /** Load an existing session's messages by ID */
+  const switchSession = useCallback(
+    async (targetSessionId: string) => {
+      // Abort any in-flight stream
+      abortRef.current?.abort();
+      setError(null);
+      setIsLoading(true);
+
+      try {
+        const response = await fetch(
+          `/api/chat/sessions/${targetSessionId}/messages`
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to load session");
+        }
+
+        const data = await response.json();
+        const loaded: ChatMessage[] = (data.messages || []).map(
+          (msg: { id: string; role: "user" | "assistant"; content: string; created_at: string }) => ({
+            id: msg.id,
+            role: msg.role,
+            content: msg.content,
+            timestamp: new Date(msg.created_at),
+          })
+        );
+
+        setMessages(loaded);
+        setSessionId(targetSessionId);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to load session";
+        setError(message);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    []
+  );
+
+  /** Start a new chat — clears messages and session */
+  const startNewChat = useCallback(() => {
+    abortRef.current?.abort();
+    setMessages([]);
+    setSessionId(null);
+    setError(null);
+  }, []);
+
   return {
     messages,
     isLoading,
@@ -191,5 +239,7 @@ export function useChat(options: UseChatOptions = {}) {
     sendMessage,
     clearChat,
     sessionId,
+    switchSession,
+    startNewChat,
   };
 }

--- a/supabase/migrations/008_chat_session_title.sql
+++ b/supabase/migrations/008_chat_session_title.sql
@@ -1,0 +1,3 @@
+-- Add title column to chat_sessions
+-- Title is auto-generated from the first user message (first 50 chars)
+ALTER TABLE chat_sessions ADD COLUMN title text;


### PR DESCRIPTION
## Summary

Implements #71 — Chat history sidebar with session list, titles, and pagination.

- **Sessions API** (`GET /api/chat/sessions`): Returns paginated list of user's chat sessions (5/page) with title, date, message count. Titles auto-generated from first user message (50 char truncation).
- **Session Messages API** (`GET /api/chat/sessions/:id/messages`): Loads full message history for a session to support session switching.
- **ChatSidebar component**: Displays past sessions in a left sidebar (280px). Includes "New Chat" button, active session highlighting, prev/next pagination. Collapses to hamburger menu on mobile (< 768px).
- **useChat hook**: Added `switchSession(id)` and `startNewChat()` functions for navigating between sessions.
- **Chat API update**: Auto-sets `title` column from first user message when creating new sessions. Updates `updated_at` timestamp after message persistence.
- **Migration 008**: Adds nullable `title` column to `chat_sessions` table.
- **CSS**: BEM-named styles with green theme, responsive mobile sidebar with overlay.

## Files Changed

| File | Change |
|------|--------|
| `supabase/migrations/008_chat_session_title.sql` | New migration for title column |
| `app/api/chat/sessions/route.ts` | New sessions list API |
| `app/api/chat/sessions/[sessionId]/messages/route.ts` | New session messages API |
| `components/chat/ChatSidebar.tsx` | New sidebar component |
| `components/chat/ChatWindow.tsx` | Integrated sidebar into layout |
| `hooks/useChat.ts` | Added switchSession and startNewChat |
| `app/api/chat/route.ts` | Title generation + updated_at |
| `app/globals.css` | Sidebar styles + responsive |
| `__tests__/chat-sidebar.test.ts` | 22 new tests |

## Test plan

- [x] `npm run lint` passes (0 errors)
- [x] `npm run typecheck` passes (0 errors)
- [x] `npx vitest run` passes (403 tests, 21 files, 0 failures)
- [ ] Manual: Verify sidebar loads on /chat page
- [ ] Manual: Click session to load its messages
- [ ] Manual: "New Chat" button clears current session
- [ ] Manual: Pagination works with > 5 sessions
- [ ] Manual: Mobile hamburger menu opens/closes sidebar

Closes #71