### PR TITLE
feat(health): add custom reference ranges per user (#50)

### DIFF
--- a/__tests__/custom-reference-ranges.test.ts
+++ b/__tests__/custom-reference-ranges.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect } from "vitest";
+import {
+  flagBiomarker,
+  flagBiomarkerWithCustomRanges,
+  applyServerSideFlags,
+  type CustomRange,
+} from "@/lib/health/flag-biomarker";
+
+// ---------------------------------------------------------------------------
+// Helper: build a CustomRange
+// ---------------------------------------------------------------------------
+
+function makeCustomRange(
+  overrides: Partial<CustomRange> & { biomarker_name: string }
+): CustomRange {
+  return {
+    green_low: null,
+    green_high: null,
+    yellow_low: null,
+    yellow_high: null,
+    red_low: null,
+    red_high: null,
+    direction: "range",
+    source: "Test Doctor",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// flagBiomarkerWithCustomRanges
+// ---------------------------------------------------------------------------
+
+describe("flagBiomarkerWithCustomRanges", () => {
+  describe("custom range overrides default", () => {
+    it("uses custom green range instead of default", () => {
+      // Default Glucose green is <= 99. Custom extends to 110.
+      const customRanges: CustomRange[] = [
+        makeCustomRange({
+          biomarker_name: "Glucose (Fasting)",
+          green_low: null,
+          green_high: 110,
+          yellow_low: 111,
+          yellow_high: 139,
+          direction: "lower-is-better",
+        }),
+      ];
+
+      // 105 would be yellow with default, but green with custom
+      expect(flagBiomarker("Glucose", 105)).toBe("yellow");
+      expect(
+        flagBiomarkerWithCustomRanges("Glucose (Fasting)", 105, customRanges)
+      ).toBe("green");
+    });
+
+    it("applies custom range for lower-is-better direction", () => {
+      const customRanges: CustomRange[] = [
+        makeCustomRange({
+          biomarker_name: "Total Cholesterol",
+          green_low: null,
+          green_high: 220,
+          yellow_low: 221,
+          yellow_high: 260,
+          direction: "lower-is-better",
+        }),
+      ];
+
+      // 210 is yellow by default (200-239), but green with custom (<=220)
+      expect(flagBiomarker("Total Cholesterol", 210)).toBe("yellow");
+      expect(
+        flagBiomarkerWithCustomRanges("Total Cholesterol", 210, customRanges)
+      ).toBe("green");
+    });
+
+    it("applies custom range for higher-is-better direction", () => {
+      const customRanges: CustomRange[] = [
+        makeCustomRange({
+          biomarker_name: "HDL Cholesterol",
+          green_low: 50,
+          green_high: null,
+          yellow_low: 35,
+          yellow_high: 49,
+          direction: "higher-is-better",
+        }),
+      ];
+
+      // 45 is yellow for male by default (40-60), but also yellow with custom (35-49)
+      expect(
+        flagBiomarkerWithCustomRanges("HDL Cholesterol", 45, customRanges, "male")
+      ).toBe("yellow");
+
+      // 50 would be yellow for male by default (40-60), but green with custom (>=50)
+      expect(
+        flagBiomarkerWithCustomRanges("HDL Cholesterol", 50, customRanges, "male")
+      ).toBe("green");
+    });
+
+    it("applies custom range with range direction", () => {
+      const customRanges: CustomRange[] = [
+        makeCustomRange({
+          biomarker_name: "TSH",
+          green_low: 0.5,
+          green_high: 3.0,
+          yellow_low: 0.3,
+          yellow_high: 5.0,
+          direction: "range",
+        }),
+      ];
+
+      // 3.5 is green by default (0.4-4.0), but yellow with custom
+      expect(flagBiomarker("TSH", 3.5)).toBe("green");
+      expect(
+        flagBiomarkerWithCustomRanges("TSH", 3.5, customRanges)
+      ).toBe("yellow");
+    });
+  });
+
+  describe("falls back to default when no custom range matches", () => {
+    it("uses default range for biomarker not in custom ranges", () => {
+      const customRanges: CustomRange[] = [
+        makeCustomRange({
+          biomarker_name: "Glucose (Fasting)",
+          green_low: null,
+          green_high: 110,
+          yellow_low: 111,
+          yellow_high: 139,
+          direction: "lower-is-better",
+        }),
+      ];
+
+      // Cholesterol has no custom range, should use default
+      expect(
+        flagBiomarkerWithCustomRanges("Total Cholesterol", 240, customRanges)
+      ).toBe("red");
+    });
+
+    it("uses default range when customRanges is empty", () => {
+      expect(
+        flagBiomarkerWithCustomRanges("Glucose", 126, [])
+      ).toBe("red");
+    });
+
+    it("uses default range when customRanges is undefined", () => {
+      expect(
+        flagBiomarkerWithCustomRanges("Glucose", 126, undefined)
+      ).toBe("red");
+    });
+  });
+
+  describe("skips non-risk measurements", () => {
+    it("returns green for height even with custom ranges", () => {
+      const customRanges: CustomRange[] = [];
+      expect(
+        flagBiomarkerWithCustomRanges("height", 170, customRanges)
+      ).toBe("green");
+    });
+
+    it("returns green for weight", () => {
+      expect(
+        flagBiomarkerWithCustomRanges("weight", 80, [])
+      ).toBe("green");
+    });
+  });
+
+  describe("returns null for unknown biomarkers", () => {
+    it("returns null when neither custom nor default range exists", () => {
+      const customRanges: CustomRange[] = [];
+      expect(
+        flagBiomarkerWithCustomRanges("Mystery Marker XYZ", 42, customRanges)
+      ).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyServerSideFlags with customRanges
+// ---------------------------------------------------------------------------
+
+describe("applyServerSideFlags with customRanges", () => {
+  it("applies custom range overrides to biomarker array", () => {
+    const customRanges: CustomRange[] = [
+      makeCustomRange({
+        biomarker_name: "glucose",
+        green_low: null,
+        green_high: 130,
+        yellow_low: 131,
+        yellow_high: 160,
+        direction: "lower-is-better",
+      }),
+    ];
+
+    const biomarkers = [
+      {
+        name: "Glucose",
+        value: 126,
+        unit: "mg/dL",
+        flag: "green" as const,
+        reference_low: null,
+        reference_high: null,
+      },
+    ];
+
+    // Without custom ranges, 126 = red (default green <= 99)
+    const defaultResult = applyServerSideFlags(biomarkers);
+    expect(defaultResult[0].flag).toBe("red");
+
+    // With custom ranges, 126 = green (custom green <= 130)
+    const customResult = applyServerSideFlags(biomarkers, undefined, customRanges);
+    expect(customResult[0].flag).toBe("green");
+  });
+
+  it("uses default for biomarkers without custom range", () => {
+    const customRanges: CustomRange[] = [
+      makeCustomRange({
+        biomarker_name: "glucose",
+        green_low: null,
+        green_high: 130,
+        yellow_low: 131,
+        yellow_high: 160,
+        direction: "lower-is-better",
+      }),
+    ];
+
+    const biomarkers = [
+      {
+        name: "Total Cholesterol",
+        value: 240,
+        unit: "mg/dL",
+        flag: "green" as const,
+        reference_low: null,
+        reference_high: null,
+      },
+    ];
+
+    // Cholesterol 240 = red by default, no custom range
+    const result = applyServerSideFlags(biomarkers, undefined, customRanges);
+    expect(result[0].flag).toBe("red");
+  });
+
+  it("handles mixed custom and default ranges", () => {
+    const customRanges: CustomRange[] = [
+      makeCustomRange({
+        biomarker_name: "glucose",
+        green_low: null,
+        green_high: 130,
+        yellow_low: 131,
+        yellow_high: 160,
+        direction: "lower-is-better",
+      }),
+    ];
+
+    const biomarkers = [
+      {
+        name: "Glucose",
+        value: 126,
+        unit: "mg/dL",
+        flag: "green" as const,
+        reference_low: null,
+        reference_high: null,
+      },
+      {
+        name: "Blood Pressure Systolic",
+        value: 140,
+        unit: "mmHg",
+        flag: "green" as const,
+        reference_low: null,
+        reference_high: null,
+      },
+    ];
+
+    const result = applyServerSideFlags(biomarkers, undefined, customRanges);
+    expect(result[0].flag).toBe("green"); // Glucose: custom range, 126 <= 130
+    expect(result[1].flag).toBe("red"); // BP: default, 140 = red
+  });
+
+  it("skips null-value biomarkers", () => {
+    const customRanges: CustomRange[] = [
+      makeCustomRange({
+        biomarker_name: "glucose",
+        green_low: null,
+        green_high: 130,
+        direction: "lower-is-better",
+      }),
+    ];
+
+    const biomarkers = [
+      {
+        name: "Glucose",
+        value: null,
+        unit: "mg/dL",
+        flag: "green" as const,
+        reference_low: null,
+        reference_high: null,
+      },
+    ];
+
+    const result = applyServerSideFlags(biomarkers, undefined, customRanges);
+    expect(result[0].flag).toBe("green"); // Unchanged — null value
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom Reference Ranges API validation (unit tests for logic)
+// ---------------------------------------------------------------------------
+
+describe("Custom Range API validation", () => {
+  it("validates direction values", () => {
+    const validDirections = ["lower-is-better", "higher-is-better", "range"];
+    for (const dir of validDirections) {
+      const cr = makeCustomRange({
+        biomarker_name: "Test",
+        direction: dir as CustomRange["direction"],
+      });
+      expect(validDirections).toContain(cr.direction);
+    }
+  });
+
+  it("handles null threshold values correctly", () => {
+    const cr = makeCustomRange({
+      biomarker_name: "LDL Cholesterol",
+      green_low: null,
+      green_high: 100,
+      yellow_low: 101,
+      yellow_high: 130,
+      direction: "lower-is-better",
+    });
+
+    // 90 should be green (below green_high)
+    expect(
+      flagBiomarkerWithCustomRanges("LDL Cholesterol", 90, [cr])
+    ).toBe("green");
+
+    // 115 should be yellow
+    expect(
+      flagBiomarkerWithCustomRanges("LDL Cholesterol", 115, [cr])
+    ).toBe("yellow");
+
+    // 140 should be red (above yellow_high)
+    expect(
+      flagBiomarkerWithCustomRanges("LDL Cholesterol", 140, [cr])
+    ).toBe("red");
+  });
+});

--- a/app/api/parse/route.ts
+++ b/app/api/parse/route.ts
@@ -103,10 +103,22 @@ export async function POST(request: Request) {
 
     console.log("[PARSE] Claude returned", parsed.biomarkers.length, "biomarkers. Applying server-side risk flags...");
 
+    // Load user's custom reference ranges (#50)
+    // Custom ranges override defaults for personalized flagging.
+    const { data: customRanges } = await supabase
+      .from("custom_reference_ranges")
+      .select("biomarker_name, green_low, green_high, yellow_low, yellow_high, red_low, red_high, direction, source")
+      .eq("user_id", user.id);
+
     // Apply deterministic server-side flagging (fixes #87)
     // This overrides Claude's advisory flags with verified reference ranges.
+    // Custom ranges take priority over defaults (#50).
     // Claude's flag is kept as fallback only for unrecognized biomarkers.
-    const reflaggedBiomarkers = applyServerSideFlags(parsed.biomarkers);
+    const reflaggedBiomarkers = applyServerSideFlags(
+      parsed.biomarkers,
+      undefined,
+      customRanges ?? undefined
+    );
     const reflaggedParsed = { ...parsed, biomarkers: reflaggedBiomarkers };
 
     // Normalize biomarker names to canonical form (#51)

--- a/app/api/profile/reference-ranges/route.ts
+++ b/app/api/profile/reference-ranges/route.ts
@@ -1,0 +1,207 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+/**
+ * Custom reference ranges API (#50)
+ *
+ * GET  — List all custom reference ranges for the authenticated user
+ * POST — Create or update a custom range for a specific biomarker
+ * DELETE — Remove a custom range (falls back to default)
+ */
+
+export interface CustomReferenceRange {
+  id: string;
+  user_id: string;
+  biomarker_name: string;
+  green_low: number | null;
+  green_high: number | null;
+  yellow_low: number | null;
+  yellow_high: number | null;
+  red_low: number | null;
+  red_high: number | null;
+  direction: "lower-is-better" | "higher-is-better" | "range";
+  source: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const VALID_DIRECTIONS = ["lower-is-better", "higher-is-better", "range"];
+
+export async function GET() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: ranges, error } = await supabase
+    .from("custom_reference_ranges")
+    .select("*")
+    .eq("user_id", user.id)
+    .order("biomarker_name");
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to fetch custom ranges" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ ranges }, { status: 200 });
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: {
+    biomarker_name: string;
+    green_low?: number | null;
+    green_high?: number | null;
+    yellow_low?: number | null;
+    yellow_high?: number | null;
+    red_low?: number | null;
+    red_high?: number | null;
+    direction?: string;
+    source?: string | null;
+  };
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  // Validate biomarker_name
+  if (!body.biomarker_name || typeof body.biomarker_name !== "string") {
+    return NextResponse.json(
+      { error: "biomarker_name is required" },
+      { status: 400 }
+    );
+  }
+
+  if (body.biomarker_name.length > 200) {
+    return NextResponse.json(
+      { error: "biomarker_name must be under 200 characters" },
+      { status: 400 }
+    );
+  }
+
+  // Validate direction
+  const direction = body.direction || "range";
+  if (!VALID_DIRECTIONS.includes(direction)) {
+    return NextResponse.json(
+      { error: `direction must be one of: ${VALID_DIRECTIONS.join(", ")}` },
+      { status: 400 }
+    );
+  }
+
+  // Validate numeric fields
+  const numericFields = [
+    "green_low",
+    "green_high",
+    "yellow_low",
+    "yellow_high",
+    "red_low",
+    "red_high",
+  ] as const;
+
+  for (const field of numericFields) {
+    const val = body[field];
+    if (val !== undefined && val !== null && typeof val !== "number") {
+      return NextResponse.json(
+        { error: `${field} must be a number or null` },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Upsert: create or update based on user_id + biomarker_name unique constraint
+  const { data: range, error } = await supabase
+    .from("custom_reference_ranges")
+    .upsert(
+      {
+        user_id: user.id,
+        biomarker_name: body.biomarker_name,
+        green_low: body.green_low ?? null,
+        green_high: body.green_high ?? null,
+        yellow_low: body.yellow_low ?? null,
+        yellow_high: body.yellow_high ?? null,
+        red_low: body.red_low ?? null,
+        red_high: body.red_high ?? null,
+        direction,
+        source: body.source ?? null,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "user_id,biomarker_name" }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to save custom range" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ range }, { status: 200 });
+}
+
+export async function DELETE(request: Request) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: { biomarker_name: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  if (!body.biomarker_name || typeof body.biomarker_name !== "string") {
+    return NextResponse.json(
+      { error: "biomarker_name is required" },
+      { status: 400 }
+    );
+  }
+
+  const { error } = await supabase
+    .from("custom_reference_ranges")
+    .delete()
+    .eq("user_id", user.id)
+    .eq("biomarker_name", body.biomarker_name);
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to delete custom range" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ deleted: true }, { status: 200 });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2515,3 +2515,345 @@ button.chat-send-button[type="submit"]:disabled {
     text-align: center;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Custom Reference Ranges (#50)
+   --------------------------------------------------------------------------- */
+
+.custom-ranges {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.custom-ranges--loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 40vh;
+  gap: 1rem;
+}
+
+.custom-ranges__spinner {
+  width: 2rem;
+  height: 2rem;
+  border: 3px solid var(--border);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.custom-ranges__header {
+  margin-bottom: 2rem;
+}
+
+.custom-ranges__header h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0.5rem 0;
+}
+
+.custom-ranges__header p {
+  color: var(--muted-foreground);
+  line-height: 1.5;
+}
+
+.custom-ranges__error {
+  background: var(--error-bg, #fef2f2);
+  color: var(--error-text, #b91c1c);
+  border: 1px solid var(--error-border, #fecaca);
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.custom-ranges__success {
+  background: var(--success-bg, #f0fdf4);
+  color: var(--success-text, #15803d);
+  border: 1px solid var(--success-border, #bbf7d0);
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.custom-ranges__form {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.custom-ranges__form h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 1rem 0;
+}
+
+.custom-ranges__field {
+  margin-bottom: 0.75rem;
+}
+
+.custom-ranges__field label {
+  display: block;
+  font-weight: 500;
+  font-size: 0.875rem;
+  margin-bottom: 0.25rem;
+}
+
+.custom-ranges__field input,
+.custom-ranges__field select {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.custom-ranges__field input:focus,
+.custom-ranges__field select:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: -1px;
+}
+
+.custom-ranges__thresholds {
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.custom-ranges__thresholds legend {
+  font-weight: 600;
+  font-size: 0.875rem;
+  padding: 0 0.25rem;
+}
+
+.custom-ranges__threshold-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.custom-ranges__form-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.custom-ranges__save-btn {
+  padding: 0.5rem 1.25rem;
+  background: var(--primary);
+  color: var(--primary-foreground, #fff);
+  border: none;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.custom-ranges__save-btn:hover {
+  opacity: 0.9;
+}
+
+.custom-ranges__save-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.custom-ranges__cancel-btn {
+  padding: 0.5rem 1.25rem;
+  background: transparent;
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+  border-radius: 0.375rem;
+  cursor: pointer;
+}
+
+.custom-ranges__cancel-btn:hover {
+  background: var(--muted);
+}
+
+.custom-ranges__list {
+  margin-top: 1rem;
+}
+
+.custom-ranges__list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.custom-ranges__list-header h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.custom-ranges__add-btn {
+  padding: 0.5rem 1rem;
+  background: var(--primary);
+  color: var(--primary-foreground, #fff);
+  border: none;
+  border-radius: 0.375rem;
+  font-weight: 500;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.custom-ranges__add-btn:hover {
+  opacity: 0.9;
+}
+
+.custom-ranges__empty {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 2rem;
+  text-align: center;
+  color: var(--muted-foreground);
+  line-height: 1.5;
+}
+
+.custom-ranges__table-wrapper {
+  overflow-x: auto;
+}
+
+.custom-ranges__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.custom-ranges__table th,
+.custom-ranges__table td {
+  padding: 0.625rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.custom-ranges__table th {
+  font-weight: 600;
+  color: var(--muted-foreground);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+}
+
+.custom-ranges__biomarker-name {
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.custom-ranges__custom-badge {
+  display: inline-block;
+  padding: 0.125rem 0.375rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  background: var(--primary);
+  color: var(--primary-foreground, #fff);
+  border-radius: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.custom-ranges__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.custom-ranges__edit-btn {
+  padding: 0.25rem 0.625rem;
+  font-size: 0.8rem;
+  background: transparent;
+  color: var(--primary);
+  border: 1px solid var(--primary);
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+
+.custom-ranges__edit-btn:hover {
+  background: var(--primary);
+  color: var(--primary-foreground, #fff);
+}
+
+.custom-ranges__edit-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.custom-ranges__delete-btn {
+  padding: 0.25rem 0.625rem;
+  font-size: 0.8rem;
+  background: transparent;
+  color: var(--error-text, #b91c1c);
+  border: 1px solid var(--error-border, #fecaca);
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+
+.custom-ranges__delete-btn:hover {
+  background: var(--error-bg, #fef2f2);
+}
+
+.custom-ranges__delete-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Profile link card for custom ranges */
+.profile-page__link-card {
+  display: block;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  margin-top: 1.5rem;
+  text-decoration: none;
+  color: var(--foreground);
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.profile-page__link-card:hover {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 1px var(--primary);
+}
+
+.profile-page__link-card h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem 0;
+}
+
+.profile-page__link-card p {
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .custom-ranges__list-header {
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: stretch;
+  }
+
+  .custom-ranges__add-btn {
+    text-align: center;
+  }
+
+  .custom-ranges__actions {
+    flex-direction: column;
+  }
+
+  .custom-ranges__biomarker-name {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import Link from "next/link";
 import NavHeader from "@/components/ui/NavHeader";
 import Avatar from "@/components/ui/Avatar";
 
@@ -275,6 +276,11 @@ export default function ProfilePage() {
           Last updated: {new Date(profile.updated_at).toLocaleDateString()}
         </p>
       )}
+
+      <Link href="/profile/reference-ranges" className="profile-page__link-card">
+        <h3>Custom Reference Ranges</h3>
+        <p>Set personalized reference ranges from your doctor to override default thresholds.</p>
+      </Link>
     </div>
   );
 }

--- a/app/profile/reference-ranges/page.tsx
+++ b/app/profile/reference-ranges/page.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import NavHeader from "@/components/ui/NavHeader";
+
+interface CustomRange {
+  id: string;
+  biomarker_name: string;
+  green_low: number | null;
+  green_high: number | null;
+  yellow_low: number | null;
+  yellow_high: number | null;
+  red_low: number | null;
+  red_high: number | null;
+  direction: "lower-is-better" | "higher-is-better" | "range";
+  source: string | null;
+}
+
+interface EditState {
+  biomarker_name: string;
+  green_low: string;
+  green_high: string;
+  yellow_low: string;
+  yellow_high: string;
+  red_low: string;
+  red_high: string;
+  direction: "lower-is-better" | "higher-is-better" | "range";
+  source: string;
+}
+
+const EMPTY_EDIT: Omit<EditState, "biomarker_name"> = {
+  green_low: "",
+  green_high: "",
+  yellow_low: "",
+  yellow_high: "",
+  red_low: "",
+  red_high: "",
+  direction: "range",
+  source: "",
+};
+
+export default function CustomReferenceRangesPage() {
+  const [ranges, setRanges] = useState<CustomRange[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [editing, setEditing] = useState<EditState | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  const fetchRanges = useCallback(async () => {
+    try {
+      const response = await fetch("/api/profile/reference-ranges");
+      if (!response.ok) throw new Error("Failed to load custom ranges");
+      const data = await response.json();
+      setRanges(data.ranges || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load ranges");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRanges();
+  }, [fetchRanges]);
+
+  const handleEdit = (range: CustomRange) => {
+    setEditing({
+      biomarker_name: range.biomarker_name,
+      green_low: range.green_low?.toString() ?? "",
+      green_high: range.green_high?.toString() ?? "",
+      yellow_low: range.yellow_low?.toString() ?? "",
+      yellow_high: range.yellow_high?.toString() ?? "",
+      red_low: range.red_low?.toString() ?? "",
+      red_high: range.red_high?.toString() ?? "",
+      direction: range.direction,
+      source: range.source ?? "",
+    });
+    setError(null);
+    setSuccess(null);
+  };
+
+  const handleAddNew = () => {
+    setEditing({
+      biomarker_name: "",
+      ...EMPTY_EDIT,
+    });
+    setError(null);
+    setSuccess(null);
+  };
+
+  const handleCancel = () => {
+    setEditing(null);
+  };
+
+  const parseNum = (val: string): number | null => {
+    if (val.trim() === "") return null;
+    const num = Number(val);
+    return isNaN(num) ? null : num;
+  };
+
+  const handleSave = async () => {
+    if (!editing) return;
+    if (!editing.biomarker_name.trim()) {
+      setError("Biomarker name is required");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/profile/reference-ranges", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          biomarker_name: editing.biomarker_name.trim(),
+          green_low: parseNum(editing.green_low),
+          green_high: parseNum(editing.green_high),
+          yellow_low: parseNum(editing.yellow_low),
+          yellow_high: parseNum(editing.yellow_high),
+          red_low: parseNum(editing.red_low),
+          red_high: parseNum(editing.red_high),
+          direction: editing.direction,
+          source: editing.source.trim() || null,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to save custom range");
+      }
+
+      setEditing(null);
+      setSuccess("Custom range saved successfully");
+      setTimeout(() => setSuccess(null), 3000);
+      await fetchRanges();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (biomarkerName: string) => {
+    setDeleting(biomarkerName);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/profile/reference-ranges", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ biomarker_name: biomarkerName }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to delete custom range");
+      }
+
+      setSuccess("Custom range removed. Default range will be used.");
+      setTimeout(() => setSuccess(null), 3000);
+      await fetchRanges();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete");
+    } finally {
+      setDeleting(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="custom-ranges custom-ranges--loading">
+        <div className="custom-ranges__spinner" aria-label="Loading custom ranges" />
+        <p>Loading your custom ranges...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="custom-ranges">
+      <div className="custom-ranges__header">
+        <NavHeader backHref="/profile" backLabel="Profile" />
+        <h1>Custom Reference Ranges</h1>
+        <p>
+          Set personalized reference ranges from your doctor. Custom ranges
+          override the default population-based thresholds when flagging your
+          biomarker results.
+        </p>
+      </div>
+
+      {error && (
+        <div className="custom-ranges__error" role="alert">
+          {error}
+        </div>
+      )}
+
+      {success && (
+        <div className="custom-ranges__success" role="status">
+          {success}
+        </div>
+      )}
+
+      {/* Editing / Adding form */}
+      {editing && (
+        <div className="custom-ranges__form">
+          <h2>{editing.biomarker_name ? `Edit: ${editing.biomarker_name}` : "Add Custom Range"}</h2>
+
+          <div className="custom-ranges__field">
+            <label htmlFor="crr-biomarker">Biomarker Name</label>
+            <input
+              id="crr-biomarker"
+              type="text"
+              value={editing.biomarker_name}
+              onChange={(e) =>
+                setEditing({ ...editing, biomarker_name: e.target.value })
+              }
+              placeholder="e.g., Glucose (Fasting)"
+              disabled={ranges.some(
+                (r) => r.biomarker_name === editing.biomarker_name
+              )}
+            />
+          </div>
+
+          <div className="custom-ranges__field">
+            <label htmlFor="crr-direction">Direction</label>
+            <select
+              id="crr-direction"
+              value={editing.direction}
+              onChange={(e) =>
+                setEditing({
+                  ...editing,
+                  direction: e.target.value as EditState["direction"],
+                })
+              }
+            >
+              <option value="range">Range (normal band)</option>
+              <option value="lower-is-better">Lower is better</option>
+              <option value="higher-is-better">Higher is better</option>
+            </select>
+          </div>
+
+          <fieldset className="custom-ranges__thresholds">
+            <legend>Green (Normal)</legend>
+            <div className="custom-ranges__threshold-row">
+              <div className="custom-ranges__field">
+                <label htmlFor="crr-green-low">Low</label>
+                <input
+                  id="crr-green-low"
+                  type="number"
+                  step="any"
+                  value={editing.green_low}
+                  onChange={(e) =>
+                    setEditing({ ...editing, green_low: e.target.value })
+                  }
+                  placeholder="Low bound"
+                />
+              </div>
+              <div className="custom-ranges__field">
+                <label htmlFor="crr-green-high">High</label>
+                <input
+                  id="crr-green-high"
+                  type="number"
+                  step="any"
+                  value={editing.green_high}
+                  onChange={(e) =>
+                    setEditing({ ...editing, green_high: e.target.value })
+                  }
+                  placeholder="High bound"
+                />
+              </div>
+            </div>
+          </fieldset>
+
+          <fieldset className="custom-ranges__thresholds">
+            <legend>Yellow (Borderline)</legend>
+            <div className="custom-ranges__threshold-row">
+              <div className="custom-ranges__field">
+                <label htmlFor="crr-yellow-low">Low</label>
+                <input
+                  id="crr-yellow-low"
+                  type="number"
+                  step="any"
+                  value={editing.yellow_low}
+                  onChange={(e) =>
+                    setEditing({ ...editing, yellow_low: e.target.value })
+                  }
+                  placeholder="Low bound"
+                />
+              </div>
+              <div className="custom-ranges__field">
+                <label htmlFor="crr-yellow-high">High</label>
+                <input
+                  id="crr-yellow-high"
+                  type="number"
+                  step="any"
+                  value={editing.yellow_high}
+                  onChange={(e) =>
+                    setEditing({ ...editing, yellow_high: e.target.value })
+                  }
+                  placeholder="High bound"
+                />
+              </div>
+            </div>
+          </fieldset>
+
+          <fieldset className="custom-ranges__thresholds">
+            <legend>Red (High Risk)</legend>
+            <div className="custom-ranges__threshold-row">
+              <div className="custom-ranges__field">
+                <label htmlFor="crr-red-low">Low</label>
+                <input
+                  id="crr-red-low"
+                  type="number"
+                  step="any"
+                  value={editing.red_low}
+                  onChange={(e) =>
+                    setEditing({ ...editing, red_low: e.target.value })
+                  }
+                  placeholder="Low bound"
+                />
+              </div>
+              <div className="custom-ranges__field">
+                <label htmlFor="crr-red-high">High</label>
+                <input
+                  id="crr-red-high"
+                  type="number"
+                  step="any"
+                  value={editing.red_high}
+                  onChange={(e) =>
+                    setEditing({ ...editing, red_high: e.target.value })
+                  }
+                  placeholder="High bound"
+                />
+              </div>
+            </div>
+          </fieldset>
+
+          <div className="custom-ranges__field">
+            <label htmlFor="crr-source">Source (optional)</label>
+            <input
+              id="crr-source"
+              type="text"
+              value={editing.source}
+              onChange={(e) =>
+                setEditing({ ...editing, source: e.target.value })
+              }
+              placeholder="e.g., Dr. Smith, Endocrinologist"
+            />
+          </div>
+
+          <div className="custom-ranges__form-actions">
+            <button
+              type="button"
+              className="custom-ranges__save-btn"
+              onClick={handleSave}
+              disabled={saving}
+            >
+              {saving ? "Saving..." : "Save Range"}
+            </button>
+            <button
+              type="button"
+              className="custom-ranges__cancel-btn"
+              onClick={handleCancel}
+              disabled={saving}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Range list */}
+      <div className="custom-ranges__list">
+        <div className="custom-ranges__list-header">
+          <h2>Your Custom Ranges ({ranges.length})</h2>
+          {!editing && (
+            <button
+              type="button"
+              className="custom-ranges__add-btn"
+              onClick={handleAddNew}
+            >
+              + Add Custom Range
+            </button>
+          )}
+        </div>
+
+        {ranges.length === 0 ? (
+          <div className="custom-ranges__empty">
+            <p>
+              No custom ranges set. Default population-based ranges are being
+              used for all biomarkers. Click &quot;Add Custom Range&quot; to set
+              personalized thresholds from your doctor.
+            </p>
+          </div>
+        ) : (
+          <div className="custom-ranges__table-wrapper">
+            <table className="custom-ranges__table">
+              <thead>
+                <tr>
+                  <th>Biomarker</th>
+                  <th>Green</th>
+                  <th>Yellow</th>
+                  <th>Direction</th>
+                  <th>Source</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ranges.map((range) => (
+                  <tr key={range.id}>
+                    <td className="custom-ranges__biomarker-name">
+                      {range.biomarker_name}
+                      <span className="custom-ranges__custom-badge">
+                        Custom
+                      </span>
+                    </td>
+                    <td>
+                      {formatBound(range.green_low)} &ndash;{" "}
+                      {formatBound(range.green_high)}
+                    </td>
+                    <td>
+                      {formatBound(range.yellow_low)} &ndash;{" "}
+                      {formatBound(range.yellow_high)}
+                    </td>
+                    <td>{formatDirection(range.direction)}</td>
+                    <td>{range.source || "---"}</td>
+                    <td className="custom-ranges__actions">
+                      <button
+                        type="button"
+                        className="custom-ranges__edit-btn"
+                        onClick={() => handleEdit(range)}
+                        disabled={!!editing}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className="custom-ranges__delete-btn"
+                        onClick={() => handleDelete(range.biomarker_name)}
+                        disabled={deleting === range.biomarker_name}
+                      >
+                        {deleting === range.biomarker_name
+                          ? "Removing..."
+                          : "Reset to Default"}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatBound(val: number | null): string {
+  if (val === null || val === undefined) return "---";
+  return String(val);
+}
+
+function formatDirection(dir: string): string {
+  switch (dir) {
+    case "lower-is-better":
+      return "Lower better";
+    case "higher-is-better":
+      return "Higher better";
+    case "range":
+      return "Range";
+    default:
+      return dir;
+  }
+}

--- a/lib/health/flag-biomarker.ts
+++ b/lib/health/flag-biomarker.ts
@@ -6,7 +6,23 @@
  * didn't include reference ranges.
  */
 
-import { REFERENCE_RANGES, type RiskFlag, type ReferenceRange } from "./reference-ranges";
+import { REFERENCE_RANGES, type RiskFlag, type ReferenceRange, type RangeThreshold } from "./reference-ranges";
+
+/**
+ * Shape of a custom reference range row from the database.
+ * Used to override default ranges on a per-user, per-biomarker basis (#50).
+ */
+export interface CustomRange {
+  biomarker_name: string;
+  green_low: number | null;
+  green_high: number | null;
+  yellow_low: number | null;
+  yellow_high: number | null;
+  red_low: number | null;
+  red_high: number | null;
+  direction: "lower-is-better" | "higher-is-better" | "range";
+  source?: string | null;
+}
 
 /**
  * Measurements that should NOT be flagged as risk indicators.
@@ -225,16 +241,101 @@ export function applyServerSideFlags<
   T extends { name: string; value: number | null; flag: RiskFlag },
 >(
   biomarkers: T[],
-  gender?: "male" | "female"
+  gender?: "male" | "female",
+  customRanges?: CustomRange[]
 ): T[] {
   return biomarkers.map((b) => {
     if (b.value == null) return b;
 
-    const serverFlag = flagBiomarker(b.name, b.value, gender);
+    const serverFlag = flagBiomarkerWithCustomRanges(
+      b.name,
+      b.value,
+      customRanges,
+      gender
+    );
     if (serverFlag) {
       return { ...b, flag: serverFlag };
     }
     // Keep Claude's flag as fallback for unrecognized biomarkers
     return b;
   });
+}
+
+// ---------------------------------------------------------------------------
+// Custom reference range support (#50)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a lookup map from normalized biomarker name to CustomRange.
+ */
+function buildCustomRangeMap(
+  customRanges: CustomRange[]
+): Map<string, CustomRange> {
+  const map = new Map<string, CustomRange>();
+  for (const cr of customRanges) {
+    map.set(normalizeName(cr.biomarker_name), cr);
+  }
+  return map;
+}
+
+/**
+ * Convert a CustomRange row into a ReferenceRange-like object
+ * so we can reuse the existing classify* functions.
+ */
+function customRangeToReferenceRange(cr: CustomRange): ReferenceRange {
+  return {
+    name: cr.biomarker_name,
+    aliases: [],
+    unit: "",
+    ranges: {
+      green: { low: cr.green_low, high: cr.green_high } as RangeThreshold,
+      yellow: { low: cr.yellow_low, high: cr.yellow_high } as RangeThreshold,
+      red: { low: cr.red_low, high: cr.red_high } as RangeThreshold,
+    },
+    direction: cr.direction,
+    source: cr.source ?? "Custom",
+  };
+}
+
+/**
+ * Flag a biomarker value, checking user's custom ranges first,
+ * then falling back to default server-side reference ranges.
+ *
+ * @param name - The biomarker name as extracted by Claude
+ * @param value - The numeric value
+ * @param customRanges - Optional array of user's custom ranges from the database
+ * @param gender - Optional patient gender for gender-specific ranges
+ * @returns The risk flag color, or null if no matching range is found
+ */
+export function flagBiomarkerWithCustomRanges(
+  name: string,
+  value: number,
+  customRanges?: CustomRange[],
+  gender?: "male" | "female"
+): RiskFlag | null {
+  // Skip measurements that aren't risk indicators on their own
+  const normalized = normalizeName(name);
+  if (SKIP_FLAG_NAMES.some((skip) => normalized === skip)) {
+    return "green";
+  }
+
+  // Check custom ranges first
+  if (customRanges && customRanges.length > 0) {
+    const customMap = buildCustomRangeMap(customRanges);
+    const customRange = customMap.get(normalized);
+    if (customRange) {
+      const ref = customRangeToReferenceRange(customRange);
+      switch (ref.direction) {
+        case "lower-is-better":
+          return classifyLowerIsBetter(value, ref);
+        case "higher-is-better":
+          return classifyHigherIsBetter(value, ref);
+        case "range":
+          return classifyRange(value, ref);
+      }
+    }
+  }
+
+  // Fall back to default reference ranges
+  return flagBiomarker(name, value, gender);
 }

--- a/supabase/migrations/009_custom_reference_ranges.sql
+++ b/supabase/migrations/009_custom_reference_ranges.sql
@@ -1,0 +1,27 @@
+-- Custom reference ranges per user (#50)
+-- Allows users to set personalized biomarker thresholds that override defaults.
+
+CREATE TABLE custom_reference_ranges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  biomarker_name text NOT NULL,
+  green_low numeric,
+  green_high numeric,
+  yellow_low numeric,
+  yellow_high numeric,
+  red_low numeric,
+  red_high numeric,
+  direction text NOT NULL DEFAULT 'range'
+    CHECK (direction IN ('lower-is-better', 'higher-is-better', 'range')),
+  source text,
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL,
+  UNIQUE(user_id, biomarker_name)
+);
+
+ALTER TABLE custom_reference_ranges ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own custom ranges"
+  ON custom_reference_ranges FOR ALL TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- Add per-user custom reference ranges that override population-based defaults when flagging biomarker results
- New `custom_reference_ranges` table with RLS, CRUD API at `/api/profile/reference-ranges`, management page at `/profile/reference-ranges`
- Parse route now loads user's custom ranges and passes them to `applyServerSideFlags()` for priority-based flagging

## Changes
- **Migration**: `009_custom_reference_ranges.sql` — table with RLS policy
- **API**: `app/api/profile/reference-ranges/route.ts` — GET/POST/DELETE for custom ranges
- **Flagging**: `lib/health/flag-biomarker.ts` — new `flagBiomarkerWithCustomRanges()` and `CustomRange` type; `applyServerSideFlags()` now accepts optional custom ranges
- **Parse route**: `app/api/parse/route.ts` — loads custom ranges from DB before flagging
- **UI**: `app/profile/reference-ranges/page.tsx` — management page with add/edit/delete
- **Profile**: `app/profile/page.tsx` — link card to custom ranges page
- **CSS**: BEM-styled `.custom-ranges__*` and `.profile-page__link-card` classes
- **Tests**: 16 new tests in `custom-reference-ranges.test.ts`

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npx vitest run` — all 569 tests pass (including 16 new)
- [ ] Manual: Navigate to Profile > Custom Reference Ranges
- [ ] Manual: Add a custom range for Glucose with extended green threshold
- [ ] Manual: Upload a lab report and verify custom range is applied
- [ ] Manual: Delete custom range and verify fallback to default
- [ ] Manual: Verify RLS prevents cross-user access

Closes #50