### PR TITLE
feat(chat): inline upload, report dating, multi-report context

### DIFF
--- a/__tests__/audit-logging.test.ts
+++ b/__tests__/audit-logging.test.ts
@@ -164,6 +164,7 @@ describe("Audit Logger", () => {
         "report.view",
         "report.parse",
         "report.delete",
+        "report.chat_upload",
         "chat.message",
         "chat.delete",
         "doctor_questions.generate",
@@ -171,6 +172,7 @@ describe("Audit Logger", () => {
 
       const resourceTypes: Record<AuditAction, AuditResourceType> = {
         "report.upload": "report",
+        "report.chat_upload": "report",
         "report.view": "report",
         "report.parse": "report",
         "report.delete": "report",

--- a/__tests__/chat-upload-multi-report.test.ts
+++ b/__tests__/chat-upload-multi-report.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  buildMultiReportContext,
+  buildReportContext,
+} from "@/lib/claude/chat-prompts";
+import type { MultiReportData } from "@/lib/claude/chat-prompts";
+import type { ParsedReportResult } from "@/lib/claude/parse-report";
+
+// Mock Anthropic SDK
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      create: vi.fn(),
+      stream: vi.fn(),
+    },
+  })),
+}));
+
+describe("Chat Upload API", () => {
+  describe("chat/upload route structure", () => {
+    it("exports a POST handler", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/upload/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("export async function POST");
+    });
+
+    it("validates authentication", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/upload/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("supabase.auth.getUser()");
+      expect(source).toContain("Unauthorized");
+    });
+
+    it("uses same validation as main upload", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/upload/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("validateFile");
+      expect(source).toContain("validateFileContent");
+      expect(source).toContain("uploadToStorage");
+    });
+
+    it("creates a report record", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/upload/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain('.from("reports")');
+      expect(source).toContain(".insert(");
+    });
+
+    it("returns report_id on success", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/upload/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("report_id: report.id");
+      expect(source).toContain("status: 201");
+    });
+
+    it("logs audit event for chat upload", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/upload/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("logAuditEvent");
+      expect(source).toContain("report.chat_upload");
+    });
+  });
+});
+
+describe("Report date extraction", () => {
+  describe("parse prompt includes report_date", () => {
+    it("includes report_date field in extraction prompt", async () => {
+      const { PARSE_REPORT_SYSTEM_PROMPT } = await import(
+        "@/lib/claude/prompts"
+      );
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain("report_date");
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain("YYYY-MM-DD");
+    });
+  });
+
+  describe("ParsedReportResult includes report_date", () => {
+    it("accepts report_date in parsed result", () => {
+      const result: ParsedReportResult = {
+        biomarkers: [
+          {
+            name: "Glucose",
+            value: 95,
+            unit: "mg/dL",
+            reference_low: 70,
+            reference_high: 100,
+            flag: "green",
+          },
+        ],
+        summary: "Normal blood work.",
+        report_date: "2024-03-15",
+      };
+
+      expect(result.report_date).toBe("2024-03-15");
+    });
+
+    it("accepts null report_date", () => {
+      const result: ParsedReportResult = {
+        biomarkers: [],
+        summary: "No data.",
+        report_date: null,
+      };
+
+      expect(result.report_date).toBeNull();
+    });
+  });
+
+  describe("parse route saves report_date", () => {
+    it("updates report with extracted report_date", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/parse/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("report_date");
+      expect(source).toContain("parsed.report_date");
+    });
+  });
+});
+
+describe("Multi-report context", () => {
+  describe("buildMultiReportContext", () => {
+    it("returns empty string for no reports", () => {
+      const result = buildMultiReportContext([]);
+      expect(result).toBe("");
+    });
+
+    it("includes report filename and date", () => {
+      const reports: MultiReportData[] = [
+        {
+          filename: "bloodwork_march.pdf",
+          report_date: "2024-03-15",
+          created_at: "2024-03-16T10:00:00Z",
+          biomarkers: [
+            { name: "Glucose", value: 95, unit: "mg/dL", flag: "green" },
+          ],
+          summary_plain: "Normal blood sugar.",
+        },
+      ];
+
+      const result = buildMultiReportContext(reports);
+      expect(result).toContain("bloodwork_march.pdf");
+      expect(result).toContain("2024-03-15");
+      expect(result).toContain("Glucose: 95 mg/dL");
+    });
+
+    it("falls back to upload date when report_date is null", () => {
+      const reports: MultiReportData[] = [
+        {
+          filename: "scan.png",
+          report_date: null,
+          created_at: "2024-04-01T10:00:00Z",
+          biomarkers: [],
+          summary_plain: "Scan results.",
+        },
+      ];
+
+      const result = buildMultiReportContext(reports);
+      expect(result).toContain("uploaded 2024-04-01");
+    });
+
+    it("includes flagged biomarkers with uppercase label", () => {
+      const reports: MultiReportData[] = [
+        {
+          filename: "test.pdf",
+          report_date: "2024-01-01",
+          created_at: "2024-01-02T00:00:00Z",
+          biomarkers: [
+            { name: "LDL", value: 190, unit: "mg/dL", flag: "red" },
+          ],
+          summary_plain: "High LDL.",
+        },
+      ];
+
+      const result = buildMultiReportContext(reports);
+      expect(result).toContain("[RED]");
+    });
+
+    it("does not flag green biomarkers", () => {
+      const reports: MultiReportData[] = [
+        {
+          filename: "test.pdf",
+          report_date: "2024-01-01",
+          created_at: "2024-01-02T00:00:00Z",
+          biomarkers: [
+            { name: "Glucose", value: 90, unit: "mg/dL", flag: "green" },
+          ],
+          summary_plain: "Normal.",
+        },
+      ];
+
+      const result = buildMultiReportContext(reports);
+      expect(result).not.toContain("[GREEN]");
+    });
+
+    it("handles multiple reports with date-aware context", () => {
+      const reports: MultiReportData[] = [
+        {
+          filename: "march_labs.pdf",
+          report_date: "2024-03-15",
+          created_at: "2024-03-16T00:00:00Z",
+          biomarkers: [
+            { name: "Glucose", value: 95, unit: "mg/dL", flag: "green" },
+          ],
+          summary_plain: "March blood work.",
+        },
+        {
+          filename: "june_labs.pdf",
+          report_date: "2024-06-10",
+          created_at: "2024-06-11T00:00:00Z",
+          biomarkers: [
+            { name: "Glucose", value: 110, unit: "mg/dL", flag: "yellow" },
+          ],
+          summary_plain: "June blood work.",
+        },
+      ];
+
+      const result = buildMultiReportContext(reports);
+      expect(result).toContain("march_labs.pdf");
+      expect(result).toContain("june_labs.pdf");
+      expect(result).toContain("2024-03-15");
+      expect(result).toContain("2024-06-10");
+      expect(result).toContain("compare values across reports");
+    });
+
+    it("truncates when context exceeds max length", () => {
+      // Create a very large report to trigger truncation
+      const bigBiomarkers = Array.from({ length: 500 }, (_, i) => ({
+        name: `Biomarker_${i}_with_a_very_long_name_for_testing`,
+        value: i * 10,
+        unit: "mg/dL",
+        flag: "green" as const,
+      }));
+
+      const reports: MultiReportData[] = [
+        {
+          filename: "huge_report.pdf",
+          report_date: "2024-01-01",
+          created_at: "2024-01-02T00:00:00Z",
+          biomarkers: bigBiomarkers,
+          summary_plain: "A very large report with many biomarkers.",
+        },
+      ];
+
+      const result = buildMultiReportContext(reports);
+      expect(result).toContain("[...truncated]");
+    });
+  });
+
+  describe("chat route multi-report loading", () => {
+    it("loads multi-report context when no report_id", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("buildMultiReportContext");
+      expect(source).toContain("Multi-report context");
+      expect(source).toContain(".limit(5)");
+    });
+
+    it("still supports single-report context with report_id", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routePath = path.resolve(
+        __dirname,
+        "../app/api/chat/route.ts"
+      );
+      const source = fs.readFileSync(routePath, "utf-8");
+
+      expect(source).toContain("buildReportContext");
+      expect(source).toContain("Single-report context");
+    });
+  });
+});
+
+describe("ChatInput file upload UI", () => {
+  it("exports ChatInput component", async () => {
+    const mod = await import("@/components/chat/ChatInput");
+    expect(mod.ChatInput).toBeDefined();
+  });
+
+  it("includes attach button with paperclip icon", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const componentPath = path.resolve(
+      __dirname,
+      "../components/chat/ChatInput.tsx"
+    );
+    const source = fs.readFileSync(componentPath, "utf-8");
+
+    expect(source).toContain("chat-input__attach-btn");
+    expect(source).toContain('aria-label="Attach file"');
+    expect(source).toContain("svg");
+  });
+
+  it("has hidden file input for PDF/PNG/JPG", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const componentPath = path.resolve(
+      __dirname,
+      "../components/chat/ChatInput.tsx"
+    );
+    const source = fs.readFileSync(componentPath, "utf-8");
+
+    expect(source).toContain('accept=".pdf,.png,.jpg,.jpeg"');
+    expect(source).toContain("chat-input__file-hidden");
+  });
+
+  it("has file preview with upload and remove buttons", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const componentPath = path.resolve(
+      __dirname,
+      "../components/chat/ChatInput.tsx"
+    );
+    const source = fs.readFileSync(componentPath, "utf-8");
+
+    expect(source).toContain("chat-input__file-preview");
+    expect(source).toContain("chat-input__file-preview-upload");
+    expect(source).toContain("chat-input__file-preview-remove");
+  });
+
+  it("has upload progress indicator", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const componentPath = path.resolve(
+      __dirname,
+      "../components/chat/ChatInput.tsx"
+    );
+    const source = fs.readFileSync(componentPath, "utf-8");
+
+    expect(source).toContain("chat-input__upload-progress");
+    expect(source).toContain("Uploading");
+    expect(source).toContain("Analyzing");
+  });
+
+  it("supports onFileUpload callback prop", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const componentPath = path.resolve(
+      __dirname,
+      "../components/chat/ChatInput.tsx"
+    );
+    const source = fs.readFileSync(componentPath, "utf-8");
+
+    expect(source).toContain("onFileUpload");
+  });
+});

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { getClaudeClient } from "@/lib/claude/client";
-import { CHAT_SYSTEM_PROMPT, buildReportContext, buildHealthContext } from "@/lib/claude/chat-prompts";
+import { CHAT_SYSTEM_PROMPT, buildReportContext, buildHealthContext, buildMultiReportContext } from "@/lib/claude/chat-prompts";
 import { logAuditEvent, getClientIp } from "@/lib/audit/logger";
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
@@ -99,12 +99,12 @@ export async function POST(request: Request) {
 
   const healthContext = profileData ? buildHealthContext(profileData) : "";
 
-  // Load report context only for the specific report_id.
-  // Each chat session is tied to one report — results may differ between reports.
+  // Load report context — single report if report_id provided, otherwise multi-report
   let reportContext = "";
   const reportId = body.report_id;
 
   if (reportId) {
+    // Single-report context: load the specific report's parsed data
     const { data: parsedResult } = await supabase
       .from("parsed_results")
       .select("biomarkers, summary_plain")
@@ -115,6 +115,54 @@ export async function POST(request: Request) {
 
     if (parsedResult && parsedResult.biomarkers) {
       reportContext = buildReportContext(parsedResult);
+    }
+  } else {
+    // Multi-report context: load ALL user's parsed reports (up to 5 most recent)
+    const { data: userReports } = await supabase
+      .from("reports")
+      .select("id, original_filename, report_date, created_at")
+      .eq("user_id", user.id)
+      .eq("status", "parsed")
+      .order("report_date", { ascending: false, nullsFirst: false })
+      .limit(5);
+
+    if (userReports && userReports.length > 0) {
+      const reportIds = userReports.map((r) => r.id);
+      const { data: allParsed } = await supabase
+        .from("parsed_results")
+        .select("report_id, biomarkers, summary_plain")
+        .in("report_id", reportIds)
+        .order("created_at", { ascending: false });
+
+      if (allParsed && allParsed.length > 0) {
+        // Build a map of report_id -> latest parsed result
+        const parsedMap = new Map<string, typeof allParsed[0]>();
+        for (const p of allParsed) {
+          if (!parsedMap.has(p.report_id)) {
+            parsedMap.set(p.report_id, p);
+          }
+        }
+
+        const multiReportData = userReports
+          .filter((r) => parsedMap.has(r.id))
+          .map((r) => {
+            const parsed = parsedMap.get(r.id)!;
+            return {
+              filename: r.original_filename,
+              report_date: r.report_date,
+              created_at: r.created_at,
+              biomarkers: (parsed.biomarkers || []).map((b: { name: string; value: number; unit: string; flag: string }) => ({
+                name: b.name,
+                value: b.value,
+                unit: b.unit,
+                flag: b.flag,
+              })),
+              summary_plain: parsed.summary_plain,
+            };
+          });
+
+        reportContext = buildMultiReportContext(multiReportData);
+      }
     }
   }
 

--- a/app/api/chat/upload/route.ts
+++ b/app/api/chat/upload/route.ts
@@ -1,0 +1,116 @@
+import { createClient } from "@/lib/supabase/server";
+import {
+  validateFile,
+  validateFileContent,
+  uploadToStorage,
+  getFileType,
+} from "@/lib/supabase/storage";
+import { logAuditEvent, getClientIp } from "@/lib/audit/logger";
+import { NextResponse } from "next/server";
+
+/**
+ * Chat inline file upload endpoint.
+ * Uses the same validation pipeline as the main upload (/api/upload),
+ * then creates a report record and triggers parsing.
+ */
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  // Verify authentication
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Parse form data
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid form data" },
+      { status: 400 }
+    );
+  }
+
+  const file = formData.get("file") as File | null;
+
+  if (!file) {
+    return NextResponse.json(
+      { error: "No file provided" },
+      { status: 400 }
+    );
+  }
+
+  // Validate file type and size (same validation as main upload)
+  const validation = validateFile(file);
+  if (!validation.valid) {
+    return NextResponse.json(
+      { error: validation.error },
+      { status: validation.statusCode }
+    );
+  }
+
+  // Validate file content matches declared MIME type (magic bytes check)
+  const contentValid = await validateFileContent(file);
+  if (!contentValid) {
+    return NextResponse.json(
+      { error: "File content does not match its declared type. Please upload a valid PDF, PNG, or JPG file." },
+      { status: 400 }
+    );
+  }
+
+  // Upload to Supabase Storage
+  const { filePath, error: uploadError } = await uploadToStorage(
+    supabase,
+    user.id,
+    file
+  );
+
+  if (uploadError) {
+    console.error("[CHAT_UPLOAD] Storage upload failed:", uploadError);
+    return NextResponse.json(
+      { error: "Upload failed. Please try again or contact support." },
+      { status: 500 }
+    );
+  }
+
+  // Create report record in database
+  const { data: report, error: dbError } = await supabase
+    .from("reports")
+    .insert({
+      user_id: user.id,
+      file_path: filePath,
+      file_type: getFileType(file),
+      original_filename: file.name,
+      status: "uploaded",
+    })
+    .select("id, status")
+    .single();
+
+  if (dbError) {
+    // Clean up uploaded file on DB failure
+    await supabase.storage.from("medical-reports").remove([filePath]);
+    return NextResponse.json(
+      { error: "Failed to create report record" },
+      { status: 500 }
+    );
+  }
+
+  // Audit log: chat inline upload (fire-and-forget)
+  logAuditEvent({
+    userId: user.id,
+    action: "report.chat_upload",
+    resourceType: "report",
+    resourceId: report.id,
+    ipAddress: getClientIp(request),
+  });
+
+  return NextResponse.json(
+    { report_id: report.id, status: report.status, filename: file.name },
+    { status: 201 }
+  );
+}

