### PR TITLE
feat(health): biomarker name normalization and synonym mapping

### DIFF
--- a/__tests__/biomarker-normalization.test.ts
+++ b/__tests__/biomarker-normalization.test.ts
@@ -1,0 +1,405 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeBiomarkerName,
+  normalizeUnit,
+} from "@/lib/health/normalize-biomarker";
+import { BIOMARKER_MAPPINGS, SYNONYM_INDEX } from "@/lib/health/biomarker-synonyms";
+
+// ── Synonym Map Integrity ──────────────────────────────────────────
+
+describe("Biomarker Synonym Map", () => {
+  it("covers at least 50 biomarker synonym entries", () => {
+    expect(SYNONYM_INDEX.size).toBeGreaterThanOrEqual(50);
+  });
+
+  it("has no duplicate synonyms across different canonical names", () => {
+    const seen = new Map<string, string>();
+    for (const mapping of BIOMARKER_MAPPINGS) {
+      for (const synonym of mapping.synonyms) {
+        const lower = synonym.toLowerCase();
+        const existing = seen.get(lower);
+        if (existing && existing !== mapping.canonical) {
+          throw new Error(
+            `Duplicate synonym "${lower}" found in both "${existing}" and "${mapping.canonical}"`
+          );
+        }
+        seen.set(lower, mapping.canonical);
+      }
+    }
+  });
+
+  it("all synonyms are lowercase", () => {
+    for (const mapping of BIOMARKER_MAPPINGS) {
+      for (const synonym of mapping.synonyms) {
+        expect(synonym).toBe(synonym.toLowerCase());
+      }
+    }
+  });
+
+  it("every mapping has a canonical name, category, and unit", () => {
+    for (const mapping of BIOMARKER_MAPPINGS) {
+      expect(mapping.canonical).toBeTruthy();
+      expect(mapping.category).toBeTruthy();
+      expect(mapping.unit).toBeTruthy();
+    }
+  });
+});
+
+// ── Name Normalization ─────────────────────────────────────────────
+
+describe("normalizeBiomarkerName", () => {
+  // --- Lipid Panel ---
+  describe("Lipid Panel", () => {
+    it.each([
+      ["Total Cholesterol", "Total Cholesterol"],
+      ["Chol", "Total Cholesterol"],
+      ["TC", "Total Cholesterol"],
+      ["Cholesterol, Total", "Total Cholesterol"],
+      ["cholesterol total", "Total Cholesterol"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+
+    it.each([
+      ["LDL", "LDL Cholesterol"],
+      ["ldl-c", "LDL Cholesterol"],
+      ["Low Density Lipoprotein", "LDL Cholesterol"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+
+    it.each([
+      ["HDL", "HDL Cholesterol"],
+      ["hdl-c", "HDL Cholesterol"],
+      ["High Density Lipoprotein", "HDL Cholesterol"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+
+    it.each([
+      ["Triglycerides", "Triglycerides"],
+      ["TG", "Triglycerides"],
+      ["Trigs", "Triglycerides"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+
+    it('maps "VLDL" to "VLDL Cholesterol"', () => {
+      expect(normalizeBiomarkerName("VLDL").canonical).toBe("VLDL Cholesterol");
+    });
+  });
+
+  // --- Metabolic ---
+  describe("Metabolic", () => {
+    it.each([
+      ["Glu", "Glucose (Fasting)"],
+      ["Glucose", "Glucose (Fasting)"],
+      ["FBS", "Glucose (Fasting)"],
+      ["Fasting Blood Sugar", "Glucose (Fasting)"],
+      ["Blood Sugar", "Glucose (Fasting)"],
+      ["GLUCOSE", "Glucose (Fasting)"],
+      ["Fasting Blood Glucose", "Glucose (Fasting)"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+
+    it.each([
+      ["HbA1c", "Hemoglobin A1C"],
+      ["A1C", "Hemoglobin A1C"],
+      ["Hemoglobin A1c", "Hemoglobin A1C"],
+      ["Glycated Hemoglobin", "Hemoglobin A1C"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+
+    it.each([
+      ["BUN", "BUN"],
+      ["Blood Urea Nitrogen", "BUN"],
+      ["Creatinine", "Creatinine"],
+      ["Creat", "Creatinine"],
+      ["eGFR", "eGFR"],
+      ["Estimated GFR", "eGFR"],
+      ["Uric Acid", "Uric Acid"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+  });
+
+  // --- Electrolytes ---
+  describe("Electrolytes", () => {
+    it.each([
+      ["Sodium", "Sodium"],
+      ["Na", "Sodium"],
+      ["Na+", "Sodium"],
+      ["Potassium", "Potassium"],
+      ["K", "Potassium"],
+      ["K+", "Potassium"],
+      ["Chloride", "Chloride"],
+      ["Cl", "Chloride"],
+      ["CO2", "CO2/Bicarbonate"],
+      ["Bicarbonate", "CO2/Bicarbonate"],
+      ["HCO3", "CO2/Bicarbonate"],
+      ["Calcium", "Calcium"],
+      ["Ca", "Calcium"],
+      ["Magnesium", "Magnesium"],
+      ["Phosphorus", "Phosphorus"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+  });
+
+  // --- Liver ---
+  describe("Liver", () => {
+    it.each([
+      ["ALT", "ALT"],
+      ["SGPT", "ALT"],
+      ["Alanine Aminotransferase", "ALT"],
+      ["AST", "AST"],
+      ["SGOT", "AST"],
+      ["Alkaline Phosphatase", "Alkaline Phosphatase"],
+      ["ALP", "Alkaline Phosphatase"],
+      ["Bilirubin", "Bilirubin Total"],
+      ["Total Bilirubin", "Bilirubin Total"],
+      ["Bilirubin Direct", "Bilirubin Direct"],
+      ["Direct Bilirubin", "Bilirubin Direct"],
+      ["Albumin", "Albumin"],
+      ["Total Protein", "Total Protein"],
+      ["GGT", "GGT"],
+      ["Gamma-Glutamyl Transferase", "GGT"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+  });
+
+  // --- CBC ---
+  describe("CBC", () => {
+    it.each([
+      ["WBC", "White Blood Cell Count"],
+      ["White Blood Cells", "White Blood Cell Count"],
+      ["Leukocytes", "White Blood Cell Count"],
+      ["RBC", "Red Blood Cell Count"],
+      ["Red Blood Cells", "Red Blood Cell Count"],
+      ["Hemoglobin", "Hemoglobin"],
+      ["Hgb", "Hemoglobin"],
+      ["Hb", "Hemoglobin"],
+      ["Hematocrit", "Hematocrit"],
+      ["HCT", "Hematocrit"],
+      ["Platelets", "Platelet Count"],
+      ["PLT", "Platelet Count"],
+      ["MCV", "MCV"],
+      ["Mean Corpuscular Volume", "MCV"],
+      ["MCH", "MCH"],
+      ["MCHC", "MCHC"],
+      ["RDW", "RDW"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+  });
+
+  // --- Thyroid ---
+  describe("Thyroid", () => {
+    it.each([
+      ["TSH", "TSH"],
+      ["Thyroid Stimulating Hormone", "TSH"],
+      ["Free T3", "Free T3"],
+      ["FT3", "Free T3"],
+      ["Free T4", "Free T4"],
+      ["FT4", "Free T4"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+  });
+
+  // --- Vitamins ---
+  describe("Vitamins & Minerals", () => {
+    it.each([
+      ["Vitamin D", "Vitamin D"],
+      ["25-Hydroxyvitamin D", "Vitamin D"],
+      ["Vitamin B12", "Vitamin B12"],
+      ["B12", "Vitamin B12"],
+      ["Cobalamin", "Vitamin B12"],
+      ["Folate", "Folate"],
+      ["Folic Acid", "Folate"],
+      ["Iron", "Iron"],
+      ["Serum Iron", "Iron"],
+      ["Fe", "Iron"],
+      ["Ferritin", "Ferritin"],
+      ["TIBC", "TIBC"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+  });
+
+  // --- Cardiovascular ---
+  describe("Cardiovascular", () => {
+    it.each([
+      ["Systolic", "Blood Pressure Systolic"],
+      ["SBP", "Blood Pressure Systolic"],
+      ["Diastolic", "Blood Pressure Diastolic"],
+      ["DBP", "Blood Pressure Diastolic"],
+      ["Heart Rate", "Resting Heart Rate"],
+      ["Pulse", "Resting Heart Rate"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+  });
+
+  // --- Body ---
+  describe("Body Measurements", () => {
+    it.each([
+      ["BMI", "BMI"],
+      ["Body Mass Index", "BMI"],
+      ["Weight", "Weight"],
+      ["Height", "Height"],
+    ])('maps "%s" to "%s"', (input, expected) => {
+      expect(normalizeBiomarkerName(input).canonical).toBe(expected);
+    });
+  });
+
+  // --- Case insensitivity ---
+  describe("Case insensitivity", () => {
+    it("handles uppercase input", () => {
+      expect(normalizeBiomarkerName("GLUCOSE").canonical).toBe("Glucose (Fasting)");
+    });
+
+    it("handles mixed case input", () => {
+      expect(normalizeBiomarkerName("hDl ChOlEsTeRoL").canonical).toBe("HDL Cholesterol");
+    });
+
+    it("handles all lowercase input", () => {
+      expect(normalizeBiomarkerName("hemoglobin a1c").canonical).toBe("Hemoglobin A1C");
+    });
+  });
+
+  // --- Prefix/suffix stripping ---
+  describe("Prefix/suffix stripping", () => {
+    it('strips "Serum" prefix', () => {
+      expect(normalizeBiomarkerName("Serum Glucose").canonical).toBe("Glucose (Fasting)");
+    });
+
+    it('strips "Blood" prefix', () => {
+      expect(normalizeBiomarkerName("Blood Creatinine").canonical).toBe("Creatinine");
+    });
+
+    it('strips "Level" suffix', () => {
+      expect(normalizeBiomarkerName("Glucose Level").canonical).toBe("Glucose (Fasting)");
+    });
+
+    it('strips "Test" suffix', () => {
+      expect(normalizeBiomarkerName("TSH Test").canonical).toBe("TSH");
+    });
+  });
+
+  // --- Unknown biomarkers ---
+  describe("Unknown biomarkers", () => {
+    it("returns original name for unknown biomarkers", () => {
+      const result = normalizeBiomarkerName("Mystery Substance X");
+      expect(result.canonical).toBe("Mystery Substance X");
+      expect(result.matched).toBe(false);
+      expect(result.category).toBe("Unknown");
+    });
+
+    it("handles empty string", () => {
+      const result = normalizeBiomarkerName("");
+      expect(result.canonical).toBe("");
+      expect(result.matched).toBe(false);
+    });
+
+    it("handles whitespace-only input", () => {
+      const result = normalizeBiomarkerName("   ");
+      expect(result.matched).toBe(false);
+    });
+  });
+
+  // --- Category assignment ---
+  describe("Category assignment", () => {
+    it("assigns Lipid Panel category", () => {
+      expect(normalizeBiomarkerName("LDL").category).toBe("Lipid Panel");
+    });
+
+    it("assigns Metabolic category", () => {
+      expect(normalizeBiomarkerName("Glucose").category).toBe("Metabolic");
+    });
+
+    it("assigns CBC category", () => {
+      expect(normalizeBiomarkerName("WBC").category).toBe("CBC");
+    });
+
+    it("assigns Liver category", () => {
+      expect(normalizeBiomarkerName("ALT").category).toBe("Liver");
+    });
+
+    it("assigns Thyroid category", () => {
+      expect(normalizeBiomarkerName("TSH").category).toBe("Thyroid");
+    });
+  });
+
+  // --- Word order variants ---
+  describe("Word order variants", () => {
+    it('handles "Cholesterol, Total" -> "Total Cholesterol"', () => {
+      expect(normalizeBiomarkerName("Cholesterol, Total").canonical).toBe(
+        "Total Cholesterol"
+      );
+    });
+
+    it('handles "Bilirubin, Direct" -> "Bilirubin Direct"', () => {
+      // "direct bilirubin" is a known synonym
+      expect(normalizeBiomarkerName("Bilirubin, Direct").canonical).toBe(
+        "Bilirubin Direct"
+      );
+    });
+  });
+});
+
+// ── Unit Normalization ─────────────────────────────────────────────
+
+describe("normalizeUnit", () => {
+  it("converts glucose from mmol/L to mg/dL", () => {
+    const result = normalizeUnit(5.5, "mmol/L", "Glucose (Fasting)");
+    expect(result.unit).toBe("mg/dL");
+    expect(result.value).toBeCloseTo(99.1, 0);
+  });
+
+  it("converts cholesterol from mmol/L to mg/dL", () => {
+    const result = normalizeUnit(5.0, "mmol/L", "Total Cholesterol");
+    expect(result.unit).toBe("mg/dL");
+    expect(result.value).toBeCloseTo(193.35, 0);
+  });
+
+  it("converts triglycerides from mmol/L to mg/dL", () => {
+    const result = normalizeUnit(1.7, "mmol/L", "Triglycerides");
+    expect(result.unit).toBe("mg/dL");
+    expect(result.value).toBeCloseTo(150.57, 0);
+  });
+
+  it("converts creatinine from umol/L to mg/dL", () => {
+    const result = normalizeUnit(88.4, "umol/L", "Creatinine");
+    expect(result.unit).toBe("mg/dL");
+    expect(result.value).toBeCloseTo(1.0, 0);
+  });
+
+  it("returns original when no conversion needed", () => {
+    const result = normalizeUnit(100, "mg/dL", "Glucose (Fasting)");
+    expect(result.unit).toBe("mg/dL");
+    expect(result.value).toBe(100);
+  });
+
+  it("returns original for unknown biomarker", () => {
+    const result = normalizeUnit(42, "widgets/L", "Mystery Marker");
+    expect(result.unit).toBe("widgets/L");
+    expect(result.value).toBe(42);
+  });
+
+  it("handles A1C IFCC to NGSP conversion", () => {
+    // 48 mmol/mol should be approximately 6.5%
+    const result = normalizeUnit(48, "mmol/mol", "Hemoglobin A1C");
+    expect(result.unit).toBe("%");
+    expect(result.value).toBeCloseTo(6.5, 0);
+  });
+
+  it("converts vitamin D from nmol/L to ng/mL", () => {
+    const result = normalizeUnit(75, "nmol/L", "Vitamin D");
+    expect(result.unit).toBe("ng/mL");
+    expect(result.value).toBeCloseTo(30, 0);
+  });
+});

--- a/app/api/parse/route.ts
+++ b/app/api/parse/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { parseReportWithClaude } from "@/lib/claude/parse-report";
 import { applyServerSideFlags } from "@/lib/health/flag-biomarker";
+import { normalizeBiomarkerName } from "@/lib/health/normalize-biomarker";
 import { logAuditEvent, getClientIp } from "@/lib/audit/logger";
 import { NextResponse } from "next/server";
 
@@ -108,14 +109,29 @@ export async function POST(request: Request) {
     const reflaggedBiomarkers = applyServerSideFlags(parsed.biomarkers);
     const reflaggedParsed = { ...parsed, biomarkers: reflaggedBiomarkers };
 
-    console.log("[PARSE] Server-side flags applied. Storing results...");
+    // Normalize biomarker names to canonical form (#51)
+    // This maps lab-specific names (e.g., "Glu", "FBS") to canonical names
+    // (e.g., "Glucose (Fasting)") while preserving the original extracted name.
+    const normalizedBiomarkers = reflaggedBiomarkers.map((b) => {
+      const norm = normalizeBiomarkerName(b.name);
+      return {
+        ...b,
+        name: norm.canonical,
+        original_name: b.name,
+        category: norm.category,
+      };
+    });
+
+    const normalizedParsed = { ...parsed, biomarkers: normalizedBiomarkers };
+
+    console.log("[PARSE] Biomarker names normalized. Storing results...");
     // Store parsed results
     const { data: parsedResult, error: insertError } = await supabase
       .from("parsed_results")
       .insert({
         report_id: report.id,
-        raw_extraction: reflaggedParsed,
-        biomarkers: reflaggedBiomarkers,
+        raw_extraction: normalizedParsed,
+        biomarkers: normalizedBiomarkers,
         summary_plain: parsed.summary,
       })
       .select("id")
@@ -134,8 +150,8 @@ export async function POST(request: Request) {
     }
     console.log("[PARSE] Stored parsed_result:", parsedResult.id);
 
-    // Create risk flags for each biomarker (using server-side flags)
-    const riskFlags = reflaggedBiomarkers
+    // Create risk flags for each biomarker (using server-side flags + normalized names)
+    const riskFlags = normalizedBiomarkers
       .filter((b) => b.flag && b.value != null)
       .map((b) => ({
         parsed_result_id: parsedResult.id,

--- a/lib/health/biomarker-synonyms.ts
+++ b/lib/health/biomarker-synonyms.ts
@@ -1,0 +1,820 @@
+/**
+ * Biomarker synonym-to-canonical-name mapping.
+ *
+ * This is the SINGLE SOURCE OF TRUTH for biomarker name normalization.
+ * All synonyms are stored lowercase for case-insensitive matching.
+ *
+ * Covers: Lipids, Metabolic, Electrolytes, Liver, CBC, Thyroid,
+ * Vitamins/Minerals, Cardiovascular, and Body measurements.
+ */
+
+export interface BiomarkerMapping {
+  /** Standardized display name */
+  canonical: string;
+  /** Category grouping (e.g., "Lipid Panel", "Metabolic") */
+  category: string;
+  /** All known alternate names (lowercase, trimmed) */
+  synonyms: string[];
+  /** Standard unit of measurement */
+  unit: string;
+  /** Optional LOINC code for interoperability */
+  loincCode?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Lipid Panel
+// ---------------------------------------------------------------------------
+
+const LIPID_PANEL: BiomarkerMapping[] = [
+  {
+    canonical: "Total Cholesterol",
+    category: "Lipid Panel",
+    synonyms: [
+      "total cholesterol",
+      "cholesterol total",
+      "cholesterol",
+      "tc",
+      "total chol",
+      "chol",
+      "cholesterol, total",
+      "serum cholesterol",
+    ],
+    unit: "mg/dL",
+    loincCode: "2093-3",
+  },
+  {
+    canonical: "LDL Cholesterol",
+    category: "Lipid Panel",
+    synonyms: [
+      "ldl cholesterol",
+      "ldl",
+      "ldl-c",
+      "low density lipoprotein",
+      "ldl chol",
+      "ldl cholesterol direct",
+      "ldl direct",
+      "ldl-cholesterol",
+      "low density lipoprotein cholesterol",
+    ],
+    unit: "mg/dL",
+    loincCode: "2089-1",
+  },
+  {
+    canonical: "HDL Cholesterol",
+    category: "Lipid Panel",
+    synonyms: [
+      "hdl cholesterol",
+      "hdl",
+      "hdl-c",
+      "high density lipoprotein",
+      "hdl chol",
+      "hdl-cholesterol",
+      "high density lipoprotein cholesterol",
+    ],
+    unit: "mg/dL",
+    loincCode: "2085-9",
+  },
+  {
+    canonical: "Triglycerides",
+    category: "Lipid Panel",
+    synonyms: [
+      "triglycerides",
+      "triglyceride",
+      "trigs",
+      "trig",
+      "tg",
+      "serum triglycerides",
+    ],
+    unit: "mg/dL",
+    loincCode: "2571-8",
+  },
+  {
+    canonical: "Cholesterol/HDL Ratio",
+    category: "Lipid Panel",
+    synonyms: [
+      "cholesterol/hdl ratio",
+      "chol/hdl ratio",
+      "cholesterol hdl ratio",
+      "tc/hdl ratio",
+      "total cholesterol/hdl",
+      "chol hdl ratio",
+      "tc/hdl",
+      "cholesterol ratio",
+    ],
+    unit: "ratio",
+    loincCode: "9830-1",
+  },
+  {
+    canonical: "VLDL Cholesterol",
+    category: "Lipid Panel",
+    synonyms: [
+      "vldl cholesterol",
+      "vldl",
+      "vldl-c",
+      "very low density lipoprotein",
+      "vldl chol",
+    ],
+    unit: "mg/dL",
+    loincCode: "13458-5",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Metabolic Panel
+// ---------------------------------------------------------------------------
+
+const METABOLIC: BiomarkerMapping[] = [
+  {
+    canonical: "Glucose (Fasting)",
+    category: "Metabolic",
+    synonyms: [
+      "glucose",
+      "fasting glucose",
+      "blood glucose",
+      "blood sugar",
+      "fbs",
+      "fasting blood sugar",
+      "fasting blood glucose",
+      "fbg",
+      "glucose fasting",
+      "serum glucose",
+      "plasma glucose",
+      "glu",
+      "glucose, fasting",
+      "fasting plasma glucose",
+      "fpg",
+    ],
+    unit: "mg/dL",
+    loincCode: "1558-6",
+  },
+  {
+    canonical: "Hemoglobin A1C",
+    category: "Metabolic",
+    synonyms: [
+      "a1c",
+      "hba1c",
+      "hemoglobin a1c",
+      "glycated hemoglobin",
+      "glycosylated hemoglobin",
+      "hb a1c",
+      "ha1c",
+      "hemoglobin a1c %",
+      "glycohemoglobin",
+      "hgb a1c",
+    ],
+    unit: "%",
+    loincCode: "4548-4",
+  },
+  {
+    canonical: "BUN",
+    category: "Metabolic",
+    synonyms: [
+      "bun",
+      "blood urea nitrogen",
+      "urea nitrogen",
+      "urea",
+      "serum urea nitrogen",
+    ],
+    unit: "mg/dL",
+    loincCode: "3094-0",
+  },
+  {
+    canonical: "Creatinine",
+    category: "Metabolic",
+    synonyms: [
+      "creatinine",
+      "creat",
+      "serum creatinine",
+      "cr",
+      "creatinine serum",
+      "blood creatinine",
+    ],
+    unit: "mg/dL",
+    loincCode: "2160-0",
+  },
+  {
+    canonical: "eGFR",
+    category: "Metabolic",
+    synonyms: [
+      "egfr",
+      "estimated gfr",
+      "estimated glomerular filtration rate",
+      "glomerular filtration rate",
+      "gfr",
+      "egfr non-african american",
+      "egfr african american",
+    ],
+    unit: "mL/min/1.73m2",
+    loincCode: "48642-3",
+  },
+  {
+    canonical: "Uric Acid",
+    category: "Metabolic",
+    synonyms: [
+      "uric acid",
+      "urate",
+      "serum uric acid",
+    ],
+    unit: "mg/dL",
+    loincCode: "3084-1",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Electrolytes
+// ---------------------------------------------------------------------------
+
+const ELECTROLYTES: BiomarkerMapping[] = [
+  {
+    canonical: "Sodium",
+    category: "Electrolytes",
+    synonyms: [
+      "sodium",
+      "na",
+      "na+",
+      "serum sodium",
+      "blood sodium",
+    ],
+    unit: "mEq/L",
+    loincCode: "2951-2",
+  },
+  {
+    canonical: "Potassium",
+    category: "Electrolytes",
+    synonyms: [
+      "potassium",
+      "k",
+      "k+",
+      "serum potassium",
+      "blood potassium",
+    ],
+    unit: "mEq/L",
+    loincCode: "2823-3",
+  },
+  {
+    canonical: "Chloride",
+    category: "Electrolytes",
+    synonyms: [
+      "chloride",
+      "cl",
+      "cl-",
+      "serum chloride",
+    ],
+    unit: "mEq/L",
+    loincCode: "2075-0",
+  },
+  {
+    canonical: "CO2/Bicarbonate",
+    category: "Electrolytes",
+    synonyms: [
+      "co2",
+      "bicarbonate",
+      "hco3",
+      "carbon dioxide",
+      "total co2",
+      "co2 total",
+      "serum bicarbonate",
+      "bicarb",
+    ],
+    unit: "mEq/L",
+    loincCode: "2028-9",
+  },
+  {
+    canonical: "Calcium",
+    category: "Electrolytes",
+    synonyms: [
+      "calcium",
+      "ca",
+      "ca2+",
+      "serum calcium",
+      "total calcium",
+      "blood calcium",
+    ],
+    unit: "mg/dL",
+    loincCode: "17861-6",
+  },
+  {
+    canonical: "Magnesium",
+    category: "Electrolytes",
+    synonyms: [
+      "magnesium",
+      "mg",
+      "serum magnesium",
+      "mag",
+      "blood magnesium",
+    ],
+    unit: "mg/dL",
+    loincCode: "19123-9",
+  },
+  {
+    canonical: "Phosphorus",
+    category: "Electrolytes",
+    synonyms: [
+      "phosphorus",
+      "phos",
+      "phosphate",
+      "serum phosphorus",
+      "inorganic phosphorus",
+    ],
+    unit: "mg/dL",
+    loincCode: "2777-1",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Liver Function
+// ---------------------------------------------------------------------------
+
+const LIVER: BiomarkerMapping[] = [
+  {
+    canonical: "ALT",
+    category: "Liver",
+    synonyms: [
+      "alt",
+      "alanine aminotransferase",
+      "sgpt",
+      "alanine transaminase",
+      "serum alt",
+      "alt/sgpt",
+    ],
+    unit: "U/L",
+    loincCode: "1742-6",
+  },
+  {
+    canonical: "AST",
+    category: "Liver",
+    synonyms: [
+      "ast",
+      "aspartate aminotransferase",
+      "sgot",
+      "aspartate transaminase",
+      "serum ast",
+      "ast/sgot",
+    ],
+    unit: "U/L",
+    loincCode: "1920-8",
+  },
+  {
+    canonical: "Alkaline Phosphatase",
+    category: "Liver",
+    synonyms: [
+      "alkaline phosphatase",
+      "alp",
+      "alk phos",
+      "alkp",
+      "alk phosphatase",
+      "serum alkaline phosphatase",
+    ],
+    unit: "U/L",
+    loincCode: "6768-6",
+  },
+  {
+    canonical: "Bilirubin Total",
+    category: "Liver",
+    synonyms: [
+      "bilirubin total",
+      "bilirubin",
+      "total bilirubin",
+      "tbili",
+      "t. bilirubin",
+      "t bilirubin",
+      "serum bilirubin",
+    ],
+    unit: "mg/dL",
+    loincCode: "1975-2",
+  },
+  {
+    canonical: "Bilirubin Direct",
+    category: "Liver",
+    synonyms: [
+      "bilirubin direct",
+      "direct bilirubin",
+      "dbili",
+      "d. bilirubin",
+      "conjugated bilirubin",
+    ],
+    unit: "mg/dL",
+    loincCode: "1968-7",
+  },
+  {
+    canonical: "Albumin",
+    category: "Liver",
+    synonyms: [
+      "albumin",
+      "alb",
+      "serum albumin",
+      "blood albumin",
+    ],
+    unit: "g/dL",
+    loincCode: "1751-7",
+  },
+  {
+    canonical: "Total Protein",
+    category: "Liver",
+    synonyms: [
+      "total protein",
+      "tp",
+      "serum protein",
+      "protein total",
+      "serum total protein",
+    ],
+    unit: "g/dL",
+    loincCode: "2885-2",
+  },
+  {
+    canonical: "GGT",
+    category: "Liver",
+    synonyms: [
+      "ggt",
+      "gamma-glutamyl transferase",
+      "gamma glutamyl transferase",
+      "gamma-gt",
+      "ggtp",
+      "gamma glutamyl transpeptidase",
+    ],
+    unit: "U/L",
+    loincCode: "2324-2",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Complete Blood Count (CBC)
+// ---------------------------------------------------------------------------
+
+const CBC: BiomarkerMapping[] = [
+  {
+    canonical: "White Blood Cell Count",
+    category: "CBC",
+    synonyms: [
+      "white blood cell count",
+      "wbc",
+      "white blood cells",
+      "white cell count",
+      "leukocytes",
+      "leukocyte count",
+      "wbc count",
+      "total wbc",
+    ],
+    unit: "/mcL",
+    loincCode: "6690-2",
+  },
+  {
+    canonical: "Red Blood Cell Count",
+    category: "CBC",
+    synonyms: [
+      "red blood cell count",
+      "rbc",
+      "red blood cells",
+      "red cell count",
+      "erythrocytes",
+      "erythrocyte count",
+      "rbc count",
+    ],
+    unit: "M/mcL",
+    loincCode: "789-8",
+  },
+  {
+    canonical: "Hemoglobin",
+    category: "CBC",
+    synonyms: [
+      "hemoglobin",
+      "hgb",
+      "hb",
+      "blood hemoglobin",
+    ],
+    unit: "g/dL",
+    loincCode: "718-7",
+  },
+  {
+    canonical: "Hematocrit",
+    category: "CBC",
+    synonyms: [
+      "hematocrit",
+      "hct",
+      "packed cell volume",
+      "pcv",
+    ],
+    unit: "%",
+    loincCode: "4544-3",
+  },
+  {
+    canonical: "Platelet Count",
+    category: "CBC",
+    synonyms: [
+      "platelet count",
+      "platelets",
+      "plt",
+      "thrombocytes",
+      "thrombocyte count",
+      "platelet",
+    ],
+    unit: "/mcL",
+    loincCode: "777-3",
+  },
+  {
+    canonical: "MCV",
+    category: "CBC",
+    synonyms: [
+      "mcv",
+      "mean corpuscular volume",
+      "mean cell volume",
+    ],
+    unit: "fL",
+    loincCode: "787-2",
+  },
+  {
+    canonical: "MCH",
+    category: "CBC",
+    synonyms: [
+      "mch",
+      "mean corpuscular hemoglobin",
+      "mean cell hemoglobin",
+    ],
+    unit: "pg",
+    loincCode: "785-6",
+  },
+  {
+    canonical: "MCHC",
+    category: "CBC",
+    synonyms: [
+      "mchc",
+      "mean corpuscular hemoglobin concentration",
+      "mean cell hemoglobin concentration",
+    ],
+    unit: "g/dL",
+    loincCode: "786-4",
+  },
+  {
+    canonical: "RDW",
+    category: "CBC",
+    synonyms: [
+      "rdw",
+      "red cell distribution width",
+      "rdw-cv",
+      "red blood cell distribution width",
+    ],
+    unit: "%",
+    loincCode: "788-0",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Thyroid
+// ---------------------------------------------------------------------------
+
+const THYROID: BiomarkerMapping[] = [
+  {
+    canonical: "TSH",
+    category: "Thyroid",
+    synonyms: [
+      "tsh",
+      "thyroid stimulating hormone",
+      "thyrotropin",
+      "thyroid-stimulating hormone",
+      "serum tsh",
+    ],
+    unit: "mIU/L",
+    loincCode: "3016-3",
+  },
+  {
+    canonical: "Free T3",
+    category: "Thyroid",
+    synonyms: [
+      "free t3",
+      "ft3",
+      "free triiodothyronine",
+      "triiodothyronine free",
+      "t3 free",
+    ],
+    unit: "pg/mL",
+    loincCode: "3051-0",
+  },
+  {
+    canonical: "Free T4",
+    category: "Thyroid",
+    synonyms: [
+      "free t4",
+      "ft4",
+      "free thyroxine",
+      "thyroxine free",
+      "t4 free",
+    ],
+    unit: "ng/dL",
+    loincCode: "3024-7",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Vitamins & Minerals
+// ---------------------------------------------------------------------------
+
+const VITAMINS: BiomarkerMapping[] = [
+  {
+    canonical: "Vitamin D",
+    category: "Vitamins",
+    synonyms: [
+      "vitamin d",
+      "vit d",
+      "25-hydroxyvitamin d",
+      "25-oh vitamin d",
+      "25(oh)d",
+      "calcidiol",
+      "vitamin d 25-hydroxy",
+      "vitamin d3",
+      "25-hydroxy vitamin d",
+    ],
+    unit: "ng/mL",
+    loincCode: "1989-3",
+  },
+  {
+    canonical: "Vitamin B12",
+    category: "Vitamins",
+    synonyms: [
+      "vitamin b12",
+      "vit b12",
+      "b12",
+      "cobalamin",
+      "cyanocobalamin",
+    ],
+    unit: "pg/mL",
+    loincCode: "2132-9",
+  },
+  {
+    canonical: "Folate",
+    category: "Vitamins",
+    synonyms: [
+      "folate",
+      "folic acid",
+      "vitamin b9",
+      "serum folate",
+      "blood folate",
+    ],
+    unit: "ng/mL",
+    loincCode: "2284-8",
+  },
+  {
+    canonical: "Iron",
+    category: "Vitamins",
+    synonyms: [
+      "iron",
+      "serum iron",
+      "fe",
+      "blood iron",
+    ],
+    unit: "mcg/dL",
+    loincCode: "2498-4",
+  },
+  {
+    canonical: "Ferritin",
+    category: "Vitamins",
+    synonyms: [
+      "ferritin",
+      "serum ferritin",
+      "blood ferritin",
+    ],
+    unit: "ng/mL",
+    loincCode: "2276-4",
+  },
+  {
+    canonical: "TIBC",
+    category: "Vitamins",
+    synonyms: [
+      "tibc",
+      "total iron binding capacity",
+      "iron binding capacity",
+      "total iron-binding capacity",
+    ],
+    unit: "mcg/dL",
+    loincCode: "2500-7",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Cardiovascular
+// ---------------------------------------------------------------------------
+
+const CARDIOVASCULAR: BiomarkerMapping[] = [
+  {
+    canonical: "Blood Pressure Systolic",
+    category: "Cardiovascular",
+    synonyms: [
+      "blood pressure systolic",
+      "systolic blood pressure",
+      "systolic bp",
+      "systolic",
+      "sbp",
+      "bp systolic",
+    ],
+    unit: "mmHg",
+    loincCode: "8480-6",
+  },
+  {
+    canonical: "Blood Pressure Diastolic",
+    category: "Cardiovascular",
+    synonyms: [
+      "blood pressure diastolic",
+      "diastolic blood pressure",
+      "diastolic bp",
+      "diastolic",
+      "dbp",
+      "bp diastolic",
+    ],
+    unit: "mmHg",
+    loincCode: "8462-4",
+  },
+  {
+    canonical: "Resting Heart Rate",
+    category: "Cardiovascular",
+    synonyms: [
+      "resting heart rate",
+      "heart rate",
+      "pulse",
+      "rhr",
+      "hr",
+      "pulse rate",
+    ],
+    unit: "bpm",
+    loincCode: "8867-4",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Body Measurements
+// ---------------------------------------------------------------------------
+
+const BODY: BiomarkerMapping[] = [
+  {
+    canonical: "BMI",
+    category: "Body",
+    synonyms: [
+      "bmi",
+      "body mass index",
+    ],
+    unit: "kg/m2",
+    loincCode: "39156-5",
+  },
+  {
+    canonical: "Weight",
+    category: "Body",
+    synonyms: [
+      "weight",
+      "body weight",
+      "wt",
+    ],
+    unit: "lbs",
+    loincCode: "29463-7",
+  },
+  {
+    canonical: "Height",
+    category: "Body",
+    synonyms: [
+      "height",
+      "body height",
+      "stature",
+      "ht",
+    ],
+    unit: "in",
+    loincCode: "8302-2",
+  },
+  {
+    canonical: "Waist-to-Height Ratio",
+    category: "Body",
+    synonyms: [
+      "waist-to-height ratio",
+      "waist to height ratio",
+      "whtr",
+      "waist height ratio",
+    ],
+    unit: "ratio",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Exported composite list — SINGLE SOURCE OF TRUTH
+// ---------------------------------------------------------------------------
+
+export const BIOMARKER_MAPPINGS: BiomarkerMapping[] = [
+  ...LIPID_PANEL,
+  ...METABOLIC,
+  ...ELECTROLYTES,
+  ...LIVER,
+  ...CBC,
+  ...THYROID,
+  ...VITAMINS,
+  ...CARDIOVASCULAR,
+  ...BODY,
+];
+
+/**
+ * Pre-built lookup: lowercase synonym -> BiomarkerMapping.
+ * Used by the normalization function for O(1) lookups.
+ */
+export const SYNONYM_INDEX: Map<string, BiomarkerMapping> = (() => {
+  const map = new Map<string, BiomarkerMapping>();
+  for (const mapping of BIOMARKER_MAPPINGS) {
+    for (const synonym of mapping.synonyms) {
+      map.set(synonym.toLowerCase(), mapping);
+    }
+  }
+  return map;
+})();

--- a/lib/health/normalize-biomarker.ts
+++ b/lib/health/normalize-biomarker.ts
@@ -1,0 +1,253 @@
+/**
+ * Biomarker name and unit normalization.
+ *
+ * Maps raw biomarker names (as extracted by Claude) to canonical names
+ * using the synonym index from biomarker-synonyms.ts.
+ *
+ * Handles: case-insensitive matching, prefix/suffix stripping,
+ * abbreviation matching, and word-order variants.
+ */
+
+import { SYNONYM_INDEX, type BiomarkerMapping } from "./biomarker-synonyms";
+
+export interface NormalizationResult {
+  /** Canonical biomarker name (or original if no match) */
+  canonical: string;
+  /** Category grouping */
+  category: string;
+  /** Standard unit */
+  unit: string;
+  /** Whether a synonym match was found */
+  matched: boolean;
+}
+
+/**
+ * Common prefixes and suffixes to strip from biomarker names before matching.
+ * These are frequently included in lab reports but not part of the core name.
+ */
+const STRIP_PATTERNS = [
+  /^serum\s+/i,
+  /^blood\s+/i,
+  /^plasma\s+/i,
+  /\s+level$/i,
+  /\s+levels$/i,
+  /\s+test$/i,
+  /\s+count$/i,
+  /\s+result$/i,
+  /\s+value$/i,
+  /\s+measurement$/i,
+];
+
+/**
+ * Normalize raw text for matching: lowercase, collapse whitespace, trim.
+ */
+function cleanForMatch(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Try multiple matching strategies in order of specificity:
+ * 1. Exact synonym match
+ * 2. After stripping common prefixes/suffixes
+ * 3. Word-order reversal (e.g., "Cholesterol, Total" -> "total cholesterol")
+ * 4. Substring containment (the raw name contains a known synonym)
+ */
+function findMapping(rawName: string): BiomarkerMapping | null {
+  const cleaned = cleanForMatch(rawName);
+
+  // Strategy 1: Exact match on cleaned name
+  const exact = SYNONYM_INDEX.get(cleaned);
+  if (exact) return exact;
+
+  // Strategy 2: Strip prefixes/suffixes and try again
+  let stripped = cleaned;
+  for (const pattern of STRIP_PATTERNS) {
+    stripped = stripped.replace(pattern, "");
+  }
+  stripped = stripped.trim();
+  if (stripped !== cleaned) {
+    const match = SYNONYM_INDEX.get(stripped);
+    if (match) return match;
+  }
+
+  // Strategy 3: Handle comma-separated word order ("Cholesterol, Total" -> "total cholesterol")
+  if (cleaned.includes(",")) {
+    const parts = cleaned.split(",").map((p) => p.trim());
+    const reversed = parts.reverse().join(" ");
+    const match = SYNONYM_INDEX.get(reversed);
+    if (match) return match;
+  }
+
+  // Strategy 4: Remove parenthetical content and retry
+  const noParens = cleaned.replace(/\s*\(.*?\)\s*/g, " ").replace(/\s+/g, " ").trim();
+  if (noParens !== cleaned) {
+    const match = SYNONYM_INDEX.get(noParens);
+    if (match) return match;
+
+    // Also try stripping prefixes from the no-parens version
+    let strippedNoParens = noParens;
+    for (const pattern of STRIP_PATTERNS) {
+      strippedNoParens = strippedNoParens.replace(pattern, "");
+    }
+    strippedNoParens = strippedNoParens.trim();
+    if (strippedNoParens !== noParens) {
+      const m = SYNONYM_INDEX.get(strippedNoParens);
+      if (m) return m;
+    }
+  }
+
+  // Strategy 5: Check if cleaned name contains any known synonym as a substring
+  // Only match synonyms >= 3 chars to avoid false positives
+  let bestMatch: BiomarkerMapping | null = null;
+  let bestLength = 0;
+  for (const [synonym, mapping] of SYNONYM_INDEX) {
+    if (synonym.length >= 3 && cleaned.includes(synonym) && synonym.length > bestLength) {
+      bestMatch = mapping;
+      bestLength = synonym.length;
+    }
+  }
+  if (bestMatch) return bestMatch;
+
+  return null;
+}
+
+/**
+ * Normalize a raw biomarker name to its canonical form.
+ *
+ * @param rawName - The biomarker name as extracted from a lab report
+ * @returns Normalization result with canonical name, category, unit, and match status
+ */
+export function normalizeBiomarkerName(rawName: string): NormalizationResult {
+  if (!rawName || typeof rawName !== "string") {
+    return {
+      canonical: rawName || "",
+      category: "Unknown",
+      unit: "",
+      matched: false,
+    };
+  }
+
+  const mapping = findMapping(rawName);
+
+  if (mapping) {
+    return {
+      canonical: mapping.canonical,
+      category: mapping.category,
+      unit: mapping.unit,
+      matched: true,
+    };
+  }
+
+  // No match found — return original name unchanged
+  return {
+    canonical: rawName.trim(),
+    category: "Unknown",
+    unit: "",
+    matched: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Unit conversion factors keyed by canonical biomarker name.
+ * Each entry maps fromUnit -> { factor, toUnit }.
+ */
+const UNIT_CONVERSIONS: Record<
+  string,
+  Record<string, { factor: number; toUnit: string }>
+> = {
+  "Glucose (Fasting)": {
+    "mmol/l": { factor: 18.0182, toUnit: "mg/dL" },
+  },
+  "Total Cholesterol": {
+    "mmol/l": { factor: 38.67, toUnit: "mg/dL" },
+  },
+  "LDL Cholesterol": {
+    "mmol/l": { factor: 38.67, toUnit: "mg/dL" },
+  },
+  "HDL Cholesterol": {
+    "mmol/l": { factor: 38.67, toUnit: "mg/dL" },
+  },
+  "Triglycerides": {
+    "mmol/l": { factor: 88.57, toUnit: "mg/dL" },
+  },
+  "VLDL Cholesterol": {
+    "mmol/l": { factor: 38.67, toUnit: "mg/dL" },
+  },
+  "Hemoglobin A1C": {
+    "mmol/mol": { factor: 0.0915, toUnit: "%" }, // IFCC to NGSP: %A1C = 0.0915 * mmol/mol + 2.15
+  },
+  "Creatinine": {
+    "umol/l": { factor: 0.0113, toUnit: "mg/dL" },
+    "µmol/l": { factor: 0.0113, toUnit: "mg/dL" },
+  },
+  "BUN": {
+    "mmol/l": { factor: 2.8, toUnit: "mg/dL" },
+  },
+  "Uric Acid": {
+    "umol/l": { factor: 0.0168, toUnit: "mg/dL" },
+    "µmol/l": { factor: 0.0168, toUnit: "mg/dL" },
+  },
+  "Calcium": {
+    "mmol/l": { factor: 4.0, toUnit: "mg/dL" },
+  },
+  "Bilirubin Total": {
+    "umol/l": { factor: 0.0585, toUnit: "mg/dL" },
+    "µmol/l": { factor: 0.0585, toUnit: "mg/dL" },
+  },
+  "Bilirubin Direct": {
+    "umol/l": { factor: 0.0585, toUnit: "mg/dL" },
+    "µmol/l": { factor: 0.0585, toUnit: "mg/dL" },
+  },
+  "Iron": {
+    "umol/l": { factor: 5.587, toUnit: "mcg/dL" },
+    "µmol/l": { factor: 5.587, toUnit: "mcg/dL" },
+  },
+  "Vitamin D": {
+    "nmol/l": { factor: 0.4, toUnit: "ng/mL" },
+  },
+};
+
+/**
+ * Normalize a biomarker value from one unit to the standard unit.
+ *
+ * @param value - The numeric value
+ * @param fromUnit - The unit as reported by the lab
+ * @param biomarker - The canonical biomarker name
+ * @returns Normalized value and unit, or original if no conversion needed
+ */
+export function normalizeUnit(
+  value: number,
+  fromUnit: string,
+  biomarker: string
+): { value: number; unit: string } {
+  const conversions = UNIT_CONVERSIONS[biomarker];
+  if (!conversions) {
+    return { value, unit: fromUnit };
+  }
+
+  const normalizedFromUnit = fromUnit.toLowerCase().replace(/\s+/g, "");
+  const conversion = conversions[normalizedFromUnit];
+  if (!conversion) {
+    return { value, unit: fromUnit };
+  }
+
+  // Special case: A1C IFCC to NGSP needs addition
+  if (biomarker === "Hemoglobin A1C" && normalizedFromUnit === "mmol/mol") {
+    return {
+      value: Math.round((value * 0.0915 + 2.15) * 10) / 10,
+      unit: conversion.toUnit,
+    };
+  }
+
+  return {
+    value: Math.round(value * conversion.factor * 100) / 100,
+    unit: conversion.toUnit,
+  };
+}


### PR DESCRIPTION
## Summary
Closes #51

- **Biomarker synonym map** (`lib/health/biomarker-synonyms.ts`): 50+ canonical biomarker mappings across 9 categories (Lipids, Metabolic, Electrolytes, Liver, CBC, Thyroid, Vitamins, Cardiovascular, Body) with LOINC codes and pre-built O(1) synonym index
- **Normalization function** (`lib/health/normalize-biomarker.ts`): Multi-strategy matching (exact, prefix/suffix stripping, word-order reversal, parenthetical removal, substring containment) plus unit conversion for common SI-to-US lab units
- **Parse route integration** (`app/api/parse/route.ts`): After Claude extraction and server-side flagging, biomarker names are normalized to canonical form while preserving `original_name` for traceability
- **137 tests** covering every synonym mapping, case insensitivity, prefix/suffix stripping, unknown biomarkers, category assignment, word-order variants, and unit conversions

## Problem
Different labs use different names for the same biomarker (e.g., "Glu", "Glucose", "FBS", "Blood Sugar" all mean Glucose). Without normalization, the same biomarker appears under different names across reports, breaking trend tracking and search/filter.

## Solution
A normalization layer that runs after Claude extraction + server-side flagging. Raw lab names are mapped to canonical names via a synonym index, while the original extracted name is preserved. Unit conversions handle international lab formats (mmol/L, umol/L, nmol/L).

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npx vitest run` — all 553 tests pass (137 new)
- [ ] Manual: upload a lab report with non-standard biomarker names and verify they appear normalized in results