### PR TITLE
feat(reports): visual trend charts for biomarker values over time

### DIFF
--- a/__tests__/trend-charts.test.ts
+++ b/__tests__/trend-charts.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+// ── TrendChart Component ─────────────────────────────────────────
+
+import TrendChart, {
+  type TrendChartProps,
+} from "@/components/reports/TrendChart";
+
+const makeDataPoints = (
+  values: number[],
+  flags?: string[]
+) =>
+  values.map((v, i) => ({
+    date: `2026-0${i + 1}-15T00:00:00Z`,
+    value: v,
+    flag: flags?.[i] ?? (v > 200 ? "red" : v > 150 ? "yellow" : "green"),
+    reportName: `report-${i + 1}.pdf`,
+  }));
+
+const defaultProps: TrendChartProps = {
+  biomarkerName: "Total Cholesterol",
+  dataPoints: makeDataPoints([220, 200, 185]),
+  referenceRange: {
+    greenLow: null,
+    greenHigh: 199,
+    yellowLow: 200,
+    yellowHigh: 239,
+  },
+  unit: "mg/dL",
+  trend: "improving",
+};
+
+describe("TrendChart Component", () => {
+  it("renders an SVG element with the chart", () => {
+    const { container } = render(React.createElement(TrendChart, defaultProps));
+    const svg = container.querySelector(".trend-chart__svg");
+    expect(svg).not.toBeNull();
+    expect(svg!.tagName.toLowerCase()).toBe("svg");
+  });
+
+  it("displays the biomarker name as title", () => {
+    const { container } = render(React.createElement(TrendChart, defaultProps));
+    const title = container.querySelector(".trend-chart__title");
+    expect(title).not.toBeNull();
+    expect(title!.textContent).toBe("Total Cholesterol");
+  });
+
+  it("displays the unit", () => {
+    const { container } = render(React.createElement(TrendChart, defaultProps));
+    const unit = container.querySelector(".trend-chart__unit");
+    expect(unit).not.toBeNull();
+    expect(unit!.textContent).toContain("mg/dL");
+  });
+
+  it("renders correct number of data points", () => {
+    const { container } = render(React.createElement(TrendChart, defaultProps));
+    const points = container.querySelectorAll(".trend-chart__point");
+    expect(points.length).toBe(3);
+  });
+
+  it("renders the data line path", () => {
+    const { container } = render(React.createElement(TrendChart, defaultProps));
+    const line = container.querySelector(".trend-chart__line");
+    expect(line).not.toBeNull();
+    expect(line!.getAttribute("d")).toContain("M");
+    expect(line!.getAttribute("d")).toContain("L");
+  });
+
+  it("renders reference range bands when provided", () => {
+    const { container } = render(React.createElement(TrendChart, defaultProps));
+    const greenBand = container.querySelector(".trend-chart__band--green");
+    const yellowBand = container.querySelector(".trend-chart__band--yellow");
+    // At least one band should render when ranges are provided
+    expect(greenBand !== null || yellowBand !== null).toBe(true);
+  });
+
+  it("color-codes data points based on flag", () => {
+    const { container } = render(React.createElement(TrendChart, defaultProps));
+    const points = container.querySelectorAll(".trend-chart__point");
+    // First point (220) has flag "red" since > 200
+    const flags = Array.from(points).map((p) =>
+      p.classList.contains("trend-chart__point--green")
+        ? "green"
+        : p.classList.contains("trend-chart__point--yellow")
+          ? "yellow"
+          : p.classList.contains("trend-chart__point--red")
+            ? "red"
+            : "unknown"
+    );
+    // 220 > 200 = "red", 200 is NOT > 200 = "yellow" (> 150), 185 > 150 = "yellow"
+    expect(flags).toEqual(["red", "yellow", "yellow"]);
+  });
+
+  it("shows empty state when fewer than 2 data points", () => {
+    const props: TrendChartProps = {
+      ...defaultProps,
+      dataPoints: makeDataPoints([220]),
+    };
+    const { container } = render(React.createElement(TrendChart, props));
+    const emptyMsg = container.querySelector(".trend-chart__empty-msg");
+    expect(emptyMsg).not.toBeNull();
+    expect(emptyMsg!.textContent).toContain("Upload more reports");
+    // Should NOT render SVG
+    const svg = container.querySelector(".trend-chart__svg");
+    expect(svg).toBeNull();
+  });
+
+  it("has accessible aria-labels on data points", () => {
+    const { container } = render(React.createElement(TrendChart, defaultProps));
+    const points = container.querySelectorAll(".trend-chart__point");
+    const firstLabel = points[0]?.getAttribute("aria-label");
+    expect(firstLabel).toContain("220");
+    expect(firstLabel).toContain("mg/dL");
+  });
+
+  it("shows tooltip on hover", () => {
+    const { container } = render(React.createElement(TrendChart, defaultProps));
+    const points = container.querySelectorAll(".trend-chart__point");
+    // No tooltip initially
+    let tooltip = container.querySelector(".trend-chart__tooltip");
+    expect(tooltip).toBeNull();
+    // Hover on first point
+    fireEvent.mouseEnter(points[0]);
+    tooltip = container.querySelector(".trend-chart__tooltip");
+    expect(tooltip).not.toBeNull();
+  });
+
+  it("renders TrendArrow when trend prop is provided", () => {
+    const { container } = render(React.createElement(TrendChart, defaultProps));
+    const arrow = container.querySelector(".trend-arrow");
+    expect(arrow).not.toBeNull();
+  });
+
+  it("renders axis labels", () => {
+    const { container } = render(React.createElement(TrendChart, defaultProps));
+    const labels = container.querySelectorAll(".trend-chart__axis-label");
+    expect(labels.length).toBeGreaterThan(0);
+  });
+});
+
+// ── Trends API Response Format ───────────────────────────────────
+
+describe("Trends API response format", () => {
+  it("matches expected BiomarkerTrend interface", () => {
+    // Validate the expected API response shape (compile-time check)
+    const sampleResponse = {
+      trends: [
+        {
+          biomarkerName: "Total Cholesterol",
+          unit: "mg/dL",
+          dataPoints: [
+            {
+              date: "2026-01-15",
+              value: 220,
+              flag: "yellow",
+              reportName: "lab-jan.pdf",
+            },
+            {
+              date: "2026-04-02",
+              value: 195,
+              flag: "green",
+              reportName: "lab-apr.pdf",
+            },
+          ],
+          referenceRange: { greenHigh: 200, yellowHigh: 240 },
+          trend: "improving" as const,
+        },
+      ],
+    };
+
+    expect(sampleResponse.trends).toHaveLength(1);
+    expect(sampleResponse.trends[0].biomarkerName).toBe("Total Cholesterol");
+    expect(sampleResponse.trends[0].dataPoints).toHaveLength(2);
+    expect(sampleResponse.trends[0].trend).toBe("improving");
+    expect(sampleResponse.trends[0].referenceRange.greenHigh).toBe(200);
+  });
+
+  it("requires at least 2 data points for a trend entry", () => {
+    // This validates the API filtering logic conceptually
+    const allDataPoints = [
+      { name: "LDL", values: [100, 95] },
+      { name: "TSH", values: [2.5] }, // Only 1 data point - should be excluded
+    ];
+
+    const filtered = allDataPoints.filter((d) => d.values.length >= 2);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].name).toBe("LDL");
+  });
+});
+
+// ── Data Point Color Coding ──────────────────────────────────────
+
+import { flagBiomarker } from "@/lib/health/flag-biomarker";
+
+describe("Data point color coding matches reference ranges", () => {
+  it("flags Total Cholesterol 195 as green", () => {
+    expect(flagBiomarker("Total Cholesterol", 195)).toBe("green");
+  });
+
+  it("flags Total Cholesterol 220 as yellow", () => {
+    expect(flagBiomarker("Total Cholesterol", 220)).toBe("yellow");
+  });
+
+  it("flags Total Cholesterol 250 as red", () => {
+    expect(flagBiomarker("Total Cholesterol", 250)).toBe("red");
+  });
+
+  it("flags Hemoglobin A1C 5.4 as green", () => {
+    expect(flagBiomarker("Hemoglobin A1C", 5.4)).toBe("green");
+  });
+
+  it("flags Hemoglobin A1C 6.0 as yellow", () => {
+    expect(flagBiomarker("Hemoglobin A1C", 6.0)).toBe("yellow");
+  });
+
+  it("flags Hemoglobin A1C 7.0 as red", () => {
+    expect(flagBiomarker("Hemoglobin A1C", 7.0)).toBe("red");
+  });
+});