--- a/app/api/parse/route.ts
+++ b/app/api/parse/route.ts
@@ -229,10 +229,14 @@ export async function POST(request: Request) {
       console.log("[PARSE] No risk flags to insert (all biomarkers filtered out)");
     }
 
-    // Update report status to 'parsed'
+    // Update report status to 'parsed' and store extracted report_date
+    const reportUpdate: { status: string; report_date?: string } = { status: "parsed" };
+    if (parsed.report_date) {
+      reportUpdate.report_date = parsed.report_date;
+    }
     await supabase
       .from("reports")
-      .update({ status: "parsed" })
+      .update(reportUpdate)
       .eq("id", report.id);
 
     // Audit log: report parse (fire-and-forget)

--- a/app/globals.css
+++ b/app/globals.css
@@ -1404,6 +1404,119 @@ button.chat-send-button[type="submit"]:disabled {
   font-size: 0.85rem;
 }
 
+/* Chat input wrapper and file upload */
+.chat-input__wrapper {
+  flex-shrink: 0;
+}
+
+.chat-input__attach-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: none;
+  color: var(--color-gray-500);
+  cursor: pointer;
+  border-radius: 50%;
+  flex-shrink: 0;
+  align-self: flex-end;
+  padding: 0;
+}
+
+.chat-input__attach-btn:hover {
+  color: var(--color-green-600);
+  background: var(--color-gray-100);
+}
+
+.chat-input__attach-btn:disabled {
+  color: var(--color-gray-300);
+  cursor: not-allowed;
+}
+
+.chat-input__file-hidden {
+  display: none;
+}
+
+.chat-input__file-preview {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  margin-bottom: 0.25rem;
+  background: var(--color-blue-50);
+  border: 1px solid var(--color-blue-200);
+  border-radius: var(--radius-md);
+  font-size: 0.85rem;
+}
+
+.chat-input__file-preview-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-gray-700);
+}
+
+.chat-input__file-preview-upload {
+  padding: 0.2rem 0.6rem;
+  background: var(--color-green-600);
+  color: white;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.chat-input__file-preview-upload:hover {
+  background: var(--color-green-700);
+}
+
+.chat-input__file-preview-remove {
+  padding: 0.2rem 0.5rem;
+  background: none;
+  border: none;
+  color: var(--color-gray-500);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.chat-input__file-preview-remove:hover {
+  color: var(--color-red-500);
+}
+
+.chat-input__upload-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  margin-bottom: 0.25rem;
+  background: var(--color-green-50);
+  border: 1px solid var(--color-green-200);
+  border-radius: var(--radius-md);
+  font-size: 0.85rem;
+  color: var(--color-gray-700);
+}
+
+.chat-input__upload-progress-spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-green-200);
+  border-top-color: var(--color-green-600);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
 /* Report Selector */
 
 .report-selector {

--- a/components/chat/ChatInput.tsx
+++ b/components/chat/ChatInput.tsx
@@ -5,11 +5,16 @@ import { useState, useRef } from "react";
 interface ChatInputProps {
   onSend: (message: string) => void;
   disabled?: boolean;
+  onFileUpload?: (file: File) => void;
+  uploadingFile?: string | null;
+  uploadProgress?: "uploading" | "parsing" | null;
 }
 
-export function ChatInput({ onSend, disabled }: ChatInputProps) {
+export function ChatInput({ onSend, disabled, onFileUpload, uploadingFile, uploadProgress }: ChatInputProps) {
   const [input, setInput] = useState("");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -37,27 +42,113 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
     textarea.style.height = `${Math.min(textarea.scrollHeight, 120)}px`;
   }
 
+  function handleAttachClick() {
+    fileInputRef.current?.click();
+  }
+
+  function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      setSelectedFile(file);
+    }
+    // Reset the input so the same file can be selected again
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }
+
+  function handleRemoveFile() {
+    setSelectedFile(null);
+  }
+
+  function handleUploadFile() {
+    if (selectedFile && onFileUpload) {
+      onFileUpload(selectedFile);
+      setSelectedFile(null);
+    }
+  }
+
   return (
-    <form className="chat-input-form" onSubmit={handleSubmit}>
-      <textarea
-        ref={textareaRef}
-        className="chat-input"
-        value={input}
-        onChange={handleInput}
-        onKeyDown={handleKeyDown}
-        placeholder="Ask about your health data..."
-        disabled={disabled}
-        rows={1}
-        aria-label="Chat message"
-      />
-      <button
-        type="submit"
-        className="chat-send-button"
-        disabled={!input.trim() || disabled}
-        aria-label="Send message"
-      >
-        Send
-      </button>
-    </form>
+    <div className="chat-input__wrapper">
+      {/* File preview bar */}
+      {selectedFile && !uploadProgress && (
+        <div className="chat-input__file-preview">
+          <span className="chat-input__file-preview-name">{selectedFile.name}</span>
+          <button
+            type="button"
+            className="chat-input__file-preview-upload"
+            onClick={handleUploadFile}
+            aria-label="Upload file"
+          >
+            Upload
+          </button>
+          <button
+            type="button"
+            className="chat-input__file-preview-remove"
+            onClick={handleRemoveFile}
+            aria-label="Remove file"
+          >
+            x
+          </button>
+        </div>
+      )}
+
+      {/* Upload progress indicator */}
+      {uploadProgress && uploadingFile && (
+        <div className="chat-input__upload-progress">
+          <span className="chat-input__upload-progress-spinner" aria-hidden="true"></span>
+          <span>
+            {uploadProgress === "uploading"
+              ? `Uploading ${uploadingFile}...`
+              : `Analyzing ${uploadingFile}...`}
+          </span>
+        </div>
+      )}
+
+      <form className="chat-input-form" onSubmit={handleSubmit}>
+        <button
+          type="button"
+          className="chat-input__attach-btn"
+          onClick={handleAttachClick}
+          disabled={disabled || !!uploadProgress}
+          aria-label="Attach file"
+          title="Upload a medical report"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+          </svg>
+        </button>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".pdf,.png,.jpg,.jpeg"
+          onChange={handleFileSelect}
+          className="chat-input__file-hidden"
+          aria-hidden="true"
+          tabIndex={-1}
+        />
+
+        <textarea
+          ref={textareaRef}
+          className="chat-input"
+          value={input}
+          onChange={handleInput}
+          onKeyDown={handleKeyDown}
+          placeholder="Ask about your health data..."
+          disabled={disabled}
+          rows={1}
+          aria-label="Chat message"
+        />
+        <button
+          type="submit"
+          className="chat-send-button"
+          disabled={!input.trim() || disabled}
+          aria-label="Send message"
+        >
+          Send
+        </button>
+      </form>
+    </div>
   );
 }

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useChat } from "@/hooks/useChat";
 import { MessageBubble, BotAvatar } from "./MessageBubble";
 import { ChatInput } from "./ChatInput";
