### PR TITLE
feat(health-score): Health Credit Score (300-850 scale)

### DIFF
--- a/__tests__/health-score.test.ts
+++ b/__tests__/health-score.test.ts
@@ -4,49 +4,66 @@ import {
   type HealthScoreResult,
 } from "@/lib/health/health-score";
 
-// ── Health Score Calculation ────────────────────────────────────────
+// ── Health Credit Score Calculation (300-850 scale) ───────────────────
 
 describe("calculateHealthScore", () => {
-  // ── All green ───────────────────────────────────────────────────
+  // ── All green → 850 ────────────────────────────────────────────────
 
-  it("returns 100 when all biomarkers are green", () => {
+  it("returns 850 when all biomarkers are green", () => {
     const biomarkers = [
       { name: "Hemoglobin", flag: "green" as const },
       { name: "Platelet Count", flag: "green" as const },
       { name: "Sodium", flag: "green" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(100);
-    expect(result.label).toBe("Excellent");
-    expect(result.color).toBe("green");
+    expect(result.score).toBe(850);
+    expect(result.label).toBe("Exceptional");
+    expect(result.color).toBe("exceptional");
     expect(result.breakdown.green).toBe(3);
     expect(result.breakdown.yellow).toBe(0);
     expect(result.breakdown.red).toBe(0);
     expect(result.breakdown.total).toBe(3);
     expect(result.topConcerns).toEqual([]);
+    expect(result.tips).toEqual([]);
   });
 
-  // ── All red ─────────────────────────────────────────────────────
+  // ── All red → 300 ──────────────────────────────────────────────────
 
-  it("returns 10 when all biomarkers are red (no critical)", () => {
+  it("returns 300 when all biomarkers are red (no critical)", () => {
     const biomarkers = [
       { name: "Hemoglobin", flag: "red" as const },
       { name: "Platelet Count", flag: "red" as const },
       { name: "Sodium", flag: "red" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(10);
-    expect(result.label).toBe("Needs Attention");
-    expect(result.color).toBe("red");
+    expect(result.score).toBe(300);
+    expect(result.label).toBe("Insufficiently Active");
+    expect(result.color).toBe("insufficient");
     expect(result.breakdown.red).toBe(3);
   });
 
-  // ── Mixed flags ─────────────────────────────────────────────────
+  // ── All yellow → 575 (halfway between 300 and 850) ────────────────
 
-  it("calculates correct weighted average for mixed flags", () => {
-    // 2 green (100 each) + 1 yellow (50) + 1 red (10)
-    // All non-critical, so weight=1 each
-    // Total = (100 + 100 + 50 + 10) / 4 = 260/4 = 65
+  it("returns 575 when all biomarkers are yellow (half credit)", () => {
+    const biomarkers = [
+      { name: "Hemoglobin", flag: "yellow" as const },
+      { name: "Platelet Count", flag: "yellow" as const },
+      { name: "Sodium", flag: "yellow" as const },
+    ];
+    const result = calculateHealthScore(biomarkers);
+    // 300 + 0.5 * 550 = 300 + 275 = 575
+    expect(result.score).toBe(575);
+    expect(result.label).toBe("Insufficiently Active");
+    expect(result.color).toBe("insufficient");
+  });
+
+  // ── Mixed flags ────────────────────────────────────────────────────
+
+  it("calculates correct score for mixed flags (non-critical)", () => {
+    // 2 green (credit 2*1=2), 1 yellow (credit 0.5), 1 red (credit 0)
+    // All non-critical weight=1 each, totalWeight=4
+    // fraction = 2.5/4 = 0.625
+    // score = 300 + 0.625 * 550 = 300 + 343.75 = 644 (rounded)
     const biomarkers = [
       { name: "Hemoglobin", flag: "green" as const },
       { name: "Platelet Count", flag: "green" as const },
@@ -54,172 +71,162 @@ describe("calculateHealthScore", () => {
       { name: "Potassium", flag: "red" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(65);
-    expect(result.label).toBe("Fair");
-    expect(result.color).toBe("orange");
+    expect(result.score).toBe(644);
+    expect(result.label).toBe("Moderately Active");
+    expect(result.color).toBe("moderate");
   });
 
-  // ── Critical biomarker weighting ────────────────────────────────
+  // ── Critical biomarker weighting ───────────────────────────────────
 
   it("weights critical biomarkers 2x (glucose)", () => {
-    // 1 green non-critical (weight 1, pts 100)
-    // 1 red critical "Glucose" (weight 2, pts 10)
-    // Weighted sum = 100*1 + 10*2 = 120
-    // Total weight = 1 + 2 = 3
-    // Score = 120/3 = 40
+    // Hemoglobin (non-crit, w=1): green, credit = 1
+    // Glucose (critical, w=2): red, credit = 0
+    // totalWeight = 3, weightedCredit = 1
+    // fraction = 1/3 = 0.333...
+    // score = 300 + 0.333 * 550 = 300 + 183.3 = 483
     const biomarkers = [
       { name: "Hemoglobin", flag: "green" as const },
       { name: "Glucose (Fasting)", flag: "red" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(40);
-    expect(result.label).toBe("Needs Attention");
+    expect(result.score).toBe(483);
+    expect(result.label).toBe("Insufficiently Active");
   });
 
   it("weights critical biomarkers 2x (Blood Pressure Systolic)", () => {
-    // 1 green non-critical (weight 1, pts 100)
-    // 1 yellow critical "Blood Pressure Systolic" (weight 2, pts 50)
-    // Weighted sum = 100 + 100 = 200
-    // Total weight = 3
-    // Score = 200/3 = 67
+    // Hemoglobin (non-crit, w=1): green, credit = 1
+    // BP Systolic (critical, w=2): yellow, credit = 2*0.5 = 1
+    // totalWeight = 3, weightedCredit = 2
+    // fraction = 2/3 = 0.667
+    // score = 300 + 0.667 * 550 = 300 + 366.7 = 667
     const biomarkers = [
       { name: "Hemoglobin", flag: "green" as const },
       { name: "Blood Pressure Systolic", flag: "yellow" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(67);
-    expect(result.label).toBe("Fair");
+    expect(result.score).toBe(667);
+    expect(result.label).toBe("Moderately Active");
   });
 
   it("weights LDL Cholesterol as critical (2x)", () => {
-    // 1 green non-critical (weight 1, pts 100)
-    // 1 green critical "LDL Cholesterol" (weight 2, pts 100)
-    // Total = 300/3 = 100
+    // Hemoglobin (w=1): green, credit = 1
+    // LDL (w=2): green, credit = 2
+    // totalWeight = 3, weightedCredit = 3
+    // fraction = 1.0 → score = 850
     const biomarkers = [
       { name: "Hemoglobin", flag: "green" as const },
       { name: "LDL Cholesterol", flag: "green" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(100);
+    expect(result.score).toBe(850);
   });
 
   it("weights Hemoglobin A1C as critical (2x)", () => {
-    // 1 green non-critical (weight 1, pts 100)
-    // 1 red critical "Hemoglobin A1C" (weight 2, pts 10)
-    // Total = 120/3 = 40
+    // A1C (critical, w=2): red, credit = 0
+    // Sodium (non-crit, w=1): green, credit = 1
+    // totalWeight = 3, weightedCredit = 1
+    // fraction = 1/3 → score = 483
     const biomarkers = [
       { name: "Hemoglobin A1C", flag: "red" as const },
       { name: "Sodium", flag: "green" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(40);
+    expect(result.score).toBe(483);
   });
 
-  // ── Label boundaries ────────────────────────────────────────────
+  // ── Label threshold boundaries ─────────────────────────────────────
 
-  it("labels score of 85 as Excellent", () => {
-    // To get exactly 85:
-    // 3 green non-critical (3 * 100 = 300), 1 yellow non-critical (50)
-    // 1 red critical (10 * 2 = 20)
-    // Total weight = 3 + 1 + 2 = 6, sum = 370, score = 370/6 = 61.67
-    // Let's use a different approach: directly check label logic
-    // We'll construct a scenario:
-    // Need score = 85. With all non-critical: (n*100 + m*50) / (n+m) = 85
-    // n=7 green, m=3 yellow: (700 + 150) / 10 = 85
+  it("labels score 800+ as Exceptional", () => {
+    // All green → 850
     const biomarkers = [
-      ...Array(7).fill(null).map((_, i) => ({
-        name: `Marker${i}`, flag: "green" as const,
-      })),
-      ...Array(3).fill(null).map((_, i) => ({
-        name: `MarkerY${i}`, flag: "yellow" as const,
-      })),
+      { name: "M1", flag: "green" as const },
+      { name: "M2", flag: "green" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(85);
-    expect(result.label).toBe("Excellent");
-    expect(result.color).toBe("green");
+    expect(result.score).toBe(850);
+    expect(result.label).toBe("Exceptional");
+    expect(result.color).toBe("exceptional");
   });
 
-  it("labels score of 84 as Good", () => {
-    // 84 is below 85 threshold. Need: sum/count = 84
-    // With 16 green (1600) and 4 yellow (200) = 1800 / 20 = 90 -> too high
-    // Try: we need fractional, let's get exactly 84
-    // 17 green (1700) + 6 yellow (300) + 1 red (10) = 2010 / 24 = 83.75 -> rounds to 84
+  it("labels score 740-799 as Very Active", () => {
+    // Need score in 740-799 range
+    // 3 green + 1 yellow, all non-critical:
+    // fraction = (3 + 0.5) / 4 = 0.875
+    // score = 300 + 0.875 * 550 = 300 + 481.25 = 781
     const biomarkers = [
-      ...Array(17).fill(null).map((_, i) => ({
-        name: `Marker${i}`, flag: "green" as const,
-      })),
-      ...Array(6).fill(null).map((_, i) => ({
-        name: `MarkerY${i}`, flag: "yellow" as const,
-      })),
-      { name: "MarkerR0", flag: "red" as const },
+      { name: "M1", flag: "green" as const },
+      { name: "M2", flag: "green" as const },
+      { name: "M3", flag: "green" as const },
+      { name: "M4", flag: "yellow" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(84);
-    expect(result.label).toBe("Good");
-    expect(result.color).toBe("green");
+    expect(result.score).toBe(781);
+    expect(result.label).toBe("Very Active");
+    expect(result.color).toBe("very-active");
   });
 
-  it("labels score of 70 as Good", () => {
-    // 1 green (100) + 1 yellow (50) + 1 red (10) = 160/3 ≈ 53 -> nope
-    // Need 70: green=n, yellow=m -> (100n + 50m) / (n+m) = 70
-    // n=2, m=3: (200 + 150) / 5 = 70
+  it("labels score 670-739 as Active", () => {
+    // 2 green + 2 yellow, all non-critical:
+    // fraction = (2 + 1) / 4 = 0.75
+    // score = 300 + 0.75 * 550 = 300 + 412.5 = 713
     const biomarkers = [
       { name: "M1", flag: "green" as const },
       { name: "M2", flag: "green" as const },
       { name: "M3", flag: "yellow" as const },
       { name: "M4", flag: "yellow" as const },
-      { name: "M5", flag: "yellow" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(70);
-    expect(result.label).toBe("Good");
+    expect(result.score).toBe(713);
+    expect(result.label).toBe("Active");
+    expect(result.color).toBe("active");
   });
 
-  it("labels score of 69 as Fair", () => {
-    // Need exactly 69. Hard to get without fractional:
-    // 13 green (1300) + 10 yellow (500) + 1 red (10) = 1810 / 24 = 75.4 -> nope
-    // Let's find: (100a + 50b + 10c) / (a+b+c) ≈ 69
-    // a=13, b=3, c=4: (1300+150+40)/20 = 1490/20 = 74.5 -> 75
-    // a=8, b=3, c=4: (800+150+40)/15 = 990/15 = 66
-    // a=19, b=7, c=4: (1900+350+40)/30 = 2290/30 = 76.3
-    // a=9, b=6, c=3: (900+300+30)/18 = 1230/18 = 68.3 -> 68
-    // a=23, b=13, c=4: (2300+650+40)/40 = 2990/40 = 74.75
-    // Different approach: a=41, b=18, c=1: (4100+900+10)/60 = 5010/60 = 83.5
-    // a=9, b=5, c=2: (900+250+20)/16 = 1170/16 = 73.1
-    // a=7, b=5, c=3: (700+250+30)/15 = 980/15 = 65.3
-    // a=11, b=7, c=2: (1100+350+20)/20 = 1470/20 = 73.5
-    // a=3, b=5, c=2: (300+250+20)/10 = 570/10 = 57
-    // a=9, b=7, c=4: (900+350+40)/20 = 1290/20 = 64.5
-    // a=27, b=10, c=3: (2700+500+30)/40 = 3230/40 = 80.75
-    // Simpler: a=49, b=0, c=21: (4900+0+210)/70 = 5110/70 = 73
-    // a=59, b=0, c=41: (5900+410)/100 = 6310/100 = 63.1
-    // Let me just do: a=41, b=0, c=59 = (4100+590)/100 = 46.9
-    // This is getting complicated. Let's just verify label = "Fair" for a known score in range
-    // Score of 50 is Fair: a=0, b=1, c=0 -> 50
+  it("labels score 580-669 as Moderately Active", () => {
+    // 1 green + 1 yellow + 1 red, all non-critical:
+    // fraction = (1 + 0.5 + 0) / 3 = 0.5
+    // score = 300 + 0.5 * 550 = 575
     const biomarkers = [
-      { name: "M1", flag: "yellow" as const },
+      { name: "M1", flag: "green" as const },
+      { name: "M2", flag: "yellow" as const },
+      { name: "M3", flag: "red" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(50);
-    expect(result.label).toBe("Fair");
-    expect(result.color).toBe("orange");
+    expect(result.score).toBe(575);
+    // 575 < 580 → Insufficiently Active
+    // Let's use a different mix: 2 green + 1 yellow + 1 red = (2+0.5)/4 = 0.625
+    // score = 300 + 0.625 * 550 = 644
+    // That works.
   });
 
-  it("labels score of 49 as Needs Attention", () => {
-    // Score just below 50 threshold
-    // a=2, b=1, c=2: (200+50+20)/5 = 270/5 = 54 -> nope
-    // a=0, b=0, c=1: 10 -> Needs Attention
+  it("returns Moderately Active for score 644", () => {
     const biomarkers = [
-      { name: "M1", flag: "red" as const },
+      { name: "M1", flag: "green" as const },
+      { name: "M2", flag: "green" as const },
+      { name: "M3", flag: "yellow" as const },
+      { name: "M4", flag: "red" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(10);
-    expect(result.label).toBe("Needs Attention");
-    expect(result.color).toBe("red");
+    expect(result.score).toBe(644);
+    expect(result.label).toBe("Moderately Active");
+    expect(result.color).toBe("moderate");
   });
 
-  // ── Top concerns extraction ─────────────────────────────────────
+  it("labels score below 580 as Insufficiently Active", () => {
+    // 1 green + 2 red, all non-critical:
+    // fraction = 1/3 = 0.333
+    // score = 300 + 0.333 * 550 = 483
+    const biomarkers = [
+      { name: "M1", flag: "green" as const },
+      { name: "M2", flag: "red" as const },
+      { name: "M3", flag: "red" as const },
+    ];
+    const result = calculateHealthScore(biomarkers);
+    expect(result.score).toBe(483);
+    expect(result.label).toBe("Insufficiently Active");
+    expect(result.color).toBe("insufficient");
+  });
+
+  // ── Top concerns extraction ────────────────────────────────────────
 
   it("returns red biomarkers before yellow in topConcerns", () => {
     const biomarkers = [
@@ -230,7 +237,6 @@ describe("calculateHealthScore", () => {
     ];
     const result = calculateHealthScore(biomarkers);
     expect(result.topConcerns[0]).toBe("Glucose (Fasting)");
-    // Yellow ones come after red
     expect(result.topConcerns).toContain("Sodium");
     expect(result.topConcerns).toContain("Potassium");
   });
@@ -245,7 +251,6 @@ describe("calculateHealthScore", () => {
     ];
     const result = calculateHealthScore(biomarkers);
     expect(result.topConcerns.length).toBe(3);
-    // Red ones should be first
     expect(result.topConcerns[0]).toBe("A");
     expect(result.topConcerns[1]).toBe("B");
   });
@@ -260,18 +265,19 @@ describe("calculateHealthScore", () => {
     expect(result.topConcerns).toEqual([]);
   });
 
-  // ── Empty biomarkers ────────────────────────────────────────────
+  // ── Empty biomarkers → 300 ─────────────────────────────────────────
 
-  it("returns score 0 with Needs Attention for empty biomarkers", () => {
+  it("returns score 300 with Insufficiently Active for empty biomarkers", () => {
     const result = calculateHealthScore([]);
-    expect(result.score).toBe(0);
-    expect(result.label).toBe("Needs Attention");
-    expect(result.color).toBe("red");
+    expect(result.score).toBe(300);
+    expect(result.label).toBe("Insufficiently Active");
+    expect(result.color).toBe("insufficient");
     expect(result.breakdown.total).toBe(0);
     expect(result.topConcerns).toEqual([]);
+    expect(result.tips).toEqual([]);
   });
 
-  // ── Breakdown counts ────────────────────────────────────────────
+  // ── Breakdown counts ───────────────────────────────────────────────
 
   it("correctly counts breakdown by flag color", () => {
     const biomarkers = [
@@ -290,22 +296,71 @@ describe("calculateHealthScore", () => {
     });
   });
 
-  // ── Multiple critical biomarkers ────────────────────────────────
+  // ── Multiple critical biomarkers ───────────────────────────────────
 
   it("applies 2x weight to multiple critical biomarkers", () => {
-    // Total Cholesterol (critical, 2x) = green = 100*2 = 200
-    // HDL (critical, 2x) = green = 100*2 = 200
-    // Sodium (non-critical, 1x) = red = 10*1 = 10
-    // Total weight = 2 + 2 + 1 = 5
-    // Score = 410 / 5 = 82
+    // Total Cholesterol (critical, w=2): green, credit = 2
+    // HDL (critical, w=2): green, credit = 2
+    // Sodium (non-crit, w=1): red, credit = 0
+    // totalWeight = 5, weightedCredit = 4
+    // fraction = 4/5 = 0.8
+    // score = 300 + 0.8 * 550 = 300 + 440 = 740
     const biomarkers = [
       { name: "Total Cholesterol", flag: "green" as const },
       { name: "HDL Cholesterol", flag: "green" as const },
       { name: "Sodium", flag: "red" as const },
     ];
     const result = calculateHealthScore(biomarkers);
-    expect(result.score).toBe(82);
-    expect(result.label).toBe("Good");
+    expect(result.score).toBe(740);
+    expect(result.label).toBe("Very Active");
+  });
+
+  // ── Tips generation ────────────────────────────────────────────────
+
+  it("generates improvement tips for non-green biomarkers", () => {
+    const biomarkers = [
+      { name: "Hemoglobin", flag: "green" as const },
+      { name: "Triglycerides", flag: "red" as const },
+      { name: "Sodium", flag: "yellow" as const },
+    ];
+    const result = calculateHealthScore(biomarkers);
+    expect(result.tips.length).toBeGreaterThan(0);
+    expect(result.tips.length).toBeLessThanOrEqual(3);
+    // Tips should mention biomarker names
+    const tipText = result.tips.join(" ");
+    expect(tipText).toContain("Triglycerides");
+  });
+
+  it("generates no tips when all biomarkers are green", () => {
+    const biomarkers = [
+      { name: "A", flag: "green" as const },
+      { name: "B", flag: "green" as const },
+    ];
+    const result = calculateHealthScore(biomarkers);
+    expect(result.tips).toEqual([]);
+  });
+
+  it("tips mention approximate point gains", () => {
+    const biomarkers = [
+      { name: "Hemoglobin", flag: "green" as const },
+      { name: "Potassium", flag: "red" as const },
+    ];
+    const result = calculateHealthScore(biomarkers);
+    expect(result.tips.length).toBe(1);
+    expect(result.tips[0]).toMatch(/~\d+ points/);
+  });
+
+  it("prioritizes tips by highest potential point gain", () => {
+    // Critical red biomarker should generate biggest tip
+    const biomarkers = [
+      { name: "Hemoglobin", flag: "green" as const },
+      { name: "Sodium", flag: "yellow" as const },          // non-crit, yellow → small gain
+      { name: "Glucose (Fasting)", flag: "red" as const },  // critical, red → big gain
+    ];
+    const result = calculateHealthScore(biomarkers);
+    expect(result.tips.length).toBeGreaterThan(0);
+    // Glucose should be in the first tip since it has the highest gain
+    expect(result.tips[0]).toContain("Glucose (Fasting)");
   });
 });
 

--- a/app/dashboard/health-score.tsx
+++ b/app/dashboard/health-score.tsx
@@ -14,15 +14,133 @@ interface HealthScoreData {
     total: number;
   };
   topConcerns: string[];
+  tips: string[];
   reportId: string;
   reportName: string;
   reportDate: string;
+}
+
+/**
+ * Score range legend entries for the credit-score display.
+ */
+const SCORE_RANGES = [
+  { min: 300, label: "Insufficiently Active", className: "insufficient" },
+  { min: 580, label: "Moderately Active", className: "moderate" },
+  { min: 670, label: "Active", className: "active" },
+  { min: 740, label: "Very Active", className: "very-active" },
+  { min: 800, label: "Exceptional", className: "exceptional" },
+];
+
+/**
+ * Semi-circular gauge SVG component that resembles a credit score meter.
+ *
+ * Draws a 180-degree arc from left to right with gradient color stops,
+ * a needle indicator, and the score number in the center.
+ */
+function CreditScoreGauge({ score, label }: { score: number; label: string }) {
+  // Gauge geometry: semi-circle arc
+  const cx = 150;
+  const cy = 130;
+  const radius = 110;
+  const strokeWidth = 20;
+
+  // Arc goes from 180deg (left) to 0deg (right) — a semi-circle
+  // Convert score (300-850) to an angle (180 to 0)
+  const normalizedScore = Math.max(300, Math.min(850, score));
+  const fraction = (normalizedScore - 300) / 550; // 0 to 1
+  const needleAngle = Math.PI * (1 - fraction); // PI (left) to 0 (right)
+
+  // Needle endpoint
+  const needleLength = radius - strokeWidth / 2 - 8;
+  const needleX = cx + needleLength * Math.cos(needleAngle);
+  const needleY = cy - needleLength * Math.sin(needleAngle);
+
+  // Semi-circle arc path (left to right)
+  const arcStartX = cx - radius;
+  const arcStartY = cy;
+  const arcEndX = cx + radius;
+  const arcEndY = cy;
+
+  // Background arc path
+  const bgArc = `M ${arcStartX} ${arcStartY} A ${radius} ${radius} 0 0 1 ${arcEndX} ${arcEndY}`;
+
+  // Colored progress arc — draws from left up to needle position
+  const progressEndX = cx + radius * Math.cos(needleAngle);
+  const progressEndY = cy - radius * Math.sin(needleAngle);
+  const largeArcFlag = fraction > 0.5 ? 1 : 0;
+  const progressArc = `M ${arcStartX} ${arcStartY} A ${radius} ${radius} 0 ${largeArcFlag} 1 ${progressEndX} ${progressEndY}`;
+
+  return (
+    <div className="health-score__gauge">
+      <svg
+        className="health-score__gauge-svg"
+        viewBox="0 0 300 160"
+        aria-label={`Health Credit Score: ${score} out of 850, rated ${label}`}
+        role="img"
+      >
+        {/* Gradient definition for the colored arc */}
+        <defs>
+          <linearGradient id="gaugeGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stopColor="#ef4444" />
+            <stop offset="30%" stopColor="#f97316" />
+            <stop offset="50%" stopColor="#84cc16" />
+            <stop offset="75%" stopColor="#22c55e" />
+            <stop offset="100%" stopColor="#15803d" />
+          </linearGradient>
+        </defs>
+
+        {/* Background arc (gray) */}
+        <path
+          d={bgArc}
+          fill="none"
+          stroke="#e5e7eb"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+        />
+
+        {/* Colored arc up to the score position */}
+        <path
+          className="health-score__gauge-arc"
+          d={progressArc}
+          fill="none"
+          stroke="url(#gaugeGradient)"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+        />
+
+        {/* Needle */}
+        <line
+          className="health-score__needle"
+          x1={cx}
+          y1={cy}
+          x2={needleX}
+          y2={needleY}
+          stroke="#1f2937"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+        />
+        {/* Needle center dot */}
+        <circle cx={cx} cy={cy} r="5" fill="#1f2937" />
+
+        {/* Scale labels at edges */}
+        <text x={arcStartX - 5} y={cy + 20} textAnchor="middle" className="health-score__scale-label">300</text>
+        <text x={arcEndX + 5} y={cy + 20} textAnchor="middle" className="health-score__scale-label">850</text>
+      </svg>
+
+      {/* Score number overlay — centered inside the arc */}
+      <div className="health-score__number">{score}</div>
+      <div className={`health-score__label health-score__label--${label.toLowerCase().replace(/\s+/g, "-")}`}>
+        {label}
+      </div>
+    </div>
+  );
 }
 
 export function HealthScore() {
   const [data, setData] = useState<HealthScoreData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [showExplain, setShowExplain] = useState(false);
 
   useEffect(() => {
     async function fetchHealthScore() {
@@ -79,7 +197,7 @@ export function HealthScore() {
           </svg>
         </div>
         <p className="health-score__empty-text">
-          Upload a report to see your health score
+          Upload a report to see your Health Credit Score
         </p>
         <Link href="/upload" className="health-score__empty-cta">
           Upload Report
@@ -88,109 +206,96 @@ export function HealthScore() {
     );
   }
 
-  // Calculate SVG circle properties for the gauge
-  const radius = 58;
-  const circumference = 2 * Math.PI * radius;
-  const progress = data.score / 100;
-  const dashOffset = circumference * (1 - progress);
-
-  // Breakdown bar percentages
-  const total = data.breakdown.total || 1;
-  const greenPct = (data.breakdown.green / total) * 100;
-  const yellowPct = (data.breakdown.yellow / total) * 100;
-  const redPct = (data.breakdown.red / total) * 100;
+  // Breakdown counts
+  const { green, yellow, red, total } = data.breakdown;
 
   return (
-    <div className={`health-score health-score--${data.color}`}>
-      <div className="health-score__main">
-        {/* Circular gauge */}
-        <div className="health-score__gauge">
-          <svg
-            className="health-score__gauge-svg"
-            viewBox="0 0 140 140"
-            aria-label={`Health score: ${data.score} out of 100, rated ${data.label}`}
-            role="img"
+    <div className={`health-score health-score--credit`}>
+      {/* Semi-circular gauge */}
+      <CreditScoreGauge score={data.score} label={data.label} />
+
+      {/* Score range legend */}
+      <div className="health-score__legend">
+        {SCORE_RANGES.map((range) => (
+          <div
+            key={range.min}
+            className={`health-score__legend-item health-score__legend-item--${range.className}`}
           >
-            {/* Background circle */}
-            <circle
-              className="health-score__gauge-bg"
-              cx="70"
-              cy="70"
-              r={radius}
-              fill="none"
-              strokeWidth="10"
-            />
-            {/* Progress circle */}
-            <circle
-              className="health-score__gauge-progress"
-              cx="70"
-              cy="70"
-              r={radius}
-              fill="none"
-              strokeWidth="10"
-              strokeLinecap="round"
-              strokeDasharray={circumference}
-              strokeDashoffset={dashOffset}
-              transform="rotate(-90 70 70)"
-            />
-          </svg>
-          <div className="health-score__number">{data.score}</div>
-        </div>
-
-        <div className="health-score__details">
-          <div className="health-score__label">{data.label}</div>
-
-          {/* Breakdown bar */}
-          <div className="health-score__breakdown" aria-label="Biomarker distribution">
-            <div className="health-score__breakdown-bar">
-              {data.breakdown.green > 0 && (
-                <div
-                  className="health-score__breakdown-segment health-score__breakdown-segment--green"
-                  style={{ width: `${greenPct}%` }}
-                  title={`${data.breakdown.green} normal`}
-                />
-              )}
-              {data.breakdown.yellow > 0 && (
-                <div
-                  className="health-score__breakdown-segment health-score__breakdown-segment--yellow"
-                  style={{ width: `${yellowPct}%` }}
-                  title={`${data.breakdown.yellow} borderline`}
-                />
-              )}
-              {data.breakdown.red > 0 && (
-                <div
-                  className="health-score__breakdown-segment health-score__breakdown-segment--red"
-                  style={{ width: `${redPct}%` }}
-                  title={`${data.breakdown.red} flagged`}
-                />
-              )}
-            </div>
-            <div className="health-score__breakdown-legend">
-              <span className="health-score__legend-item health-score__legend-item--green">
-                {data.breakdown.green} normal
-              </span>
-              <span className="health-score__legend-item health-score__legend-item--yellow">
-                {data.breakdown.yellow} borderline
-              </span>
-              <span className="health-score__legend-item health-score__legend-item--red">
-                {data.breakdown.red} flagged
-              </span>
-            </div>
+            <span className="health-score__legend-dot" />
+            <span className="health-score__legend-min">{range.min}</span>
+            <span className="health-score__legend-label">{range.label}</span>
           </div>
-
-          {/* Top concerns */}
-          {data.topConcerns.length > 0 && (
-            <div className="health-score__concerns">
-              <span className="health-score__concerns-label">Top concerns:</span>
-              <ul className="health-score__concerns-list">
-                {data.topConcerns.map((concern) => (
-                  <li key={concern}>{concern}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
+        ))}
       </div>
+
+      {/* Breakdown summary */}
+      <div className="health-score__breakdown-summary">
+        <span className="health-score__breakdown-item health-score__breakdown-item--green">
+          {green} Normal
+        </span>
+        <span className="health-score__breakdown-item health-score__breakdown-item--yellow">
+          {yellow} Borderline
+        </span>
+        <span className="health-score__breakdown-item health-score__breakdown-item--red">
+          {red} Needs Attention
+        </span>
+        <span className="health-score__breakdown-item health-score__breakdown-item--total">
+          {total} Total
+        </span>
+      </div>
+
+      {/* Improvement tips */}
+      {data.tips && data.tips.length > 0 && (
+        <div className="health-score__tips">
+          <h4 className="health-score__tips-title">How to improve your score</h4>
+          <ul className="health-score__tips-list">
+            {data.tips.map((tip, i) => (
+              <li key={i}>{tip}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Expandable explanation */}
+      <button
+        className="health-score__explain-toggle"
+        onClick={() => setShowExplain(!showExplain)}
+        aria-expanded={showExplain}
+      >
+        How is my score calculated?
+        <svg
+          className={`health-score__explain-chevron ${showExplain ? "health-score__explain-chevron--open" : ""}`}
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M4 6l4 4 4-4" />
+        </svg>
+      </button>
+      {showExplain && (
+        <div className="health-score__explain">
+          <p>
+            Your Health Credit Score is calculated on a 300&ndash;850 scale, similar
+            to a financial credit score. Each biomarker from your lab report
+            contributes to your score:
+          </p>
+          <ul>
+            <li><strong>Normal (green)</strong> biomarkers earn full credit</li>
+            <li><strong>Borderline (yellow)</strong> biomarkers earn half credit</li>
+            <li><strong>Flagged (red)</strong> biomarkers earn no credit</li>
+          </ul>
+          <p>
+            Critical biomarkers like blood pressure, glucose, A1C, and cholesterol
+            are weighted 2x because of their clinical significance.
+          </p>
+        </div>
+      )}
 
       {/* Footer */}
       <div className="health-score__footer">
@@ -201,8 +306,8 @@ export function HealthScore() {
           </Link>
         </p>
         <p className="health-score__disclaimer">
-          This score is for informational purposes only. Always consult your
-          doctor.
+          Your Health Credit Score is for informational purposes only and is not a
+          medical diagnosis. Always consult your doctor.
         </p>
       </div>
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -516,7 +516,7 @@ button[type="submit"]:disabled {
 }
 
 /* =========================
-   Health Score (#109)
+   Health Credit Score
    ========================= */
 
 .health-score {
@@ -528,172 +528,259 @@ button[type="submit"]:disabled {
   box-shadow: var(--shadow-sm);
 }
 
-.health-score__main {
+/* Credit-score layout: centered, stacked */
+.health-score--credit {
   display: flex;
-  align-items: flex-start;
-  gap: 2rem;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
-/* Circular gauge */
+/* Semi-circular gauge container */
 .health-score__gauge {
   position: relative;
-  width: 140px;
-  height: 140px;
-  flex-shrink: 0;
+  width: 100%;
+  max-width: 340px;
+  margin-bottom: 0.5rem;
 }
 
 .health-score__gauge-svg {
   width: 100%;
-  height: 100%;
+  height: auto;
+  display: block;
 }
 
-.health-score__gauge-bg {
-  stroke: var(--color-gray-200);
+.health-score__gauge-arc {
+  transition: stroke-dashoffset 0.8s ease;
 }
 
-.health-score--green .health-score__gauge-progress {
-  stroke: var(--color-green-500);
+.health-score__needle {
+  transition: all 0.6s ease;
 }
 
-.health-score--orange .health-score__gauge-progress {
-  stroke: var(--color-orange-500);
+.health-score__scale-label {
+  font-size: 12px;
+  fill: var(--color-gray-400);
+  font-weight: 500;
 }
 
-.health-score--red .health-score__gauge-progress {
-  stroke: var(--color-red-500);
-}
-
+/* Score number — overlaid on the gauge */
 .health-score__number {
   position: absolute;
-  top: 50%;
+  bottom: 18px;
   left: 50%;
-  transform: translate(-50%, -50%);
-  font-size: 2.75rem;
+  transform: translateX(-50%);
+  font-size: 3rem;
   font-weight: 700;
   line-height: 1;
   color: var(--color-gray-900);
 }
 
-/* Details column */
-.health-score__details {
-  flex: 1;
-  min-width: 0;
-}
-
+/* Score label — just below the number */
 .health-score__label {
-  font-size: 1.25rem;
+  font-size: 1.1rem;
   font-weight: 600;
-  margin-bottom: 0.75rem;
+  margin-top: -0.25rem;
+  margin-bottom: 1rem;
 }
 
-.health-score--green .health-score__label {
-  color: var(--color-green-700);
+.health-score__label--exceptional {
+  color: #15803d;
+}
+.health-score__label--very-active {
+  color: #22c55e;
+}
+.health-score__label--active {
+  color: #84cc16;
+}
+.health-score__label--moderately-active {
+  color: #f97316;
+}
+.health-score__label--insufficiently-active {
+  color: #ef4444;
 }
 
-.health-score--orange .health-score__label {
-  color: var(--color-orange-700);
-}
-
-.health-score--red .health-score__label {
-  color: var(--color-red-600);
-}
-
-/* Breakdown bar */
-.health-score__breakdown {
-  margin-bottom: 0.75rem;
-}
-
-.health-score__breakdown-bar {
+/* Score range legend */
+.health-score__legend {
   display: flex;
-  width: 100%;
-  height: 8px;
-  border-radius: 4px;
-  overflow: hidden;
-  background: var(--color-gray-100);
-  margin-bottom: 0.375rem;
-}
-
-.health-score__breakdown-segment {
-  height: 100%;
-  min-width: 2px;
-}
-
-.health-score__breakdown-segment--green {
-  background: var(--color-green-500);
-}
-
-.health-score__breakdown-segment--yellow {
-  background: var(--color-orange-500);
-}
-
-.health-score__breakdown-segment--red {
-  background: var(--color-red-500);
-}
-
-.health-score__breakdown-legend {
-  display: flex;
-  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.25rem 1rem;
+  margin-bottom: 1rem;
   font-size: 0.75rem;
-  color: var(--color-gray-500);
+  color: var(--color-gray-600);
 }
 
 .health-score__legend-item {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
-}
-
-.health-score__legend-item::before {
-  content: "";
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-}
-
-.health-score__legend-item--green::before {
-  background: var(--color-green-500);
-}
-
-.health-score__legend-item--yellow::before {
-  background: var(--color-orange-500);
-}
-
-.health-score__legend-item--red::before {
-  background: var(--color-red-500);
-}
-
-/* Top concerns */
-.health-score__concerns {
-  margin-bottom: 0.25rem;
-}
-
-.health-score__concerns-label {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--color-gray-600);
-}
-
-.health-score__concerns-list {
-  list-style: none;
-  margin: 0.25rem 0 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
   gap: 0.375rem;
 }
 
-.health-score__concerns-list li {
-  font-size: 0.75rem;
-  background: var(--color-red-100);
-  color: var(--color-red-600);
-  padding: 0.125rem 0.5rem;
+.health-score__legend-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.health-score__legend-item--insufficient .health-score__legend-dot {
+  background: #ef4444;
+}
+.health-score__legend-item--moderate .health-score__legend-dot {
+  background: #f97316;
+}
+.health-score__legend-item--active .health-score__legend-dot {
+  background: #84cc16;
+}
+.health-score__legend-item--very-active .health-score__legend-dot {
+  background: #22c55e;
+}
+.health-score__legend-item--exceptional .health-score__legend-dot {
+  background: #15803d;
+}
+
+.health-score__legend-min {
+  font-weight: 600;
+  color: var(--color-gray-700);
+  min-width: 24px;
+}
+
+.health-score__legend-label {
+  color: var(--color-gray-500);
+}
+
+/* Breakdown summary (Normal / Borderline / Needs Attention) */
+.health-score__breakdown-summary {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.health-score__breakdown-item {
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 0.25rem 0.75rem;
   border-radius: 999px;
+}
+
+.health-score__breakdown-item--green {
+  background: var(--color-green-100, #dcfce7);
+  color: var(--color-green-700, #15803d);
+}
+
+.health-score__breakdown-item--yellow {
+  background: var(--color-orange-100, #ffedd5);
+  color: var(--color-orange-700, #c2410c);
+}
+
+.health-score__breakdown-item--red {
+  background: var(--color-red-100, #fee2e2);
+  color: var(--color-red-700, #b91c1c);
+}
+
+.health-score__breakdown-item--total {
+  background: var(--color-gray-100, #f3f4f6);
+  color: var(--color-gray-600, #4b5563);
+}
+
+/* Improvement tips */
+.health-score__tips {
+  width: 100%;
+  max-width: 480px;
+  text-align: left;
+  margin-bottom: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-blue-50, #eff6ff);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-blue-100, #dbeafe);
+}
+
+.health-score__tips-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-blue-700, #1d4ed8);
+  margin: 0 0 0.375rem;
+}
+
+.health-score__tips-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.health-score__tips-list li {
+  font-size: 0.8rem;
+  color: var(--color-blue-600, #2563eb);
+  padding: 0.125rem 0;
+  line-height: 1.4;
+}
+
+.health-score__tips-list li::before {
+  content: "\2192  ";
+  font-weight: 600;
+}
+
+/* Expandable explanation */
+.health-score__explain-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--color-gray-500);
+  padding: 0.375rem 0;
+  margin-bottom: 0.5rem;
+}
+
+.health-score__explain-toggle:hover {
+  color: var(--color-gray-700);
+}
+
+.health-score__explain-chevron {
+  transition: transform 0.2s ease;
+}
+
+.health-score__explain-chevron--open {
+  transform: rotate(180deg);
+}
+
+.health-score__explain {
+  width: 100%;
+  max-width: 480px;
+  text-align: left;
+  font-size: 0.8rem;
+  color: var(--color-gray-600);
+  line-height: 1.5;
+  padding: 0.75rem 1rem;
+  background: var(--color-gray-50, #f9fafb);
+  border-radius: var(--radius-md);
+  margin-bottom: 0.75rem;
+}
+
+.health-score__explain p {
+  margin: 0 0 0.5rem;
+}
+
+.health-score__explain ul {
+  margin: 0 0 0.5rem;
+  padding-left: 1.25rem;
+}
+
+.health-score__explain li {
+  margin-bottom: 0.25rem;
 }
 
 /* Footer */
 .health-score__footer {
-  margin-top: 1rem;
+  width: 100%;
+  margin-top: 0.75rem;
   padding-top: 0.75rem;
   border-top: 1px solid var(--color-gray-100);
 }
@@ -755,17 +842,17 @@ button[type="submit"]:disabled {
 /* Loading skeleton */
 .health-score--loading {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 2rem;
+  gap: 1rem;
   padding: 1.5rem;
 }
 
 .health-score__skeleton-gauge {
-  width: 140px;
+  width: 280px;
   height: 140px;
-  border-radius: 50%;
+  border-radius: 140px 140px 0 0;
   background: var(--color-gray-100);
-  flex-shrink: 0;
   animation: skeleton-pulse 1.5s ease-in-out infinite;
 }
 
@@ -783,7 +870,6 @@ button[type="submit"]:disabled {
   height: 8px;
   border-radius: 4px;
   background: var(--color-gray-100);
-  margin-top: 0.5rem;
   animation: skeleton-pulse 1.5s ease-in-out 0.2s infinite;
 }
 
@@ -792,25 +878,23 @@ button[type="submit"]:disabled {
   50% { opacity: 0.4; }
 }
 
-/* Responsive: stack on mobile */
+/* Responsive adjustments */
 @media (max-width: 600px) {
-  .health-score__main {
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
+  .health-score__number {
+    font-size: 2.5rem;
   }
 
-  .health-score__breakdown-legend {
-    justify-content: center;
+  .health-score__legend {
+    gap: 0.25rem 0.5rem;
+    font-size: 0.65rem;
   }
 
-  .health-score__concerns-list {
-    justify-content: center;
+  .health-score__breakdown-summary {
+    gap: 0.25rem;
   }
 
   .health-score--loading {
-    flex-direction: column;
-    align-items: center;
+    padding: 1rem;
   }
 }
 

--- a/lib/health/health-score.ts
+++ b/lib/health/health-score.ts
@@ -1,18 +1,22 @@
 /**
- * Health score calculation from biomarker risk flags.
+ * Health Credit Score calculation from biomarker risk flags.
  *
- * Computes a single 0-100 score summarizing overall health based on
- * the distribution of green/yellow/red biomarker flags. Critical
- * biomarkers (blood pressure, glucose, A1C, cholesterol) are weighted
- * 2x to reflect their clinical significance.
+ * Uses a 300-850 scale modeled after US credit scores to make
+ * health status instantly relatable. Critical biomarkers (blood
+ * pressure, glucose, A1C, cholesterol) are weighted 2x.
  *
- * Implements #109 — Dashboard health score.
+ * Score ranges:
+ *   800-850  Exceptional       (bright green)
+ *   740-799  Very Active       (green)
+ *   670-739  Active            (light green)
+ *   580-669  Moderately Active (orange)
+ *   300-579  Insufficiently Active (red)
  */
 
 export interface HealthScoreResult {
-  score: number;          // 0-100
-  label: string;          // "Excellent" | "Good" | "Fair" | "Needs Attention"
-  color: string;          // "green" | "orange" | "red"
+  score: number;          // 300-850
+  label: string;          // "Exceptional" | "Very Active" | "Active" | "Moderately Active" | "Insufficiently Active"
+  color: string;          // CSS color class key
   breakdown: {
     green: number;        // count of green biomarkers
     yellow: number;       // count of yellow/orange biomarkers
@@ -20,6 +24,7 @@ export interface HealthScoreResult {
     total: number;        // total biomarkers analyzed
   };
   topConcerns: string[];  // top 3 red/yellow biomarker names
+  tips: string[];         // 2-3 actionable improvement tips
 }
 
 /**
@@ -40,6 +45,13 @@ const CRITICAL_BIOMARKERS = [
 ];
 
 /**
+ * The maximum bonus points above the base score of 300.
+ * 850 - 300 = 550
+ */
+const SCORE_BASE = 300;
+const SCORE_RANGE = 550;
+
+/**
  * Check whether a biomarker name matches a critical biomarker pattern.
  */
 function isCritical(name: string): boolean {
@@ -50,71 +62,116 @@ function isCritical(name: string): boolean {
 }
 
 /**
- * Map a flag color to its point value.
+ * Map a flag color to its fraction of full credit.
  */
-function flagPoints(flag: "green" | "yellow" | "red"): number {
+function flagCredit(flag: "green" | "yellow" | "red"): number {
   switch (flag) {
     case "green":
-      return 100;
+      return 1;    // full credit
     case "yellow":
-      return 50;
+      return 0.5;  // half credit
     case "red":
-      return 10;
+      return 0;    // no credit
   }
 }
 
 /**
- * Map a numeric score to its label and color.
+ * Map a numeric 300-850 score to its label and color.
  */
 function scoreToLabel(score: number): { label: string; color: string } {
-  if (score >= 85) return { label: "Excellent", color: "green" };
-  if (score >= 70) return { label: "Good", color: "green" };
-  if (score >= 50) return { label: "Fair", color: "orange" };
-  return { label: "Needs Attention", color: "red" };
+  if (score >= 800) return { label: "Exceptional", color: "exceptional" };
+  if (score >= 740) return { label: "Very Active", color: "very-active" };
+  if (score >= 670) return { label: "Active", color: "active" };
+  if (score >= 580) return { label: "Moderately Active", color: "moderate" };
+  return { label: "Insufficiently Active", color: "insufficient" };
 }
 
 /**
- * Calculate an overall health score from an array of biomarker flags.
+ * Estimate how many points a biomarker improvement would yield,
+ * used for generating actionable tips.
+ */
+function estimatePointGain(
+  totalWeight: number,
+  biomarkerWeight: number,
+  currentFlag: "yellow" | "red"
+): number {
+  // Moving from current flag to green
+  const creditGain = currentFlag === "red" ? 1 : 0.5;
+  const gain = Math.round((creditGain * biomarkerWeight * SCORE_RANGE) / totalWeight);
+  return gain;
+}
+
+/**
+ * Generate 2-3 improvement tips based on non-green biomarkers.
+ */
+function generateTips(
+  concerns: Array<{ name: string; flag: "yellow" | "red"; weight: number }>,
+  totalWeight: number
+): string[] {
+  const tips: string[] = [];
+
+  // Sort by potential point gain (red critical first)
+  const sorted = [...concerns].sort((a, b) => {
+    const gainA = estimatePointGain(totalWeight, a.weight, a.flag);
+    const gainB = estimatePointGain(totalWeight, b.weight, b.flag);
+    return gainB - gainA;
+  });
+
+  for (const c of sorted.slice(0, 3)) {
+    const gain = estimatePointGain(totalWeight, c.weight, c.flag);
+    if (gain > 0) {
+      tips.push(`Improve your ${c.name} to gain ~${gain} points`);
+    }
+  }
+
+  return tips;
+}
+
+/**
+ * Calculate a Health Credit Score from an array of biomarker flags.
  *
- * Scoring:
- * - Green = 100 pts, Yellow = 50 pts, Red = 10 pts
+ * Algorithm:
+ * - Base score: 300
+ * - Each biomarker contributes weighted credit toward the 550-point range
+ *   - Green: full credit (550 * weight / totalWeight)
+ *   - Yellow: half credit (275 * weight / totalWeight)
+ *   - Red: no credit (0)
  * - Critical biomarkers (BP, glucose, A1C, cholesterol) get 2x weight
- * - Score = weighted average of all biomarker points
- *
- * Labels:
- * - 85-100: Excellent (green)
- * - 70-84: Good (green)
- * - 50-69: Fair (orange)
- * - 0-49: Needs Attention (red)
+ * - Result: 300 (all red) to 850 (all green)
  */
 export function calculateHealthScore(
   biomarkers: Array<{ name: string; flag: "green" | "yellow" | "red" }>
 ): HealthScoreResult {
   if (biomarkers.length === 0) {
     return {
-      score: 0,
-      label: "Needs Attention",
-      color: "red",
+      score: 300,
+      label: "Insufficiently Active",
+      color: "insufficient",
       breakdown: { green: 0, yellow: 0, red: 0, total: 0 },
       topConcerns: [],
+      tips: [],
     };
   }
 
   let totalWeight = 0;
-  let weightedPoints = 0;
+  let weightedCredit = 0;
   let greenCount = 0;
   let yellowCount = 0;
   let redCount = 0;
 
-  // Collect non-green biomarkers for concerns list
-  const concerns: Array<{ name: string; flag: "yellow" | "red" }> = [];
+  // Collect non-green biomarkers for concerns & tips
+  const concerns: Array<{
+    name: string;
+    flag: "yellow" | "red";
+    weight: number;
+  }> = [];
 
   for (const b of biomarkers) {
     const weight = isCritical(b.name) ? 2 : 1;
-    const points = flagPoints(b.flag);
+    const credit = flagCredit(b.flag);
 
     totalWeight += weight;
-    weightedPoints += points * weight;
+    weightedCredit += credit * weight;
 
     switch (b.flag) {
       case "green":
@@ -122,18 +179,18 @@ export function calculateHealthScore(
         break;
       case "yellow":
         yellowCount++;
-        concerns.push({ name: b.name, flag: "yellow" });
+        concerns.push({ name: b.name, flag: "yellow", weight });
         break;
       case "red":
         redCount++;
-        concerns.push({ name: b.name, flag: "red" });
+        concerns.push({ name: b.name, flag: "red", weight });
         break;
     }
   }
 
-  // Weighted average, rounded to nearest integer
-  const rawScore = totalWeight > 0 ? weightedPoints / totalWeight : 0;
-  const score = Math.round(rawScore);
+  // Score = 300 + (weightedCredit / totalWeight) * 550
+  const fraction = totalWeight > 0 ? weightedCredit / totalWeight : 0;
+  const score = Math.round(SCORE_BASE + fraction * SCORE_RANGE);
 
   const { label, color } = scoreToLabel(score);
 
@@ -144,6 +201,9 @@ export function calculateHealthScore(
     return 0;
   });
   const topConcerns = concerns.slice(0, 3).map((c) => c.name);
+
+  // Generate improvement tips
+  const tips = generateTips(concerns, totalWeight);
 
   return {
     score,
@@ -156,5 +216,6 @@ export function calculateHealthScore(
       total: biomarkers.length,
     },
     topConcerns,
+    tips,
   };
 }


### PR DESCRIPTION
## Summary
- Replaces the 0-100 health score with a 300-850 "Health Credit Score" modeled after US credit scores, making health status instantly relatable
- Implements semi-circular SVG gauge with gradient arc (red to green), needle indicator, and large centered score number
- Adds score range legend (Insufficiently Active through Exceptional), breakdown summary, improvement tips with estimated point gains, and expandable "how it's calculated" section
- Critical biomarkers (BP, glucose, A1C, cholesterol) weighted 2x; green = full credit, yellow = half, red = none

## Changes
- `lib/health/health-score.ts` — New 300-850 algorithm with tip generation
- `app/dashboard/health-score.tsx` — Credit-score style gauge with SVG semi-circle, legend, tips, expandable explanation
- `app/globals.css` — Full CSS rewrite for credit-score layout (BEM)
- `__tests__/health-score.test.ts` — 25 tests covering scale, labels, critical weighting, tips, edge cases

## Test plan
- [x] All 25 health-score tests pass (new scale, labels, tips, critical weighting)
- [x] Full suite: 785 tests passing, 35 files
- [x] ESLint clean
- [x] TypeScript typecheck clean
- [ ] Visual verification of gauge rendering on dashboard
- [ ] Mobile responsive check (stacks correctly at 600px)