--- a/app/api/reports/trends/route.ts
+++ b/app/api/reports/trends/route.ts
@@ -1,0 +1,221 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextRequest, NextResponse } from "next/server";
+import { SYNONYM_INDEX } from "@/lib/health/biomarker-synonyms";
+import { flagBiomarker } from "@/lib/health/flag-biomarker";
+import {
+  calculateBiomarkerTrend,
+  findRangeForTrend,
+  type TrendDirection,
+} from "@/lib/health/trend";
+import { logAuditEvent, getClientIp } from "@/lib/audit/logger";
+
+interface TrendDataPoint {
+  date: string;
+  value: number;
+  flag: string;
+  reportName: string;
+}
+
+interface BiomarkerTrend {
+  biomarkerName: string;
+  unit: string;
+  dataPoints: TrendDataPoint[];
+  referenceRange: {
+    greenLow?: number | null;
+    greenHigh?: number | null;
+    yellowLow?: number | null;
+    yellowHigh?: number | null;
+  };
+  trend: TrendDirection;
+}
+
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Fetch all parsed reports for the user, ordered by date ascending
+  const { data: reports, error: reportsError } = await supabase
+    .from("reports")
+    .select("id, original_filename, created_at, user_id, status")
+    .eq("user_id", user.id)
+    .eq("status", "parsed")
+    .order("created_at", { ascending: true });
+
+  if (reportsError) {
+    return NextResponse.json(
+      { error: "Failed to fetch reports" },
+      { status: 500 }
+    );
+  }
+
+  if (!reports || reports.length < 2) {
+    return NextResponse.json({ trends: [] }, { status: 200 });
+  }
+
+  // Audit log
+  logAuditEvent({
+    userId: user.id,
+    action: "report.view",
+    resourceType: "report",
+    resourceId: "trends",
+    ipAddress: getClientIp(request),
+  });
+
+  // Fetch parsed results for all reports
+  const { data: parsedResults, error: parsedError } = await supabase
+    .from("parsed_results")
+    .select("report_id, biomarkers")
+    .in(
+      "report_id",
+      reports.map((r) => r.id)
+    );
+
+  if (parsedError || !parsedResults) {
+    return NextResponse.json(
+      { error: "Failed to fetch parsed results" },
+      { status: 500 }
+    );
+  }
+
+  // Build report date/name lookup
+  const reportMeta = new Map(
+    reports.map((r) => [
+      r.id,
+      { date: r.created_at, name: r.original_filename },
+    ])
+  );
+
+  // Collect biomarker values by canonical name
+  const biomarkerMap = new Map<
+    string,
+    {
+      canonicalName: string;
+      unit: string;
+      dataPoints: TrendDataPoint[];
+    }
+  >();
+
+  for (const pr of parsedResults) {
+    const biomarkers = pr.biomarkers as Array<{
+      name: string;
+      value: number | null;
+      unit: string;
+      flag: string;
+    }>;
+    if (!Array.isArray(biomarkers)) continue;
+
+    const meta = reportMeta.get(pr.report_id);
+    if (!meta) continue;
+
+    for (const b of biomarkers) {
+      if (b.value === null || b.value === undefined) continue;
+
+      const mapping = SYNONYM_INDEX.get(b.name.toLowerCase().trim());
+      const canonicalName = mapping ? mapping.canonical : b.name;
+      const unit = mapping?.unit || b.unit || "";
+
+      // Apply server-side flagging
+      const numericValue = Number(b.value);
+      if (isNaN(numericValue)) continue;
+
+      let flag = b.flag || "green";
+      const serverFlag = flagBiomarker(canonicalName, numericValue);
+      if (serverFlag) flag = serverFlag;
+
+      if (!biomarkerMap.has(canonicalName)) {
+        biomarkerMap.set(canonicalName, {
+          canonicalName,
+          unit,
+          dataPoints: [],
+        });
+      }
+
+      biomarkerMap.get(canonicalName)!.dataPoints.push({
+        date: meta.date,
+        value: numericValue,
+        flag,
+        reportName: meta.name,
+      });
+    }
+  }
+
+  // Build trends — only biomarkers with 2+ data points
+  const trends: BiomarkerTrend[] = [];
+
+  for (const [, entry] of biomarkerMap) {
+    if (entry.dataPoints.length < 2) continue;
+
+    // Sort data points by date ascending
+    entry.dataPoints.sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+    );
+
+    // Limit to 12 most recent data points for performance
+    const dataPoints = entry.dataPoints.slice(-12);
+
+    // Calculate trend
+    const oldest = dataPoints[0];
+    const newest = dataPoints[dataPoints.length - 1];
+    const trend = calculateBiomarkerTrend(
+      entry.canonicalName,
+      oldest.value,
+      newest.value
+    );
+
+    // Get reference range for chart bands
+    const range = findRangeForTrend(entry.canonicalName);
+    const referenceRange: BiomarkerTrend["referenceRange"] = {};
+    if (range) {
+      referenceRange.greenLow = range.ranges.green.low;
+      referenceRange.greenHigh = range.ranges.green.high;
+      referenceRange.yellowLow = range.ranges.yellow.low;
+      referenceRange.yellowHigh = range.ranges.yellow.high;
+    }
+
+    trends.push({
+      biomarkerName: entry.canonicalName,
+      unit: entry.unit,
+      dataPoints,
+      referenceRange,
+      trend,
+    });
+  }
+
+  // Sort: biomarkers with biggest changes first (most interesting)
+  trends.sort((a, b) => {
+    // Worsening first, then improving, then stable
+    const trendOrder: Record<TrendDirection, number> = {
+      worsening: 0,
+      improving: 1,
+      stable: 2,
+    };
+    const orderDiff = trendOrder[a.trend] - trendOrder[b.trend];
+    if (orderDiff !== 0) return orderDiff;
+
+    // Within same trend, sort by magnitude of change
+    const aChange = Math.abs(
+      a.dataPoints[a.dataPoints.length - 1].value - a.dataPoints[0].value
+    );
+    const bChange = Math.abs(
+      b.dataPoints[b.dataPoints.length - 1].value - b.dataPoints[0].value
+    );
+    // Normalize by average to compare relative changes
+    const aAvg =
+      (a.dataPoints[a.dataPoints.length - 1].value + a.dataPoints[0].value) / 2;
+    const bAvg =
+      (b.dataPoints[b.dataPoints.length - 1].value + b.dataPoints[0].value) / 2;
+    const aRelative = aAvg !== 0 ? aChange / aAvg : 0;
+    const bRelative = bAvg !== 0 ? bChange / bAvg : 0;
+
+    return bRelative - aRelative;
+  });
+
+  return NextResponse.json({ trends }, { status: 200 });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -4050,6 +4050,12 @@ button.chat-send-button[type="submit"]:disabled {
   transition: background 0.15s, border-color 0.15s;
 }
 
