### PR TITLE
feat(parse): confidence scoring for biomarker extractions

### DIFF
--- a/__tests__/chat-upload-multi-report.test.ts
+++ b/__tests__/chat-upload-multi-report.test.ts
@@ -120,6 +120,7 @@ describe("Report date extraction", () => {
             reference_low: 70,
             reference_high: 100,
             flag: "green",
+            confidence: 1.0,
           },
         ],
         summary: "Normal blood work.",

--- a/__tests__/confidence-scoring.test.ts
+++ b/__tests__/confidence-scoring.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  PARSE_REPORT_SYSTEM_PROMPT,
+} from "@/lib/claude/prompts";
+
+// Mock the Anthropic SDK
+const mockCreate = vi.fn();
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn().mockImplementation(() => ({
+    messages: {
+      create: mockCreate,
+    },
+  })),
+}));
+
+describe("Confidence Scoring (#133)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Prompt ────────────────────────────────────────────────────────
+
+  describe("Parse prompt includes confidence instruction", () => {
+    it("instructs Claude to provide confidence scores", () => {
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain("confidence");
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain("0.0 to 1.0");
+    });
+
+    it("describes confidence levels for different scenarios", () => {
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain("clearly printed values");
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain("partially visible");
+      expect(PARSE_REPORT_SYSTEM_PROMPT).toContain("below 0.7");
+    });
+  });
+
+  // ── ParsedBiomarker interface + default ───────────────────────────
+
+  describe("ParsedBiomarker confidence field", () => {
+    it("defaults confidence to 1.0 when not provided by Claude", async () => {
+      const mockResponse = {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              biomarkers: [
+                {
+                  name: "Glucose",
+                  value: 95,
+                  unit: "mg/dL",
+                  reference_low: 70,
+                  reference_high: 100,
+                  flag: "green",
+                  // no confidence field
+                },
+              ],
+              summary: "Blood sugar is normal.",
+            }),
+          },
+        ],
+      };
+      mockCreate.mockResolvedValue(mockResponse);
+
+      const { parseReportWithClaude } = await import(
+        "@/lib/claude/parse-report"
+      );
+      const result = await parseReportWithClaude("base64data", "image/jpeg");
+
+      expect(result.biomarkers[0].confidence).toBe(1.0);
+    });
+
+    it("preserves confidence when provided by Claude", async () => {
+      const mockResponse = {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              biomarkers: [
+                {
+                  name: "Glucose",
+                  value: 95,
+                  unit: "mg/dL",
+                  reference_low: 70,
+                  reference_high: 100,
+                  flag: "green",
+                  confidence: 0.85,
+                },
+                {
+                  name: "Cholesterol",
+                  value: 245,
+                  unit: "mg/dL",
+                  reference_low: 0,
+                  reference_high: 200,
+                  flag: "red",
+                  confidence: 0.5,
+                },
+              ],
+              summary: "Mixed results.",
+            }),
+          },
+        ],
+      };
+      mockCreate.mockResolvedValue(mockResponse);
+
+      const { parseReportWithClaude } = await import(
+        "@/lib/claude/parse-report"
+      );
+      const result = await parseReportWithClaude("base64data", "image/jpeg");
+
+      expect(result.biomarkers[0].confidence).toBe(0.85);
+      expect(result.biomarkers[1].confidence).toBe(0.5);
+    });
+  });
+
+  // ── RiskDashboard confidence UI ───────────────────────────────────
+
+  describe("RiskDashboard confidence indicators", () => {
+    it("RiskDashboard exports a default component", async () => {
+      const mod = await import("@/components/reports/RiskDashboard");
+      expect(mod.default).toBeDefined();
+      expect(typeof mod.default).toBe("function");
+    });
+
+    it("RiskFlagData interface accepts confidence field", () => {
+      // Type-level check: this compiles if the interface is correct
+      const flag = {
+        id: "f1",
+        biomarker_name: "Glucose",
+        value: 95,
+        reference_low: 70,
+        reference_high: 100,
+        flag: "green" as const,
+        trend: "stable",
+        confidence: 0.5,
+      };
+      expect(flag.confidence).toBe(0.5);
+    });
+  });
+
+  // ── Risk flags API includes confidence ────────────────────────────
+
+  describe("Risk flags API returns confidence", () => {
+    it("SELECT query includes confidence column", async () => {
+      // Read the source to verify the SELECT includes confidence
+      const fs = await import("fs");
+      const path = await import("path");
+      const routeSource = fs.readFileSync(
+        path.resolve("app/api/risk-flags/route.ts"),
+        "utf-8"
+      );
+      expect(routeSource).toContain("confidence");
+    });
+  });
+
+  // ── Parse route passes confidence to risk_flags ───────────────────
+
+  describe("Parse route includes confidence in risk_flags", () => {
+    it("parse route maps confidence to risk_flags insert", async () => {
+      const fs = await import("fs");
+      const path = await import("path");
+      const routeSource = fs.readFileSync(
+        path.resolve("app/api/parse/route.ts"),
+        "utf-8"
+      );
+      // The risk flags mapping should include confidence
+      expect(routeSource).toContain("confidence: b.confidence");
+    });
+  });
+});