@@ -28,6 +28,9 @@ export function ChatWindow({ reportId }: ChatWindowProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [sidebarRefreshKey, setSidebarRefreshKey] = useState(0);
   const [selectorDismissed, setSelectorDismissed] = useState(false);
+  const [uploadingFile, setUploadingFile] = useState<string | null>(null);
+  const [uploadProgress, setUploadProgress] = useState<"uploading" | "parsing" | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
 
   // Show report selector when: no reportId prop, no active session, not dismissed,
   // and no report already attached
@@ -59,6 +62,58 @@ export function ChatWindow({ reportId }: ChatWindowProps) {
 
   // Whether there is any report context active (prop or attached)
   const hasReportContext = !!reportId || !!attachedReport;
+
+  /** Handle inline file upload from chat input */
+  const handleFileUpload = useCallback(async (file: File) => {
+    setUploadingFile(file.name);
+    setUploadProgress("uploading");
+    setUploadError(null);
+
+    try {
+      // 1. Upload the file
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const uploadRes = await fetch("/api/chat/upload", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!uploadRes.ok) {
+        const data = await uploadRes.json();
+        throw new Error(data.error || "Upload failed");
+      }
+
+      const { report_id, filename } = await uploadRes.json();
+
+      // 2. Trigger parsing
+      setUploadProgress("parsing");
+
+      const parseRes = await fetch("/api/parse", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ report_id }),
+      });
+
+      if (!parseRes.ok) {
+        const data = await parseRes.json();
+        throw new Error(data.error || "Analysis failed");
+      }
+
+      // 3. Attach the report to the chat
+      attachReport({
+        id: report_id,
+        filename: filename || file.name,
+        date: new Date().toLocaleDateString(),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upload failed";
+      setUploadError(message);
+    } finally {
+      setUploadingFile(null);
+      setUploadProgress(null);
+    }
+  }, [attachReport]);
 
   return (
     <div className="chat-layout">
@@ -166,7 +221,19 @@ export function ChatWindow({ reportId }: ChatWindowProps) {
           </div>
         )}
 
-        <ChatInput onSend={sendMessage} disabled={isLoading} />
+        {uploadError && (
+          <div className="chat-error">
+            Upload: {uploadError}
+          </div>
+        )}
+
+        <ChatInput
+          onSend={sendMessage}
+          disabled={isLoading}
+          onFileUpload={handleFileUpload}
+          uploadingFile={uploadingFile}
+          uploadProgress={uploadProgress}
+        />
       </div>
     </div>
   );

