### PR TITLE
feat(chat): add report selector to attach reports to chat sessions

### DIFF
--- a/__tests__/chat-report-selector.test.ts
+++ b/__tests__/chat-report-selector.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetch = vi.fn();
+
+describe("Chat Report Selector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(globalThis, "fetch").mockImplementation(mockFetch);
+  });
+
+  describe("ReportSelector component", () => {
+    it("exports ReportSelector component", async () => {
+      const mod = await import("@/components/chat/ReportSelector");
+      expect(mod.ReportSelector).toBeDefined();
+      expect(typeof mod.ReportSelector).toBe("function");
+    });
+  });
+
+  describe("Reports API contract for selector", () => {
+    it("fetches reports from /api/reports", async () => {
+      const mockReports = {
+        reports: [
+          {
+            id: "report-1",
+            file_name: "blood-work.pdf",
+            file_type: "application/pdf",
+            status: "parsed",
+            created_at: "2026-03-15T10:00:00Z",
+          },
+          {
+            id: "report-2",
+            file_name: "lipid-panel.pdf",
+            file_type: "application/pdf",
+            status: "parsed",
+            created_at: "2026-03-10T09:00:00Z",
+          },
+          {
+            id: "report-3",
+            file_name: "pending-report.pdf",
+            file_type: "application/pdf",
+            status: "pending",
+            created_at: "2026-03-20T08:00:00Z",
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockReports,
+      });
+
+      const response = await fetch("/api/reports");
+      const data = await response.json();
+
+      expect(mockFetch).toHaveBeenCalledWith("/api/reports");
+      expect(data.reports).toHaveLength(3);
+
+      // Only parsed reports should be shown in selector
+      const parsedReports = data.reports.filter(
+        (r: { status: string }) => r.status === "parsed"
+      );
+      expect(parsedReports).toHaveLength(2);
+    });
+
+    it("returns reports with file_name, status, and created_at", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          reports: [
+            {
+              id: "report-1",
+              file_name: "blood-work.pdf",
+              file_type: "application/pdf",
+              status: "parsed",
+              created_at: "2026-03-15T10:00:00Z",
+            },
+          ],
+        }),
+      });
+
+      const response = await fetch("/api/reports");
+      const data = await response.json();
+
+      expect(data.reports[0]).toHaveProperty("id");
+      expect(data.reports[0]).toHaveProperty("file_name");
+      expect(data.reports[0]).toHaveProperty("status");
+      expect(data.reports[0]).toHaveProperty("created_at");
+    });
+  });
+
+  describe("useChat attach/detach report", () => {
+    it("useChat source includes attachReport and detachReport", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const hookPath = path.resolve(
+        __dirname,
+        "../hooks/useChat.ts"
+      );
+      const source = fs.readFileSync(hookPath, "utf-8");
+
+      expect(source).toContain("attachReport");
+      expect(source).toContain("detachReport");
+      expect(source).toContain("attachedReport");
+    });
+
+    it("exports AttachedReport interface", async () => {
+      const mod = await import("@/hooks/useChat");
+      // The module should export the hook that returns attach/detach functions
+      expect(mod.useChat).toBeDefined();
+    });
+
+    it("useChat uses effectiveReportId for API calls", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const hookPath = path.resolve(
+        __dirname,
+        "../hooks/useChat.ts"
+      );
+      const source = fs.readFileSync(hookPath, "utf-8");
+
+      expect(source).toContain("effectiveReportId");
+      expect(source).toContain(
+        "report_id: effectiveReportId"
+      );
+    });
+
+    it("startNewChat clears attachedReport", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const hookPath = path.resolve(
+        __dirname,
+        "../hooks/useChat.ts"
+      );
+      const source = fs.readFileSync(hookPath, "utf-8");
+
+      expect(source).toContain("setAttachedReport(null)");
+    });
+  });
+
+  describe("Report context indicator", () => {
+    it("ChatWindow source includes report indicator markup", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const componentPath = path.resolve(
+        __dirname,
+        "../components/chat/ChatWindow.tsx"
+      );
+      const source = fs.readFileSync(componentPath, "utf-8");
+
+      expect(source).toContain("chat-report-indicator");
+      expect(source).toContain("Discussing:");
+      expect(source).toContain("Detach report");
+    });
+
+    it("ChatWindow imports and renders ReportSelector", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const componentPath = path.resolve(
+        __dirname,
+        "../components/chat/ChatWindow.tsx"
+      );
+      const source = fs.readFileSync(componentPath, "utf-8");
+
+      expect(source).toContain("ReportSelector");
+      expect(source).toContain("showReportSelector");
+      expect(source).toContain("selectorDismissed");
+    });
+
+    it("ChatWindow uses attachReport and detachReport from useChat", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const componentPath = path.resolve(
+        __dirname,
+        "../components/chat/ChatWindow.tsx"
+      );
+      const source = fs.readFileSync(componentPath, "utf-8");
+
+      expect(source).toContain("attachReport");
+      expect(source).toContain("detachReport");
+      expect(source).toContain("attachedReport");
+    });
+
+    it("report selector only shows when no reportId prop, no session, and not dismissed", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const componentPath = path.resolve(
+        __dirname,
+        "../components/chat/ChatWindow.tsx"
+      );
+      const source = fs.readFileSync(componentPath, "utf-8");
+
+      // Check the condition logic
+      expect(source).toContain("!reportId");
+      expect(source).toContain("!sessionId");
+      expect(source).toContain("!selectorDismissed");
+      expect(source).toContain("!attachedReport");
+    });
+  });
+
+  describe("Chat API sends report_id from attached report", () => {
+    it("sends report_id in chat request body", async () => {
+      const sseData = 'data: {"type":"done"}\n\n';
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(sseData));
+            controller.close();
+          },
+        }),
+      });
+
+      await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: "Tell me about my results",
+          session_id: null,
+          report_id: "report-attached-1",
+        }),
+      });
+
+      const callBody = JSON.parse(
+        mockFetch.mock.calls[0][1].body as string
+      );
+      expect(callBody.report_id).toBe("report-attached-1");
+    });
+  });
+
+  describe("CSS classes exist", () => {
+    it("globals.css contains report-selector styles", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const cssPath = path.resolve(
+        __dirname,
+        "../app/globals.css"
+      );
+      const source = fs.readFileSync(cssPath, "utf-8");
+
+      expect(source).toContain(".report-selector");
+      expect(source).toContain(".report-selector__item");
+      expect(source).toContain(".report-selector__item--selected");
+      expect(source).toContain(".report-selector__skip");
+      expect(source).toContain(".chat-report-indicator");
+      expect(source).toContain(".chat-report-indicator__remove");
+    });
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -928,6 +928,128 @@ button.chat-send-button[type="submit"]:disabled {
   font-size: 0.85rem;
 }
 
+/* Report Selector */
+
+.report-selector {
+  background: #f0faf4;
+  border: 1px solid #b8e6cc;
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+  margin: 0.5rem 0.25rem 1rem;
+}
+
+.report-selector__prompt {
+  font-size: 0.95rem;
+  color: #1a3a2a;
+  margin: 0 0 0.75rem;
+  line-height: 1.4;
+}
+
+.report-selector__loading {
+  color: #5a8a6a;
+  font-size: 0.85rem;
+  padding: 0.5rem 0;
+}
+
+.report-selector__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.report-selector__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #fff;
+  border: 1px solid #d0e8d8;
+  border-radius: var(--radius-sm, 6px);
+  padding: 0.6rem 0.75rem;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  text-align: left;
+  width: 100%;
+  font-size: 0.875rem;
+}
+
+.report-selector__item:hover {
+  border-color: #4a9c6d;
+  background: #f7fdf9;
+}
+
+.report-selector__item--selected {
+  border-color: #2d8a4e;
+  background: #e8f5ee;
+}
+
+.report-selector__item-name {
+  font-weight: 500;
+  color: #1a3a2a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-right: 0.5rem;
+}
+
+.report-selector__item-date {
+  color: #6b8a7a;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.report-selector__skip {
+  background: none;
+  border: none;
+  color: #5a8a6a;
+  font-size: 0.85rem;
+  cursor: pointer;
+  padding: 0.25rem 0;
+  text-decoration: underline;
+}
+
+.report-selector__skip:hover {
+  color: #2d8a4e;
+}
+
+/* Report Context Indicator */
+
+.chat-report-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #e8f5ee;
+  border: 1px solid #b8e6cc;
+  border-radius: var(--radius-sm, 6px);
+  padding: 0.4rem 0.75rem;
+  margin: 0 0.75rem 0.25rem;
+  font-size: 0.8rem;
+}
+
+.chat-report-indicator__text {
+  color: #1a3a2a;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-report-indicator__remove {
+  background: none;
+  border: none;
+  color: #6b8a7a;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0 0.25rem;
+  line-height: 1;
+  margin-left: 0.5rem;
+  flex-shrink: 0;
+}
+
+.chat-report-indicator__remove:hover {
+  color: #cc0000;
+}
+
 /* =========================
    Health Summary Styles
    ========================= */

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -5,6 +5,7 @@ import { useChat } from "@/hooks/useChat";
 import { MessageBubble, BotAvatar } from "./MessageBubble";
 import { ChatInput } from "./ChatInput";
 import { ChatSidebar } from "./ChatSidebar";