--- a/app/api/parse/route.ts
+++ b/app/api/parse/route.ts
@@ -204,6 +204,7 @@ export async function POST(request: Request) {
         reference_high: b.reference_high,
         flag: b.flag,
         trend: "unknown" as const,
+        confidence: b.confidence ?? 1.0,
       }));
 
     if (riskFlags.length > 0) {

--- a/app/api/risk-flags/route.ts
+++ b/app/api/risk-flags/route.ts
@@ -67,7 +67,7 @@ export async function GET(request: Request) {
   const { data: riskFlags, error: flagsError } = await supabase
     .from("risk_flags")
     .select(
-      "id, biomarker_name, value, reference_low, reference_high, flag, trend, created_at"
+      "id, biomarker_name, value, reference_low, reference_high, flag, trend, confidence, created_at"
     )
     .eq("parsed_result_id", parsedResult.id)
     .order("created_at", { ascending: true });

--- a/app/globals.css
+++ b/app/globals.css
@@ -2215,6 +2215,37 @@ button.chat-send-button[type="submit"]:disabled {
   grid-column: span 2;
 }
 
+.risk-card__confidence-warning {
+  font-size: 0.75rem;
+  color: var(--color-orange-600);
+  background: #fff8e1;
+  border: 1px solid #ffe082;
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.5rem;
+  margin-top: 0.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.risk-card__confidence-warning::before {
+  content: "\26A0";
+  font-size: 0.85rem;
+}
+
+.risk-card__confidence-note {
+  font-size: 0.7rem;
+  color: var(--color-gray-500);
+  font-style: italic;
+  margin-top: 0.125rem;
+}
+
+.risk-card__approximate {
+  font-weight: 600;
+  margin-right: 0.125rem;
+  opacity: 0.7;
+}
+
 @media (max-width: 768px) {
   .risk-card--expanded {
     grid-column: span 1;

--- a/components/reports/RiskDashboard.tsx
+++ b/components/reports/RiskDashboard.tsx
@@ -10,6 +10,7 @@ interface RiskFlagData {
   reference_high: number | null;
   flag: "green" | "yellow" | "red";
   trend: string;
+  confidence: number;
 }
 
 interface RiskSummary {
@@ -229,6 +230,9 @@ export default function RiskDashboard({ reportId }: RiskDashboardProps) {
                   </div>
                   <div className="risk-card__value-row">
                     <span className={`risk-card__value risk-card__value--${flag.flag}`}>
+                      {(flag.confidence ?? 1) < 0.7 && (
+                        <span className="risk-card__approximate" aria-label="Approximate value">~</span>
+                      )}
                       {Number(flag.value).toLocaleString()}
                     </span>
                     {getGoalText(flag) && (
@@ -237,6 +241,16 @@ export default function RiskDashboard({ reportId }: RiskDashboardProps) {
                       </span>
                     )}
                   </div>
+                  {(flag.confidence ?? 1) < 0.7 && (
+                    <div className="risk-card__confidence-warning" role="alert">
+                      Value may be inaccurate — verify against your report
+                    </div>
+                  )}
+                  {(flag.confidence ?? 1) >= 0.7 && (flag.confidence ?? 1) <= 0.9 && (
+                    <div className="risk-card__confidence-note">
+                      Approximate reading
+                    </div>
+                  )}
                 </div>
                 <p className="risk-card__description">
                   {getDescription(flag.biomarker_name)}

--- a/lib/claude/parse-report.ts
+++ b/lib/claude/parse-report.ts
@@ -9,6 +9,7 @@ export interface ParsedBiomarker {
   reference_low: number | null;
   reference_high: number | null;
   flag: "green" | "yellow" | "red";
+  confidence: number;
 }
 
 export interface ParsedReportResult {
@@ -85,6 +86,12 @@ export async function parseReportWithClaude(
   if (typeof parsed.summary !== "string") {
     throw new Error("Invalid response: summary must be a string");
   }
+
+  // Default confidence to 1.0 for backward compatibility
+  parsed.biomarkers = parsed.biomarkers.map((b) => ({
+    ...b,
+    confidence: typeof b.confidence === "number" ? b.confidence : 1.0,
+  }));
 
   return parsed;
 }

--- a/lib/claude/prompts.ts
+++ b/lib/claude/prompts.ts
@@ -20,7 +20,8 @@ Respond ONLY with valid JSON in this exact format:
       "unit": "string — unit of measurement (e.g., mg/dL, mmol/L)",
       "reference_low": "number or null — lower bound of normal range",
       "reference_high": "number or null — upper bound of normal range",
-      "flag": "string — 'green' if within range, 'yellow' if borderline, 'red' if outside range, 'unknown' if no range available. NOTE: this flag is advisory only; the server applies verified reference ranges after extraction"
+      "flag": "string — 'green' if within range, 'yellow' if borderline, 'red' if outside range, 'unknown' if no range available. NOTE: this flag is advisory only; the server applies verified reference ranges after extraction",
+      "confidence": "number — 0.0 to 1.0 indicating how confident you are in this extraction. Use 1.0 for clearly printed values, 0.7-0.9 for partially visible or ambiguous values, below 0.7 for guesses or unclear text"
     }
   ],
   "summary": "string — 1-3 sentence plain-language summary of the report contents, written at a 5th grade reading level",

--- a/supabase/migrations/013_risk_flag_confidence.sql
+++ b/supabase/migrations/013_risk_flag_confidence.sql
@@ -1,0 +1,2 @@
+-- Add confidence column to risk_flags for extraction quality scoring (#133)
+ALTER TABLE risk_flags ADD COLUMN IF NOT EXISTS confidence numeric DEFAULT 1.0;


### PR DESCRIPTION
## Summary
- Adds per-biomarker confidence scoring (0.0-1.0) to the extraction pipeline so users can identify which values may need manual verification
- Low-confidence values (<0.7) display a warning indicator on risk cards; medium confidence (0.7-0.9) shows an approximate indicator
- Backward compatible: defaults to 1.0 when Claude does not provide confidence

## Changes
- **`lib/claude/prompts.ts`** — prompt now asks Claude for a confidence score per biomarker
- **`lib/claude/parse-report.ts`** — `ParsedBiomarker` interface adds `confidence: number`, defaults to 1.0
- **`app/api/parse/route.ts`** — passes confidence through to `risk_flags` insert
- **`app/api/risk-flags/route.ts`** — includes `confidence` in SELECT query
- **`components/reports/RiskDashboard.tsx`** — shows warning for low confidence, note for medium
- **`app/globals.css`** — new `.risk-card__confidence-warning`, `.risk-card__confidence-note`, `.risk-card__approximate` styles
- **`supabase/migrations/013_risk_flag_confidence.sql`** — adds `confidence` column to `risk_flags`
- **`__tests__/confidence-scoring.test.ts`** — 8 new tests covering prompt, default, flow, and UI

## Test plan
- [x] All 759 tests pass (including 8 new confidence-scoring tests)
- [x] TypeScript type checking passes
- [x] ESLint passes
- [ ] Manual: upload a report and verify confidence scores appear in parsed results
- [ ] Manual: verify low-confidence biomarkers show warning indicator on risk cards
- [ ] Manual: verify existing reports without confidence still render correctly (default 1.0)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)