--- a/lib/audit/logger.ts
+++ b/lib/audit/logger.ts
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 
 export type AuditAction =
   | "report.upload"
+  | "report.chat_upload"
   | "report.view"
   | "report.parse"
   | "report.delete"

--- a/lib/claude/chat-prompts.ts
+++ b/lib/claude/chat-prompts.ts
@@ -85,6 +85,57 @@ export function buildHealthContext(profile: {
   return `Patient health profile:\n${parts.join("\n")}\n\nUse this information to personalize your responses. For example, if the patient has diabetes, pay extra attention to glucose and A1C values.`;
 }
 
+const MAX_MULTI_REPORT_CHARS = 12000; // ~3000 tokens
+
+export interface MultiReportData {
+  filename: string;
+  report_date: string | null;
+  created_at: string;
+  biomarkers: Array<{
+    name: string;
+    value: number;
+    unit: string;
+    flag: string;
+  }>;
+  summary_plain: string;
+}
+
+/**
+ * Builds combined context from multiple reports for date-aware chat.
+ * Truncates if combined context exceeds token budget.
+ */
+export function buildMultiReportContext(reports: MultiReportData[]): string {
+  if (reports.length === 0) return "";
+
+  const sections: string[] = [];
+
+  for (const report of reports) {
+    const dateLabel = report.report_date
+      ? report.report_date
+      : `uploaded ${report.created_at.slice(0, 10)}`;
+
+    const biomarkerList = report.biomarkers
+      .map((b) => {
+        const flag = b.flag !== "green" ? ` [${b.flag.toUpperCase()}]` : "";
+        return `  - ${b.name}: ${b.value} ${b.unit}${flag}`;
+      })
+      .join("\n");
+
+    sections.push(
+      `--- Report: ${report.filename} (${dateLabel}) ---\nSummary: ${report.summary_plain}\nLab Results:\n${biomarkerList}`
+    );
+  }
+
+  let combined = sections.join("\n\n");
+
+  // Truncate if too long
+  if (combined.length > MAX_MULTI_REPORT_CHARS) {
+    combined = combined.slice(0, MAX_MULTI_REPORT_CHARS) + "\n[...truncated]";
+  }
+
+  return `Here are ALL of the patient's uploaded reports for context. Use the dates to track changes over time and provide date-aware insights.\n\n${combined}\n\nUse this data to answer the patient's questions. You can compare values across reports when relevant.`;
+}
+
 export function buildReportContext(parsedResult: {
   biomarkers: Array<{
     name: string;

--- a/lib/claude/parse-report.ts
+++ b/lib/claude/parse-report.ts
@@ -14,6 +14,7 @@ export interface ParsedBiomarker {
 export interface ParsedReportResult {
   biomarkers: ParsedBiomarker[];
   summary: string;
+  report_date: string | null;
 }
 
 /**

--- a/lib/claude/prompts.ts
+++ b/lib/claude/prompts.ts
@@ -23,7 +23,8 @@ Respond ONLY with valid JSON in this exact format:
       "flag": "string — 'green' if within range, 'yellow' if borderline, 'red' if outside range, 'unknown' if no range available. NOTE: this flag is advisory only; the server applies verified reference ranges after extraction"
     }
   ],
-  "summary": "string — 1-3 sentence plain-language summary of the report contents, written at a 5th grade reading level"
+  "summary": "string — 1-3 sentence plain-language summary of the report contents, written at a 5th grade reading level",
+  "report_date": "string or null — the date the lab test was performed or the report was issued, in YYYY-MM-DD format. Extract from the document content (look for collection date, test date, report date, or similar). Return null if no date found."
 }`;
 
 export const PARSE_REPORT_USER_PROMPT =

--- a/supabase/migrations/012_report_date.sql
+++ b/supabase/migrations/012_report_date.sql
@@ -1,0 +1,4 @@
+-- Add report_date column to reports table
+-- Stores the actual date the lab test was performed / report was issued,
+-- extracted from the document content during parsing.
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS report_date date;


### PR DESCRIPTION
## Summary
Closes #72

- **Inline chat file upload**: Paperclip/attachment button in chat input lets users upload files (PDF, PNG, JPG) directly in conversation. Same validation pipeline as main upload. Creates report record and triggers parse.
- **Report date extraction**: Parse prompt now extracts the actual test/report date from documents. New `report_date` column on reports table (migration 012). Stored after parsing completes.
- **Multi-report context**: When chatting without a specific report_id, loads up to 5 most recent parsed reports as context with dates, enabling date-aware responses like "your cholesterol improved since March."

## Changes
| File | What |
|------|------|
| `supabase/migrations/012_report_date.sql` | New migration: `report_date` column |
| `lib/claude/prompts.ts` | Added `report_date` to extraction prompt |
| `lib/claude/parse-report.ts` | Added `report_date` to `ParsedReportResult` |
| `app/api/parse/route.ts` | Save extracted `report_date` to report record |
| `lib/claude/chat-prompts.ts` | New `buildMultiReportContext()` function |
| `app/api/chat/route.ts` | Multi-report context when no report_id |
| `app/api/chat/upload/route.ts` | New inline chat upload endpoint |
| `components/chat/ChatInput.tsx` | Paperclip button, file preview, upload progress |
| `components/chat/ChatWindow.tsx` | File upload handler, progress state |
| `app/globals.css` | Styles for attach button, file preview, progress |
| `lib/audit/logger.ts` | New `report.chat_upload` audit action |
| `__tests__/chat-upload-multi-report.test.ts` | 25 new tests |
| `__tests__/audit-logging.test.ts` | Updated for new audit action |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] All 713 tests pass (32 test files, including 25 new tests)
- [ ] Manual: upload a file via chat paperclip button
- [ ] Manual: verify report_date is extracted and stored
- [ ] Manual: chat without selecting a report loads multi-report context
- [ ] Manual: run migration 012 on Supabase

Generated with [Claude Code](https://claude.com/claude-code)