+import { ReportSelector } from "./ReportSelector";
 import NavHeader from "@/components/ui/NavHeader";
 
 interface ChatWindowProps {
@@ -20,9 +21,18 @@ export function ChatWindow({ reportId }: ChatWindowProps) {
     sessionId,
     switchSession,
     startNewChat,
+    attachedReport,
+    attachReport,
+    detachReport,
   } = useChat({ reportId });
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [sidebarRefreshKey, setSidebarRefreshKey] = useState(0);
+  const [selectorDismissed, setSelectorDismissed] = useState(false);
+
+  // Show report selector when: no reportId prop, no active session, not dismissed,
+  // and no report already attached
+  const showReportSelector =
+    !reportId && !sessionId && !selectorDismissed && !attachedReport && messages.length === 0;
 
   // Auto-scroll to bottom on new messages
   useEffect(() => {
@@ -37,6 +47,18 @@ export function ChatWindow({ reportId }: ChatWindowProps) {
     }
     prevMessageCountRef.current = messages.length;
   }, [messages.length]);
+
+  // Reset selector dismissed state when starting a new chat
+  const prevSessionId = useRef(sessionId);
+  useEffect(() => {
+    if (prevSessionId.current !== null && sessionId === null) {
+      setSelectorDismissed(false);
+    }
+    prevSessionId.current = sessionId;
+  }, [sessionId]);
+
+  // Whether there is any report context active (prop or attached)
+  const hasReportContext = !!reportId || !!attachedReport;
 
   return (
     <div className="chat-layout">
@@ -56,7 +78,16 @@ export function ChatWindow({ reportId }: ChatWindowProps) {
         </div>
 
         <div className="chat-messages" role="log" aria-live="polite">
-          {messages.length === 0 && !isLoading && (
+          {showReportSelector && (
+            <ReportSelector
+              onSelect={(report) => {
+                attachReport(report);
+              }}
+              onSkip={() => setSelectorDismissed(true)}
+            />
+          )}
+
+          {messages.length === 0 && !isLoading && !showReportSelector && (
             <div className="chat-welcome">
               <h2>Welcome to HealthChat AI</h2>
               <p>
@@ -99,6 +130,22 @@ export function ChatWindow({ reportId }: ChatWindowProps) {
 
           <div ref={messagesEndRef} />
         </div>
+
+        {hasReportContext && attachedReport && (
+          <div className="chat-report-indicator" role="status">
+            <span className="chat-report-indicator__text">
+              Discussing: {attachedReport.filename} ({attachedReport.date})
+            </span>
+            <button
+              className="chat-report-indicator__remove"
+              onClick={detachReport}
+              type="button"
+              aria-label="Detach report"
+            >
+              x
+            </button>
+          </div>
+        )}
 
         <ChatInput onSend={sendMessage} disabled={isLoading} />
       </div>

--- a/components/chat/ReportSelector.tsx
+++ b/components/chat/ReportSelector.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import type { AttachedReport } from "@/hooks/useChat";
+
+interface Report {
+  id: string;
+  file_name: string;
+  file_type: string;
+  status: string;
+  created_at: string;
+}
+
+interface ReportSelectorProps {
+  onSelect: (report: AttachedReport) => void;
+  onSkip: () => void;
+}
+
+export function ReportSelector({ onSelect, onSkip }: ReportSelectorProps) {
+  const [reports, setReports] = useState<Report[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchReports() {
+      try {
+        const response = await fetch("/api/reports");
+        if (!response.ok) return;
+        const data = await response.json();
+        // Only show parsed (analyzed) reports
+        const parsed = (data.reports || []).filter(
+          (r: Report) => r.status === "parsed"
+        );
+        setReports(parsed);
+      } catch {
+        // Non-critical — silently fail
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    fetchReports();
+  }, []);
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  };
+
+  const handleSelect = (report: Report) => {
+    setSelectedId(report.id);
+    onSelect({
+      id: report.id,
+      filename: report.file_name,
+      date: formatDate(report.created_at),
+    });
+  };
+
+  // Don't show if no parsed reports available
+  if (!isLoading && reports.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="report-selector" role="region" aria-label="Report selector">
+      <p className="report-selector__prompt">
+        Want to discuss a specific report? Select one below, or just start
+        chatting!
+      </p>
+
+      {isLoading && (
+        <div className="report-selector__loading">Loading reports...</div>
+      )}
+
+      {!isLoading && (
+        <div className="report-selector__list">
+          {reports.map((report) => (
+            <button
+              key={report.id}
+              className={`report-selector__item ${
+                selectedId === report.id
+                  ? "report-selector__item--selected"
+                  : ""
+              }`}
+              onClick={() => handleSelect(report)}
+              type="button"
+            >
+              <span className="report-selector__item-name">
+                {report.file_name}
+              </span>
+              <span className="report-selector__item-date">
+                {formatDate(report.created_at)}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      <button
+        className="report-selector__skip"
+        onClick={onSkip}
+        type="button"
+      >
+        Skip — just chat
+      </button>
+    </div>
+  );
+}

--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -10,6 +10,12 @@ export interface ChatMessage {
   isStreaming?: boolean;
 }
 
+export interface AttachedReport {
+  id: string;
+  filename: string;
+  date: string;
+}
+
 interface UseChatOptions {
   reportId?: string;
 }
@@ -55,7 +61,11 @@ export function useChat(options: UseChatOptions = {}) {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [attachedReport, setAttachedReport] = useState<AttachedReport | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+
+  // Compute the effective report_id: prop takes precedence, then attached report
+  const effectiveReportId = options.reportId || attachedReport?.id;
 
   const sendMessage = useCallback(
     async (content: string) => {
@@ -85,7 +95,7 @@ export function useChat(options: UseChatOptions = {}) {
           body: JSON.stringify({
             message: content.trim(),
             session_id: sessionId,
-            report_id: options.reportId,
+            report_id: effectiveReportId,
           }),
           signal: controller.signal,
         });
@@ -173,7 +183,7 @@ export function useChat(options: UseChatOptions = {}) {
         abortRef.current = null;
       }
     },
-    [isLoading, sessionId, options.reportId]
+    [isLoading, sessionId, effectiveReportId]
   );
 
   const clearChat = useCallback(() => {
@@ -229,7 +239,18 @@ export function useChat(options: UseChatOptions = {}) {
     abortRef.current?.abort();
     setMessages([]);
     setSessionId(null);
+    setAttachedReport(null);
     setError(null);
+  }, []);
+
+  /** Attach a report to the current chat context */
+  const attachReport = useCallback((report: AttachedReport) => {
+    setAttachedReport(report);
+  }, []);
+
+  /** Detach the report from the chat context */
+  const detachReport = useCallback(() => {
+    setAttachedReport(null);
   }, []);
 
   return {
@@ -241,5 +262,8 @@ export function useChat(options: UseChatOptions = {}) {
     sessionId,
     switchSession,
     startNewChat,
+    attachedReport,
+    attachReport,
+    detachReport,
   };
 }


### PR DESCRIPTION
## Summary
- Add `ReportSelector` component that displays parsed reports when chat opens without a report context
- Add report context indicator bar above chat input showing attached report with detach button
- Extend `useChat` hook with `attachReport`/`detachReport` functions and `attachedReport` state
- Add BEM-styled CSS for report selector and context indicator (green theme)
- Add 13 tests covering component exports, API contract, hook behavior, and CSS classes

Closes #100

## Test plan
- [ ] Open chat without a report_id — verify report selector banner appears
- [ ] Select a parsed report — verify it attaches and indicator shows
- [ ] Click "Skip — just chat" — verify selector dismisses and welcome screen shows
- [ ] Click X on report indicator — verify report detaches
- [ ] Open chat via "Chat About Results" (with report_id) — verify selector does NOT appear
- [ ] Switch sessions in sidebar — verify selector resets on new chat
- [ ] All 416 tests pass (lint, typecheck, vitest)