### PR TITLE
fix(auth,perf): Next.js Link nav + singleton Supabase client

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -2,7 +2,8 @@
 
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import Link from "next/link";
 import Logo from "@/components/ui/Logo";
 
 export default function LoginPage() {
@@ -11,7 +12,7 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault();
@@ -74,7 +75,7 @@ export default function LoginPage() {
       </form>
 
       <p className="auth-link">
-        Don&apos;t have an account? <a href="/auth/signup">Sign up</a>
+        Don&apos;t have an account? <Link href="/auth/signup">Sign up</Link>
       </p>
     </div>
   );

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -2,7 +2,8 @@
 
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import Link from "next/link";
 import Logo from "@/components/ui/Logo";
 
 /** Validate password meets complexity requirements. */
@@ -20,7 +21,7 @@ export default function SignupPage() {
   const [passwordError, setPasswordError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
 
   async function handleSignup(e: React.FormEvent) {
     e.preventDefault();
@@ -100,7 +101,7 @@ export default function SignupPage() {
       </form>
 
       <p className="auth-link">
-        Already have an account? <a href="/auth/login">Log in</a>
+        Already have an account? <Link href="/auth/login">Log in</Link>
       </p>
     </div>
   );

--- a/app/dashboard/logout-button.tsx
+++ b/app/dashboard/logout-button.tsx
@@ -2,10 +2,11 @@
 
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 
 export function LogoutButton() {
   const router = useRouter();
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
 
   async function handleLogout() {
     await supabase.auth.signOut();

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import Logo from "@/components/ui/Logo";
@@ -27,7 +27,7 @@ export default function OnboardingPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const router = useRouter();
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
   const nameInputRef = useRef<HTMLInputElement>(null);
 
   // Redirect if not authenticated or already onboarded

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -2,7 +2,7 @@
 
 import { createClient } from "@/lib/supabase/client";
 import { useRouter } from "next/navigation";
-import { useState, useRef } from "react";
+import { useMemo, useState, useRef } from "react";
 import Link from "next/link";
 import NavHeader from "@/components/ui/NavHeader";
 
@@ -18,7 +18,7 @@ export default function UploadPage() {
   const [reportId, setReportId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
 
   function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
     setError(null);

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,8 +1,21 @@
 import { createBrowserClient } from "@supabase/ssr";
 
+/**
+ * Singleton browser Supabase client.
+ *
+ * `createBrowserClient` already deduplicates internally, but caching at module
+ * scope avoids the function-call overhead on every render and makes the
+ * singleton contract explicit. Safe in the browser because there is exactly one
+ * module instance per page load.
+ */
+let client: ReturnType<typeof createBrowserClient> | null = null;
+
 export function createClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  if (!client) {
+    client = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+  }
+  return client;
 }


### PR DESCRIPTION
## Summary
- **#39**: Replace `<a>` tags with Next.js `<Link>` on login and signup pages for client-side navigation (no full page reload)
- **#40**: Make browser Supabase client a module-level singleton in `lib/supabase/client.ts` and wrap all component-level `createClient()` calls with `useMemo` to prevent per-render re-creation

## Changes
| File | Change |
|------|--------|
| `lib/supabase/client.ts` | Singleton pattern with module-scoped cache |
| `app/auth/login/page.tsx` | `<a>` to `<Link>`, `useMemo` for Supabase client |
| `app/auth/signup/page.tsx` | `<a>` to `<Link>`, `useMemo` for Supabase client |
| `app/upload/page.tsx` | `useMemo` for Supabase client |
| `app/dashboard/logout-button.tsx` | `useMemo` for Supabase client |
| `app/onboarding/page.tsx` | `useMemo` for Supabase client |

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (713/713)
- [ ] Manual: navigate between login/signup — confirm no full page reload
- [ ] Manual: verify auth flows (login, signup, logout, upload) still work

Closes #39
Closes #40