### PR TITLE
fix(ui): white background, reports as 4-across cards, modernize

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -69,8 +69,8 @@ body {
   font-family: var(--font-body), system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
   line-height: 1.6;
-  color: #134e4a;
-  background: var(--color-green-50);
+  color: var(--color-gray-900);
+  background: #fafafa;
   margin: 0;
   padding: 0;
   font-size: 1rem;
@@ -432,9 +432,8 @@ button[type="submit"]:disabled {
   display: block;
   background: white;
   border: 1px solid var(--color-gray-200);
-  border-left: 4px solid var(--color-green-500);
-  border-radius: var(--radius-md);
-  padding: 1.25rem;
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
   text-decoration: none;
   color: inherit;
   box-shadow: var(--shadow-sm);
@@ -862,14 +861,14 @@ button[type="submit"]:disabled {
 
 .upload-label {
   display: block;
-  padding: 2rem;
-  border: 2px dashed var(--color-green-300);
-  border-radius: var(--radius-md);
+  padding: 2.5rem;
+  border: 2px dashed var(--color-gray-300);
+  border-radius: var(--radius-lg);
   text-align: center;
   cursor: pointer;
   color: var(--color-gray-500);
-  background: var(--color-green-50);
-  transition: border-color 0.2s, color 0.2s;
+  background: white;
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
 }
 
 .upload-label:hover {
@@ -3211,89 +3210,108 @@ button.chat-send-button[type="submit"]:disabled {
   text-decoration: underline;
 }
 
-.report-list__items {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  margin-top: 0.75rem;
+/* Report card grid — 4 across on desktop */
+.report-list__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-top: 1rem;
 }
 
-.report-list__item {
+@media (max-width: 1024px) {
+  .report-list__grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .report-list__grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .report-list__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.report-list__card {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  text-align: center;
+  padding: 1.5rem 1rem;
   background: white;
   border: 1px solid var(--color-gray-200);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   text-decoration: none;
   color: inherit;
   box-shadow: var(--shadow-sm);
-  transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s;
+  cursor: pointer;
+  position: relative;
 }
 
-.report-list__item:hover {
+.report-list__card:hover {
   border-color: var(--color-green-500);
-  box-shadow: var(--shadow-md);
-  transform: translateY(-1px);
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-3px);
 }
 
-.report-list__item-icon {
-  flex-shrink: 0;
+.report-list__card-icon {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  width: 56px;
+  height: 56px;
   background: var(--color-gray-50);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
+  margin-bottom: 0.75rem;
 }
 
-.report-list__item-info {
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
-  flex: 1;
-  min-width: 0;
+.report-list__card-name {
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--color-gray-900);
+  margin-bottom: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
 }
 
-.report-list__item-name {
-  font-weight: 500;
-  font-size: 0.9375rem;
-}
-
-.report-list__item-date {
+.report-list__card-date {
   font-size: 0.75rem;
   color: var(--color-gray-400);
+  margin-bottom: 0.75rem;
 }
 
-.report-list__item-status {
+.report-list__card-status {
   display: inline-block;
-  padding: 0.125rem 0.5rem;
+  padding: 0.25rem 0.75rem;
   border-radius: 9999px;
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   font-weight: 500;
-  flex-shrink: 0;
-  margin-left: auto;
   white-space: nowrap;
 }
 
-.report-list__item-status--parsed {
+.report-list__card-status--parsed {
   background: var(--color-green-100);
   color: var(--color-green-800);
 }
 
-.report-list__item-status--parsing {
+.report-list__card-status--parsing {
   background: var(--color-blue-100);
   color: #1e40af;
 }
 
-.report-list__item-status--uploaded {
+.report-list__card-status--uploaded {
   background: var(--color-orange-100);
   color: var(--color-orange-700);
 }
 
-.report-list__item-status--error {
+.report-list__card-status--error {
   background: var(--color-red-100);
   color: var(--color-red-600);
 }

--- a/components/reports/ReportList.tsx
+++ b/components/reports/ReportList.tsx
@@ -133,43 +133,41 @@ export default function ReportList() {
           </Link>
         )}
       </div>
-      <div className="report-list__items">
+      <div className="report-list__grid">
         {reports.map((report) => (
           <Link
             key={report.id}
             href={`/reports/${report.id}`}
-            className="report-list__item"
+            className="report-list__card"
           >
-            <div className="report-list__item-icon" aria-hidden="true">
+            <div className="report-list__card-icon" aria-hidden="true">
               {report.file_type === "pdf" ? (
-                <svg viewBox="0 0 24 24" width="28" height="28" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <svg viewBox="0 0 24 24" width="36" height="36" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <path d="M6 2C4.9 2 4 2.9 4 4v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6H6z" fill="#ef4444" opacity="0.15"/>
                   <path d="M6 2C4.9 2 4 2.9 4 4v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6H6z" stroke="#ef4444" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" fill="none"/>
                   <path d="M14 2v6h6" stroke="#ef4444" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
                   <text x="12" y="17" textAnchor="middle" fill="#ef4444" fontSize="5" fontWeight="bold" fontFamily="system-ui">PDF</text>
                 </svg>
               ) : (
-                <svg viewBox="0 0 24 24" width="28" height="28" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <svg viewBox="0 0 24 24" width="36" height="36" fill="none" xmlns="http://www.w3.org/2000/svg">
                   <rect x="3" y="3" width="18" height="18" rx="2" fill="#3b82f6" opacity="0.15" stroke="#3b82f6" strokeWidth="1.5"/>
                   <circle cx="8.5" cy="8.5" r="2" fill="#3b82f6" opacity="0.5"/>
                   <path d="M21 15l-5-5L5 21" stroke="#3b82f6" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
                 </svg>
               )}
             </div>
-            <div className="report-list__item-info">
-              <span className="report-list__item-name">
-                {report.file_name}
-              </span>
-              <span className="report-list__item-date">
-                {new Date(report.created_at).toLocaleDateString("en-US", {
-                  month: "short",
-                  day: "numeric",
-                  year: "numeric",
-                })}
-              </span>
-            </div>
+            <span className="report-list__card-name">
+              {report.file_name}
+            </span>
+            <span className="report-list__card-date">
+              {new Date(report.created_at).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </span>
             <span
-              className={`report-list__item-status report-list__item-status--${report.status}`}
+              className={`report-list__card-status report-list__card-status--${report.status}`}
             >
               {statusLabel[report.status] || report.status}
             </span>


### PR DESCRIPTION
## Summary
- **White background** — removed green tint (#fafafa instead of green-50)
- **Reports as 4-across card grid** — centered cards with icon, name, date, status badge (responsive: 4→3→2→1)
- **Upload area**: clean white with gray dashed border instead of green
- **Dashboard cards**: removed green left border, larger border radius
- **Report icons**: increased to 36px

## Test plan
- [x] All 688 tests pass
- [ ] White background on all pages
- [ ] Reports page shows cards in 4-across grid
- [ ] Responsive on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)