+.report-list__header-links {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
 .report-list__compare-link:hover {
   background: var(--color-blue-100);
   border-color: var(--color-blue-300);
@@ -4088,6 +4094,22 @@ button.chat-send-button[type="submit"]:disabled {
   border-radius: var(--radius-sm);
   font-size: 0.875rem;
   margin-bottom: 1rem;
+}
+
+.compare-page__chart-link {
+  text-align: center;
+  margin: 0.75rem 0;
+}
+
+.compare-page__chart-link a {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--link-color, #3182ce);
+  text-decoration: none;
+}
+
+.compare-page__chart-link a:hover {
+  text-decoration: underline;
 }
 
 .compare-page__disclaimer {
@@ -4961,4 +4983,211 @@ button.chat-send-button[type="submit"]:disabled {
   .whats-changed__biomarker-values {
     display: none;
   }
+}
+
+/* ===================================================================
+   Trend Charts (#140)
+   =================================================================== */
+
+.trends-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+.trends-page h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin: 0.5rem 0 0.25rem;
+  color: var(--text-primary, #1a202c);
+}
+
+.trends-page__subtitle {
+  color: var(--text-muted, #718096);
+  font-size: 0.875rem;
+  margin: 0 0 0.5rem;
+}
+
+.trends-page__disclaimer {
+  background: var(--surface-muted, #f7fafc);
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 8px;
+  padding: 0.625rem 0.875rem;
+  font-size: 0.75rem;
+  color: var(--text-muted, #718096);
+  margin-bottom: 1.25rem;
+}
+
+.trends-page__loading {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--text-muted, #718096);
+}
+
+.trends-page__error {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: #dc2626;
+}
+
+.trends-page__empty {
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+.trends-page__actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1.5rem;
+  padding-bottom: 2rem;
+}
+
+.trends-page__link {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--link-color, #3182ce);
+  text-decoration: none;
+}
+
+.trends-page__link:hover {
+  text-decoration: underline;
+}
+
+/* Trends grid — 2 across desktop, 1 on mobile */
+.trends-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+@media (max-width: 640px) {
+  .trends-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* --- Trend Chart Component --- */
+
+.trend-chart {
+  background: #fff;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 12px;
+  padding: 0.875rem 1rem 0.75rem;
+  position: relative;
+}
+
+.trend-chart--empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+}
+
+.trend-chart__header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-bottom: 0.375rem;
+}
+
+.trend-chart__title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary, #1a202c);
+  margin: 0;
+}
+
+.trend-chart__unit {
+  font-size: 0.75rem;
+  color: var(--text-muted, #718096);
+}
+
+.trend-chart__empty-msg {
+  font-size: 0.8125rem;
+  color: var(--text-muted, #718096);
+  margin: 0.5rem 0 0;
+}
+
+.trend-chart__container {
+  width: 100%;
+  overflow: visible;
+}
+
+.trend-chart__svg {
+  width: 100%;
+  height: auto;
+  max-height: 200px;
+  display: block;
+}
+
+/* Reference range bands */
+.trend-chart__band {
+  opacity: 0.15;
+}
+
+.trend-chart__band--green {
+  fill: #16a34a;
+}
+
+.trend-chart__band--yellow {
+  fill: #f59e0b;
+  opacity: 0.1;
+}
+
+/* Gridlines */
+.trend-chart__gridline {
+  stroke: var(--border-color, #e2e8f0);
+  stroke-width: 0.5;
+  stroke-dasharray: 3 3;
+}
+
+/* Axis labels */
+.trend-chart__axis-label {
+  font-size: 9px;
+  fill: var(--text-muted, #718096);
+  font-family: inherit;
+}
+
+/* Data line */
+.trend-chart__line {
+  fill: none;
+  stroke: var(--color-green, #16a34a);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Data points */
+.trend-chart__point {
+  cursor: pointer;
+  transition: r 0.15s ease;
+  stroke: #fff;
+  stroke-width: 1.5;
+}
+
+.trend-chart__point:hover,
+.trend-chart__point:focus {
+  r: 6;
+  outline: none;
+}
+
+/* Tooltip */
+.trend-chart__tooltip rect {
+  fill: var(--text-primary, #1a202c);
+  opacity: 0.92;
+}
+
+.trend-chart__tooltip text {
+  fill: #fff;
+  font-size: 10px;
+  font-weight: 500;
+  font-family: inherit;
+}
+
+.trend-chart__tooltip-date {
+  font-size: 9px !important;
+  font-weight: 400 !important;
+  opacity: 0.75;
 }

--- a/app/reports/compare/page.tsx
+++ b/app/reports/compare/page.tsx
@@ -310,6 +310,13 @@ export default function ComparePage() {
             </div>
           </div>
 
+          {/* View as charts link */}
+          <div className="compare-page__chart-link">
+            <Link href="/reports/trends">
+              View as Charts
+            </Link>
+          </div>
+
           {/* Disclaimer */}
           <p className="compare-page__disclaimer">
             Trends are informational only and do not constitute medical advice.

--- a/app/reports/trends/layout.tsx
+++ b/app/reports/trends/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function TrendsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/reports/trends/page.tsx
+++ b/app/reports/trends/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import NavHeader from "@/components/ui/NavHeader";
+import TrendChart from "@/components/reports/TrendChart";
+
+interface TrendDataPoint {
+  date: string;
+  value: number;
+  flag: string;
+  reportName: string;
+}
+
+interface BiomarkerTrend {
+  biomarkerName: string;
+  unit: string;
+  dataPoints: TrendDataPoint[];
+  referenceRange: {
+    greenLow?: number | null;
+    greenHigh?: number | null;
+    yellowLow?: number | null;
+    yellowHigh?: number | null;
+  };
+  trend: "improving" | "worsening" | "stable";
+}
+
+export default function TrendsPage() {
+  const [trends, setTrends] = useState<BiomarkerTrend[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadTrends() {
+      setLoading(true);
+      try {
+        const res = await fetch("/api/reports/trends");
+        if (!res.ok) {
+          if (res.status === 401) {
+            throw new Error("Please log in to view trends");
+          }
+          throw new Error("Failed to load trends");
+        }
+        const data = await res.json();
+        setTrends(data.trends || []);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load trends");
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadTrends();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="trends-page">
+        <NavHeader backLabel="Reports" />
+        <div className="trends-page__loading">
+          <p>Loading trends...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="trends-page">
+        <NavHeader backLabel="Reports" />
+        <div className="trends-page__error" role="alert">
+          <p>{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (trends.length === 0) {
+    return (
+      <div className="trends-page">
+        <NavHeader backLabel="Reports" />
+        <h1>Your Health Trends</h1>
+        <div className="trends-page__empty">
+          <div className="empty-state__icon" aria-hidden="true">
+            <svg
+              width="64"
+              height="64"
+              viewBox="0 0 64 64"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                x="8"
+                y="8"
+                width="48"
+                height="48"
+                rx="6"
+                fill="#dcfce7"
+                stroke="#16a34a"
+                strokeWidth="2"
+              />
+              <polyline
+                points="16,44 24,32 32,36 40,20 48,24"
+                fill="none"
+                stroke="#16a34a"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <circle cx="16" cy="44" r="3" fill="#16a34a" />
+              <circle cx="24" cy="32" r="3" fill="#16a34a" />
+              <circle cx="32" cy="36" r="3" fill="#f59e0b" />
+              <circle cx="40" cy="20" r="3" fill="#16a34a" />
+              <circle cx="48" cy="24" r="3" fill="#16a34a" />
+            </svg>
+          </div>
+          <h3 className="empty-state__heading">Not enough data for trends</h3>
+          <p className="empty-state__text">
+            Upload at least 2 reports to see how your biomarkers change over
+            time
+          </p>
+          <Link href="/upload" className="empty-state__cta">
+            Upload Report
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="trends-page">
+      <NavHeader backLabel="Reports" />
+      <h1>Your Health Trends</h1>
+      <p className="trends-page__subtitle">
+        See how your biomarkers change over time. Each chart shows values from
+        your uploaded lab reports.
+      </p>
+      <p className="trends-page__disclaimer">
+        Trends are informational only and do not constitute medical advice.
+        Consult your healthcare provider for interpretation.
+      </p>
+
+      <div className="trends-grid">
+        {trends.map((t) => (
+          <TrendChart
+            key={t.biomarkerName}
+            biomarkerName={t.biomarkerName}
+            dataPoints={t.dataPoints}
+            referenceRange={t.referenceRange}
+            unit={t.unit}
+            trend={t.trend}
+          />
+        ))}
+      </div>
+
+      <div className="trends-page__actions">
+        <Link href="/reports/compare" className="trends-page__link">
+          Compare Reports Table
+        </Link>
+        <Link href="/reports" className="trends-page__link">
+          All Reports
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/reports/ReportList.tsx
+++ b/components/reports/ReportList.tsx
@@ -128,9 +128,14 @@ export default function ReportList() {
       <div className="report-list__header">
         <h2>Your Reports</h2>
         {parsedReports.length >= 2 && (
-          <Link href="/reports/compare" className="report-list__compare-link">
-            Compare Reports
-          </Link>
+          <div className="report-list__header-links">
+            <Link href="/reports/trends" className="report-list__compare-link">
+              View Trends
+            </Link>
+            <Link href="/reports/compare" className="report-list__compare-link">
+              Compare Reports
+            </Link>
+          </div>
         )}
       </div>
       <div className="report-list__grid">

--- a/components/reports/TrendChart.tsx
+++ b/components/reports/TrendChart.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import TrendArrow from "./TrendArrow";
+
+interface TrendDataPoint {
+  date: string;
+  value: number;
+  flag: string;
+  reportName: string;
+}
+
+export interface TrendChartProps {
+  biomarkerName: string;
+  dataPoints: TrendDataPoint[];
+  referenceRange?: {
+    greenLow?: number | null;
+    greenHigh?: number | null;
+    yellowLow?: number | null;
+    yellowHigh?: number | null;
+  };
+  unit?: string;
+  trend?: "improving" | "worsening" | "stable";
+}
+
+/** Format date as "Mar 15" */
+function formatAxisDate(dateStr: string): string {
+  const d = new Date(dateStr);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/** Chart layout constants */
+const PADDING = { top: 20, right: 20, bottom: 32, left: 48 };
+const CHART_HEIGHT = 180;
+const SVG_WIDTH = 400; // viewBox width, responsive via CSS
+const PLOT_WIDTH = SVG_WIDTH - PADDING.left - PADDING.right;
+const PLOT_HEIGHT = CHART_HEIGHT - PADDING.top - PADDING.bottom;
+
+export default function TrendChart({
+  biomarkerName,
+  dataPoints,
+  referenceRange,
+  unit,
+  trend,
+}: TrendChartProps) {
+  const [activePoint, setActivePoint] = useState<number | null>(null);
+
+  // Calculate Y domain from data + reference ranges
+  const { yMin, yMax, xScale, yScale } = useMemo(() => {
+    const values = dataPoints.map((d) => d.value);
+    let lo = Math.min(...values);
+    let hi = Math.max(...values);
+
+    // Expand domain to include reference range bands
+    if (referenceRange) {
+      if (referenceRange.greenLow != null) lo = Math.min(lo, referenceRange.greenLow);
+      if (referenceRange.greenHigh != null) hi = Math.max(hi, referenceRange.greenHigh);
+      if (referenceRange.yellowLow != null) lo = Math.min(lo, referenceRange.yellowLow);
+      if (referenceRange.yellowHigh != null) hi = Math.max(hi, referenceRange.yellowHigh);
+    }
+
+    // Add 10% padding to Y domain
+    const range = hi - lo || 1;
+    lo = lo - range * 0.1;
+    hi = hi + range * 0.1;
+
+    const xS = (i: number) =>
+      dataPoints.length === 1
+        ? PLOT_WIDTH / 2
+        : (i / (dataPoints.length - 1)) * PLOT_WIDTH;
+
+    const yS = (v: number) =>
+      PLOT_HEIGHT - ((v - lo) / (hi - lo)) * PLOT_HEIGHT;
+
+    return { yMin: lo, yMax: hi, xScale: xS, yScale: yS };
+  }, [dataPoints, referenceRange]);
+
+  if (dataPoints.length < 2) {
+    return (
+      <div className="trend-chart trend-chart--empty">
+        <h3 className="trend-chart__title">{biomarkerName}</h3>
+        <p className="trend-chart__empty-msg">
+          Upload more reports to see trends
+        </p>
+      </div>
+    );
+  }
+
+  // Build line path
+  const linePath = dataPoints
+    .map((d, i) => {
+      const x = PADDING.left + xScale(i);
+      const y = PADDING.top + yScale(d.value);
+      return `${i === 0 ? "M" : "L"}${x},${y}`;
+    })
+    .join(" ");
+
+  // Reference range band helpers
+  const bandRect = (low: number | null | undefined, high: number | null | undefined) => {
+    const bandLow = low != null ? Math.max(low, yMin) : yMin;
+    const bandHigh = high != null ? Math.min(high, yMax) : yMax;
+    if (bandLow >= bandHigh) return null;
+    const y1 = PADDING.top + yScale(bandHigh);
+    const y2 = PADDING.top + yScale(bandLow);
+    return {
+      x: PADDING.left,
+      y: y1,
+      width: PLOT_WIDTH,
+      height: y2 - y1,
+    };
+  };
+
+  const greenBand = bandRect(referenceRange?.greenLow, referenceRange?.greenHigh);
+  const yellowBand = bandRect(referenceRange?.yellowLow, referenceRange?.yellowHigh);
+
+  // Y-axis ticks (4-5 ticks)
+  const yRange = yMax - yMin;
+  const tickStep = yRange / 4;
+  const yTicks = Array.from({ length: 5 }, (_, i) => yMin + i * tickStep);
+
+  const flagColor = (flag: string) => {
+    switch (flag) {
+      case "green": return "var(--color-green, #16a34a)";
+      case "yellow": return "var(--color-yellow, #f59e0b)";
+      case "red": return "var(--color-red, #dc2626)";
+      default: return "var(--color-green, #16a34a)";
+    }
+  };
+
+  return (
+    <div className="trend-chart">
+      <div className="trend-chart__header">
+        <h3 className="trend-chart__title">{biomarkerName}</h3>
+        {trend && <TrendArrow trend={trend} size={16} />}
+        {unit && <span className="trend-chart__unit">({unit})</span>}
+      </div>
+
+      <div className="trend-chart__container">
+        <svg
+          className="trend-chart__svg"
+          viewBox={`0 0 ${SVG_WIDTH} ${CHART_HEIGHT}`}
+          preserveAspectRatio="xMidYMid meet"
+          role="img"
+          aria-label={`Trend chart for ${biomarkerName} showing ${dataPoints.length} data points`}
+        >
+          {/* Reference range bands */}
+          {yellowBand && (
+            <rect
+              className="trend-chart__band trend-chart__band--yellow"
+              {...yellowBand}
+            />
+          )}
+          {greenBand && (
+            <rect
+              className="trend-chart__band trend-chart__band--green"
+              {...greenBand}
+            />
+          )}
+
+          {/* Y-axis gridlines and labels */}
+          {yTicks.map((tick, i) => {
+            const y = PADDING.top + yScale(tick);
+            const label =
+              Math.abs(tick) >= 1000
+                ? tick.toFixed(0)
+                : tick < 1
+                  ? tick.toFixed(2)
+                  : tick.toFixed(1);
+            return (
+              <g key={i}>
+                <line
+                  className="trend-chart__gridline"
+                  x1={PADDING.left}
+                  y1={y}
+                  x2={PADDING.left + PLOT_WIDTH}
+                  y2={y}
+                />
+                <text className="trend-chart__axis-label" x={PADDING.left - 6} y={y + 3} textAnchor="end">
+                  {label}
+                </text>
+              </g>
+            );
+          })}
+
+          {/* X-axis labels */}
+          {dataPoints.map((d, i) => {
+            // Only show first, last, and middle labels for space
+            if (dataPoints.length > 4 && i > 0 && i < dataPoints.length - 1) {
+              const mid = Math.floor(dataPoints.length / 2);
+              if (i !== mid) return null;
+            }
+            const x = PADDING.left + xScale(i);
+            return (
+              <text
+                key={i}
+                className="trend-chart__axis-label"
+                x={x}
+                y={CHART_HEIGHT - 4}
+                textAnchor="middle"
+              >
+                {formatAxisDate(d.date)}
+              </text>
+            );
+          })}
+
+          {/* Data line */}
+          <path className="trend-chart__line" d={linePath} />
+
+          {/* Data points (clickable) */}
+          {dataPoints.map((d, i) => {
+            const cx = PADDING.left + xScale(i);
+            const cy = PADDING.top + yScale(d.value);
+            return (
+              <circle
+                key={i}
+                className={`trend-chart__point trend-chart__point--${d.flag}`}
+                cx={cx}
+                cy={cy}
+                r={activePoint === i ? 6 : 4}
+                fill={flagColor(d.flag)}
+                onMouseEnter={() => setActivePoint(i)}
+                onMouseLeave={() => setActivePoint(null)}
+                onClick={() => setActivePoint(activePoint === i ? null : i)}
+                role="button"
+                tabIndex={0}
+                aria-label={`${d.value} ${unit || ""} on ${formatAxisDate(d.date)}`}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    setActivePoint(activePoint === i ? null : i);
+                  }
+                }}
+              />
+            );
+          })}
+
+          {/* Tooltip */}
+          {activePoint !== null && dataPoints[activePoint] && (() => {
+            const d = dataPoints[activePoint];
+            const cx = PADDING.left + xScale(activePoint);
+            const cy = PADDING.top + yScale(d.value);
+            const tooltipX = cx > SVG_WIDTH / 2 ? cx - 120 : cx + 10;
+            const tooltipY = cy < 50 ? cy + 15 : cy - 45;
+            return (
+              <g className="trend-chart__tooltip">
+                <rect
+                  x={tooltipX}
+                  y={tooltipY}
+                  width={110}
+                  height={38}
+                  rx={4}
+                />
+                <text x={tooltipX + 6} y={tooltipY + 15}>
+                  {d.value} {unit || ""}
+                </text>
+                <text x={tooltipX + 6} y={tooltipY + 29} className="trend-chart__tooltip-date">
+                  {formatAxisDate(d.date)}
+                </text>
+              </g>
+            );
+          })()}
+        </svg>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Closes #140

- Adds a dedicated `/reports/trends` page with pure SVG line charts showing how each biomarker changes across uploaded lab reports
- New `GET /api/reports/trends` API endpoint that aggregates biomarker data across all parsed reports, groups by canonical name, and returns trends sorted by significance (worsening first)
- Pure SVG `TrendChart` component with reference range bands (green/yellow zones), color-coded data points, hover tooltips, and responsive layout -- no external chart library (keeps bundle small)
- "View Trends" link on the reports list page and "View as Charts" link on the compare page
- 20 new tests covering component rendering, color coding, tooltips, empty states, and API response format

## Changes
| File | Description |
|------|-------------|
| `app/api/reports/trends/route.ts` | New API route: aggregates biomarker data across reports, applies server-side flagging, returns sorted trends with reference ranges |
| `components/reports/TrendChart.tsx` | Pure SVG line chart component with reference bands, color-coded points, hover tooltips, accessibility labels |
| `app/reports/trends/page.tsx` | Trends page with 2-across grid layout, loading/error/empty states |
| `app/reports/trends/layout.tsx` | Force-dynamic layout for SSR |
| `app/globals.css` | Styles for trends page, grid, chart, bands, tooltips |
| `components/reports/ReportList.tsx` | Added "View Trends" navigation link |
| `app/reports/compare/page.tsx` | Added "View as Charts" link to comparison results |
| `__tests__/trend-charts.test.ts` | 20 tests for TrendChart component, API format, color coding |

## Test plan
- [x] All 771 tests pass (34 test files)
- [x] Lint passes
- [x] TypeScript type-check passes
- [x] Production build succeeds
- [ ] Manual: navigate to /reports/trends with 2+ parsed reports -- verify charts render with correct data
- [ ] Manual: verify reference range bands (green/yellow zones) appear on charts
- [ ] Manual: hover/click data points to see tooltips
- [ ] Manual: verify responsive layout (2-across desktop, 1 on mobile)
- [ ] Manual: verify empty state when < 2 reports
- [ ] Manual: verify "View Trends" link on /reports page
- [ ] Manual: verify "View as Charts" link on /reports/compare page