### PR TITLE
feat(medications): add medication tracker with CRUD, photo upload, and chat context

### DIFF
--- a/__tests__/audit-logging.test.ts
+++ b/__tests__/audit-logging.test.ts
@@ -168,6 +168,11 @@ describe("Audit Logger", () => {
         "chat.message",
         "chat.delete",
         "doctor_questions.generate",
+        "medication.create",
+        "medication.update",
+        "medication.delete",
+        "medication.photo_upload",
+        "medication.photo_delete",
       ];
 
       const resourceTypes: Record<AuditAction, AuditResourceType> = {
@@ -179,6 +184,11 @@ describe("Audit Logger", () => {
         "chat.message": "chat_session",
         "chat.delete": "chat_session",
         "doctor_questions.generate": "parsed_result",
+        "medication.create": "medication",
+        "medication.update": "medication",
+        "medication.delete": "medication",
+        "medication.photo_upload": "medication",
+        "medication.photo_delete": "medication",
       };
 
       for (const action of actions) {

--- a/__tests__/medications.test.ts
+++ b/__tests__/medications.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Medications API Route — GET/POST ──────────────────────────────
+
+describe("Medications API Route", () => {
+  it("exports GET and POST handlers", async () => {
+    const mod = await import("@/app/api/medications/route");
+    expect(mod.GET).toBeDefined();
+    expect(mod.POST).toBeDefined();
+    expect(typeof mod.GET).toBe("function");
+    expect(typeof mod.POST).toBe("function");
+  });
+});
+
+describe("Medications API — GET", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+      }),
+    }));
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { GET } = await import("@/app/api/medications/route");
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 200 with medications list for authenticated user", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const mockMedications = [
+      { id: "med-1", name: "Metformin", active: true },
+      { id: "med-2", name: "Lisinopril", active: false },
+    ];
+
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          order: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({
+              data: mockMedications,
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/medications/route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.medications).toHaveLength(2);
+    expect(body.medications[0].name).toBe("Metformin");
+  });
+});
+
+describe("Medications API — POST", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+      }),
+    }));
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { POST } = await import("@/app/api/medications/route");
+    const request = new Request("http://localhost:3000/api/medications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Test" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when medication name is missing", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const { POST } = await import("@/app/api/medications/route");
+    const request = new Request("http://localhost:3000/api/medications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ dosage: "500" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("name");
+  });
+
+  it("returns 201 on successful creation", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const mockMedication = {
+      id: "med-1",
+      name: "Metformin",
+      dosage: "500",
+      dosage_unit: "mg",
+      frequency: "twice_daily",
+      active: true,
+    };
+
+    mockFrom.mockReturnValue({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: mockMedication,
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const { POST } = await import("@/app/api/medications/route");
+    const request = new Request("http://localhost:3000/api/medications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Metformin",
+        dosage: "500",
+        dosage_unit: "mg",
+        frequency: "twice_daily",
+      }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.medication.name).toBe("Metformin");
+  });
+});
+
+// ── Single Medication API — GET/PUT/DELETE ─────────────────────────
+
+describe("Single Medication API Route", () => {
+  it("exports GET, PUT, and DELETE handlers", async () => {
+    const mod = await import("@/app/api/medications/[id]/route");
+    expect(mod.GET).toBeDefined();
+    expect(mod.PUT).toBeDefined();
+    expect(mod.DELETE).toBeDefined();
+  });
+});
+
+describe("Single Medication API — DELETE", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+  let mockStorage: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+    mockStorage = { from: vi.fn() };
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+        storage: mockStorage,
+      }),
+    }));
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { DELETE } = await import("@/app/api/medications/[id]/route");
+    const request = new Request("http://localhost:3000/api/medications/med-1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: "med-1" }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+});
+
+// ── Medication Photo API ──────────────────────────────────────────
+
+describe("Medication Photo API Route", () => {
+  it("exports POST and DELETE handlers", async () => {
+    const mod = await import("@/app/api/medications/[id]/photo/route");
+    expect(mod.POST).toBeDefined();
+    expect(mod.DELETE).toBeDefined();
+    expect(typeof mod.POST).toBe("function");
+    expect(typeof mod.DELETE).toBe("function");
+  });
+});
+
+describe("Medication Photo API — POST", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+  let mockStorage: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+    mockStorage = { from: vi.fn() };
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+        storage: mockStorage,
+      }),
+    }));
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { POST } = await import("@/app/api/medications/[id]/photo/route");
+    const formData = new FormData();
+    formData.append("file", new File([new ArrayBuffer(1024)], "photo.png", { type: "image/png" }));
+    const request = new Request("http://localhost:3000/api/medications/med-1/photo", {
+      method: "POST",
+      body: formData,
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ id: "med-1" }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 when medication does not belong to user", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: "Not found" },
+            }),
+          }),
+        }),
+      }),
+    });
+
+    const { POST } = await import("@/app/api/medications/[id]/photo/route");
+    const formData = new FormData();
+    formData.append("file", new File([new ArrayBuffer(1024)], "photo.png", { type: "image/png" }));
+    const request = new Request("http://localhost:3000/api/medications/med-999/photo", {
+      method: "POST",
+      body: formData,
+    });
+
+    const response = await POST(request, {
+      params: Promise.resolve({ id: "med-999" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+// ── Medications Page Component ────────────────────────────────────
+
+describe("Medications Page", () => {
+  it("exports a default component", async () => {
+    const mod = await import("@/app/medications/page");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+});
+
+describe("Add Medication Page", () => {
+  it("exports a default component", async () => {
+    const mod = await import("@/app/medications/add/page");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+});
+
+describe("Edit Medication Page", () => {
+  it("exports a default component", async () => {
+    const mod = await import("@/app/medications/[id]/edit/page");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+});
+
+// ── Chat Context — Structured Medications ─────────────────────────
+
+describe("buildHealthContext with structured medications", () => {
+  it("includes structured medications when provided", async () => {
+    const { buildHealthContext } = await import("@/lib/claude/chat-prompts");
+
+    const profile = {
+      gender: "male",
+      medications: "old free text",
+    };
+
+    const structuredMeds = [
+      { name: "Metformin", dosage: "500", dosage_unit: "mg", frequency: "twice_daily" },
+      { name: "Lisinopril", dosage: "10", dosage_unit: "mg", frequency: "once_daily" },
+    ];
+
+    const result = buildHealthContext(profile, structuredMeds);
+
+    expect(result).toContain("Active medications:");
+    expect(result).toContain("Metformin 500mg");
+    expect(result).toContain("Lisinopril 10mg");
+    // Should NOT contain free-text when structured is available
+    expect(result).not.toContain("old free text");
+  });
+
+  it("falls back to free-text when no structured medications", async () => {
+    const { buildHealthContext } = await import("@/lib/claude/chat-prompts");
+
+    const profile = {
+      medications: "Aspirin, Vitamin D",
+    };
+
+    const result = buildHealthContext(profile, []);
+
+    expect(result).toContain("Medications: Aspirin, Vitamin D");
+    expect(result).not.toContain("Active medications:");
+  });
+
+  it("falls back to free-text when structuredMedications is undefined", async () => {
+    const { buildHealthContext } = await import("@/lib/claude/chat-prompts");
+
+    const profile = {
+      medications: "Aspirin",
+    };
+
+    const result = buildHealthContext(profile);
+
+    expect(result).toContain("Medications: Aspirin");
+  });
+});
+
+describe("formatMedicationForContext", () => {
+  it("formats medication with name, dosage, unit, and frequency", async () => {
+    const { formatMedicationForContext } = await import("@/lib/claude/chat-prompts");
+
+    const result = formatMedicationForContext({
+      name: "Metformin",
+      dosage: "500",
+      dosage_unit: "mg",
+      frequency: "twice_daily",
+    });
+
+    expect(result).toBe("Metformin 500mg (twice daily)");
+  });
+
+  it("formats medication with name only", async () => {
+    const { formatMedicationForContext } = await import("@/lib/claude/chat-prompts");
+
+    const result = formatMedicationForContext({
+      name: "Vitamin D",
+      frequency: "once_daily",
+    });
+
+    expect(result).toBe("Vitamin D (daily)");
+  });
+
+  it("handles dosage without unit", async () => {
+    const { formatMedicationForContext } = await import("@/lib/claude/chat-prompts");
+
+    const result = formatMedicationForContext({
+      name: "Aspirin",
+      dosage: "81",
+      frequency: "once_daily",
+    });
+
+    expect(result).toBe("Aspirin 81 (daily)");
+  });
+});
+
+// ── Audit Logger — medication actions ─────────────────────────────
+
+describe("Audit Logger — medication types", () => {
+  it("includes medication audit action types", async () => {
+    // The AuditAction type includes medication actions — verify the module loads cleanly
+    const mod = await import("@/lib/audit/logger");
+    expect(mod.logAuditEvent).toBeDefined();
+    expect(typeof mod.logAuditEvent).toBe("function");
+  });
+});

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { getClaudeClient } from "@/lib/claude/client";
-import { CHAT_SYSTEM_PROMPT, buildReportContext, buildHealthContext, buildMultiReportContext, buildEnrichedContext } from "@/lib/claude/chat-prompts";
+import { CHAT_SYSTEM_PROMPT, buildReportContext, buildHealthContext, buildMultiReportContext, buildEnrichedContext, type StructuredMedication } from "@/lib/claude/chat-prompts";
 import { lookupCondition } from "@/lib/health/nlm-api";
 import { logAuditEvent, getClientIp } from "@/lib/audit/logger";
 import { NextResponse } from "next/server";
@@ -98,7 +98,22 @@ export async function POST(request: Request) {
     .eq("id", user.id)
     .single();
 
-  const healthContext = profileData ? buildHealthContext(profileData) : "";
+  // Load structured medications for richer chat context
+  const { data: medicationsData } = await supabase
+    .from("medications")
+    .select("name, dosage, dosage_unit, frequency")
+    .eq("user_id", user.id)
+    .eq("active", true)
+    .order("name");
+
+  const structuredMeds: StructuredMedication[] = (medicationsData || []).map((m) => ({
+    name: m.name,
+    dosage: m.dosage,
+    dosage_unit: m.dosage_unit,
+    frequency: m.frequency,
+  }));
+
+  const healthContext = profileData ? buildHealthContext(profileData, structuredMeds) : "";
 
   // Load report context — single report if report_id provided, otherwise multi-report
   let reportContext = "";

--- a/app/api/medications/[id]/photo/route.ts
+++ b/app/api/medications/[id]/photo/route.ts
@@ -1,0 +1,227 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/webp"];
+
+function getExtension(mimeType: string): string {
+  const map: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp",
+  };
+  return map[mimeType] || "png";
+}
+
+/**
+ * Validate file content by checking magic bytes (file signatures).
+ * Prevents MIME type spoofing.
+ */
+async function validateMagicBytes(file: File): Promise<boolean> {
+  const buffer = await file.slice(0, 4).arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+
+  // JPEG: starts with 0xFF 0xD8 0xFF
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return true;
+
+  // PNG: starts with 0x89 0x50 0x4E 0x47
+  if (
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  )
+    return true;
+
+  // WebP: starts with RIFF....WEBP (0x52 0x49 0x46 0x46)
+  if (
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46
+  )
+    return true;
+
+  return false;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id } = await params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Verify medication belongs to user
+  const { data: medication } = await supabase
+    .from("medications")
+    .select("id, photo_path")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!medication) {
+    return NextResponse.json(
+      { error: "Medication not found" },
+      { status: 404 }
+    );
+  }
+
+  // Parse multipart form data
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid form data" },
+      { status: 400 }
+    );
+  }
+
+  const file = formData.get("file");
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json(
+      { error: "No file provided" },
+      { status: 400 }
+    );
+  }
+
+  // Validate file type
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      { error: "Invalid file type. Accepted: PNG, JPEG, WebP" },
+      { status: 400 }
+    );
+  }
+
+  // Validate file size
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { error: "File too large. Maximum size is 5MB" },
+      { status: 413 }
+    );
+  }
+
+  // Validate magic bytes
+  const validContent = await validateMagicBytes(file);
+  if (!validContent) {
+    return NextResponse.json(
+      { error: "File content does not match its type" },
+      { status: 400 }
+    );
+  }
+
+  // Delete existing photo if present
+  if (medication.photo_path) {
+    await supabase.storage
+      .from("medication-photos")
+      .remove([medication.photo_path]);
+  }
+
+  const ext = getExtension(file.type);
+  const filePath = `${user.id}/${id}.${ext}`;
+
+  // Upload new photo
+  const { error: uploadError } = await supabase.storage
+    .from("medication-photos")
+    .upload(filePath, file, {
+      contentType: file.type,
+      upsert: true,
+    });
+
+  if (uploadError) {
+    return NextResponse.json(
+      { error: "Failed to upload photo" },
+      { status: 500 }
+    );
+  }
+
+  // Update medication record with photo path
+  const { error: updateError } = await supabase
+    .from("medications")
+    .update({
+      photo_path: filePath,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: "Failed to update medication" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ photo_path: filePath }, { status: 200 });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id } = await params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Fetch medication to get photo path
+  const { data: medication } = await supabase
+    .from("medications")
+    .select("photo_path")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!medication) {
+    return NextResponse.json(
+      { error: "Medication not found" },
+      { status: 404 }
+    );
+  }
+
+  if (!medication.photo_path) {
+    return NextResponse.json(
+      { error: "No photo to delete" },
+      { status: 400 }
+    );
+  }
+
+  // Delete from storage
+  await supabase.storage
+    .from("medication-photos")
+    .remove([medication.photo_path]);
+
+  // Clear photo_path in medication record
+  const { error: updateError } = await supabase
+    .from("medications")
+    .update({
+      photo_path: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: "Failed to update medication" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ photo_path: null }, { status: 200 });
+}

--- a/app/api/medications/[id]/route.ts
+++ b/app/api/medications/[id]/route.ts
@@ -1,0 +1,194 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id } = await params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: medication, error } = await supabase
+    .from("medications")
+    .select("*")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (error || !medication) {
+    return NextResponse.json(
+      { error: "Medication not found" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ medication });
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id } = await params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  // Build update object with only provided fields
+  const updates: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  };
+
+  if (body.name !== undefined) {
+    if (typeof body.name !== "string" || body.name.trim() === "") {
+      return NextResponse.json(
+        { error: "Medication name cannot be empty" },
+        { status: 400 }
+      );
+    }
+    updates.name = (body.name as string).trim();
+  }
+
+  if (body.dosage !== undefined) {
+    updates.dosage = typeof body.dosage === "string" ? body.dosage.trim() || null : null;
+  }
+
+  if (body.dosage_unit !== undefined) {
+    const validUnits = ["mg", "mcg", "ml", "tablets", "capsules", "drops", "units", "other"];
+    updates.dosage_unit =
+      typeof body.dosage_unit === "string" && validUnits.includes(body.dosage_unit)
+        ? body.dosage_unit
+        : null;
+  }
+
+  if (body.frequency !== undefined) {
+    const validFrequencies = [
+      "once_daily", "twice_daily", "three_times_daily", "weekly", "as_needed", "other",
+    ];
+    if (typeof body.frequency === "string" && validFrequencies.includes(body.frequency)) {
+      updates.frequency = body.frequency;
+    }
+  }
+
+  if (body.time_of_day !== undefined) {
+    const validTimes = ["morning", "afternoon", "evening", "bedtime", "with_meals", "any_time"];
+    updates.time_of_day =
+      typeof body.time_of_day === "string" && validTimes.includes(body.time_of_day)
+        ? body.time_of_day
+        : null;
+  }
+
+  if (body.prescribing_doctor !== undefined) {
+    updates.prescribing_doctor =
+      typeof body.prescribing_doctor === "string"
+        ? body.prescribing_doctor.trim() || null
+        : null;
+  }
+
+  if (body.start_date !== undefined) {
+    updates.start_date =
+      typeof body.start_date === "string" && body.start_date ? body.start_date : null;
+  }
+
+  if (body.notes !== undefined) {
+    updates.notes = typeof body.notes === "string" ? body.notes.trim() || null : null;
+  }
+
+  if (body.active !== undefined) {
+    updates.active = Boolean(body.active);
+  }
+
+  const { data: medication, error } = await supabase
+    .from("medications")
+    .update(updates)
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .select()
+    .single();
+
+  if (error || !medication) {
+    return NextResponse.json(
+      { error: "Medication not found" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ medication });
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id } = await params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // First, fetch the medication to check for a photo
+  const { data: medication } = await supabase
+    .from("medications")
+    .select("photo_path")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!medication) {
+    return NextResponse.json(
+      { error: "Medication not found" },
+      { status: 404 }
+    );
+  }
+
+  // Clean up photo from storage if it exists
+  if (medication.photo_path) {
+    await supabase.storage
+      .from("medication-photos")
+      .remove([medication.photo_path]);
+  }
+
+  const { error } = await supabase
+    .from("medications")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to delete medication" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/medications/route.ts
+++ b/app/api/medications/route.ts
@@ -1,0 +1,125 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: medications, error } = await supabase
+    .from("medications")
+    .select("*")
+    .eq("user_id", user.id)
+    .order("active", { ascending: false })
+    .order("name", { ascending: true });
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to load medications" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ medications });
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  // Validate required fields
+  if (!body.name || typeof body.name !== "string" || body.name.trim() === "") {
+    return NextResponse.json(
+      { error: "Medication name is required" },
+      { status: 400 }
+    );
+  }
+
+  const validFrequencies = [
+    "once_daily",
+    "twice_daily",
+    "three_times_daily",
+    "weekly",
+    "as_needed",
+    "other",
+  ];
+  const frequency =
+    typeof body.frequency === "string" && validFrequencies.includes(body.frequency)
+      ? body.frequency
+      : "once_daily";
+
+  const validUnits = ["mg", "mcg", "ml", "tablets", "capsules", "drops", "units", "other"];
+  const dosageUnit =
+    typeof body.dosage_unit === "string" && validUnits.includes(body.dosage_unit)
+      ? body.dosage_unit
+      : null;
+
+  const validTimes = [
+    "morning",
+    "afternoon",
+    "evening",
+    "bedtime",
+    "with_meals",
+    "any_time",
+  ];
+  const timeOfDay =
+    typeof body.time_of_day === "string" && validTimes.includes(body.time_of_day)
+      ? body.time_of_day
+      : null;
+
+  const { data: medication, error } = await supabase
+    .from("medications")
+    .insert({
+      user_id: user.id,
+      name: (body.name as string).trim(),
+      dosage: typeof body.dosage === "string" ? body.dosage.trim() || null : null,
+      dosage_unit: dosageUnit,
+      frequency,
+      time_of_day: timeOfDay,
+      prescribing_doctor:
+        typeof body.prescribing_doctor === "string"
+          ? body.prescribing_doctor.trim() || null
+          : null,
+      start_date:
+        typeof body.start_date === "string" && body.start_date
+          ? body.start_date
+          : null,
+      notes:
+        typeof body.notes === "string" ? body.notes.trim() || null : null,
+      active: true,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to create medication" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ medication }, { status: 201 });
+}

--- a/app/dashboard/dashboard-grid.tsx
+++ b/app/dashboard/dashboard-grid.tsx
@@ -92,6 +92,12 @@ export function DashboardGrid({ displayName }: DashboardGridProps) {
               </svg>
               Reports
             </Link>
+            <Link href="/medications" className="db-action">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3" />
+              </svg>
+              Medications
+            </Link>
             <Link href="/profile" className="db-action">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                 <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -37,6 +37,7 @@ export default async function DashboardPage() {
           <Link href="/upload" className="dashboard-header__link">Upload</Link>
           <Link href="/chat" className="dashboard-header__link">Chat</Link>
           <Link href="/reports" className="dashboard-header__link">Reports</Link>
+          <Link href="/medications" className="dashboard-header__link">Medications</Link>
           <Link href="/profile" className="dashboard-header__link">Profile</Link>
         </nav>
         <div className="dashboard-header__right">

--- a/app/globals.css
+++ b/app/globals.css
@@ -5562,3 +5562,564 @@ button.chat-send-button[type="submit"]:disabled {
   font-weight: 400 !important;
   opacity: 0.75;
 }
+
+/* =========================
+   Medications Page
+   ========================= */
+
+.medications-page {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.medications-page--loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  gap: 1rem;
+  color: var(--color-gray-500);
+}
+
+.medications-page__spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--color-gray-200);
+  border-top-color: var(--color-blue-500);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.medications-page__header {
+  margin-bottom: 1.5rem;
+}
+
+.medications-page__header h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-gray-900);
+  margin: 0.5rem 0 0.25rem;
+}
+
+.medications-page__header p {
+  color: var(--color-gray-500);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.medications-page__title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.medications-page__add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.5rem 1rem;
+  background: var(--color-blue-600);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+
+.medications-page__add-btn:hover {
+  background: var(--color-blue-700);
+}
+
+.medications-page__disclaimer {
+  background: var(--color-blue-50);
+  border: 1px solid var(--color-blue-200);
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 0.8125rem;
+  color: var(--color-blue-700);
+  margin-bottom: 1.5rem;
+}
+
+.medications-page__error {
+  background: var(--color-red-100);
+  color: var(--color-red-600);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.medications-page__dismiss {
+  background: none;
+  border: none;
+  color: var(--color-red-600);
+  font-size: 0.75rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.medications-page__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 3rem 1rem;
+  text-align: center;
+  color: var(--color-gray-500);
+}
+
+.medications-page__empty h2 {
+  font-size: 1.125rem;
+  color: var(--color-gray-700);
+  margin: 0;
+}
+
+.medications-page__empty p {
+  font-size: 0.875rem;
+  margin: 0 0 0.5rem;
+}
+
+.medications-page__section {
+  margin-bottom: 2rem;
+}
+
+.medications-page__section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-gray-700);
+  margin: 0 0 0.75rem;
+}
+
+.medications-page__section-empty {
+  color: var(--color-gray-400);
+  font-size: 0.875rem;
+  font-style: italic;
+}
+
+.medications-page__section-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: 0.75rem;
+  width: 100%;
+}
+
+.medications-page__section-toggle h2 {
+  margin: 0;
+}
+
+.medications-page__chevron {
+  transition: transform 0.2s;
+  display: flex;
+}
+
+.medications-page__chevron[data-open="true"] {
+  transform: rotate(180deg);
+}
+
+.medications-page__grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+/* Medication Card */
+
+.medication-card {
+  background: #fff;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  transition: box-shadow 0.15s;
+}
+
+.medication-card:hover {
+  box-shadow: var(--shadow-sm);
+}
+
+.medication-card--inactive {
+  opacity: 0.65;
+}
+
+.medication-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.medication-card__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.medication-card__name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-gray-900);
+  margin: 0;
+}
+
+.medication-card__dosage {
+  font-size: 0.875rem;
+  color: var(--color-gray-500);
+}
+
+.medication-card__status {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.medication-card__status--active {
+  background: var(--color-green-100);
+  color: var(--color-green-700);
+}
+
+.medication-card__status--inactive {
+  background: var(--color-gray-100);
+  color: var(--color-gray-500);
+}
+
+.medication-card__details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.medication-card__detail {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.8125rem;
+}
+
+.medication-card__label {
+  color: var(--color-gray-400);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+}
+
+.medication-card__notes {
+  font-size: 0.8125rem;
+  color: var(--color-gray-500);
+  margin: 0.25rem 0 0.5rem;
+  line-height: 1.4;
+}
+
+.medication-card__photo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  color: var(--color-blue-600);
+  margin-bottom: 0.5rem;
+}
+
+.medication-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--color-gray-100);
+}
+
+.medication-card__action {
+  font-size: 0.8125rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--color-gray-200);
+  background: #fff;
+  color: var(--color-gray-600);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.medication-card__action:hover {
+  background: var(--color-gray-50);
+}
+
+.medication-card__action--delete {
+  color: var(--color-red-600);
+  border-color: var(--color-red-100);
+}
+
+.medication-card__action--delete:hover {
+  background: var(--color-red-100);
+}
+
+/* Delete Dialog */
+
+.medications-page__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.medications-page__dialog {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  max-width: 400px;
+  width: 100%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+}
+
+.medications-page__dialog h3 {
+  font-size: 1.125rem;
+  margin: 0 0 0.5rem;
+  color: var(--color-gray-900);
+}
+
+.medications-page__dialog p {
+  font-size: 0.875rem;
+  color: var(--color-gray-500);
+  margin: 0 0 1.25rem;
+  line-height: 1.4;
+}
+
+.medications-page__dialog-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.medications-page__dialog-cancel {
+  padding: 0.5rem 1rem;
+  background: var(--color-gray-100);
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: var(--color-gray-600);
+}
+
+.medications-page__dialog-delete {
+  padding: 0.5rem 1rem;
+  background: var(--color-red-600);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.medications-page__dialog-delete:hover {
+  background: var(--color-red-500);
+}
+
+/* Medication Form */
+
+.medication-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.medication-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.medication-form__field label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-gray-700);
+}
+
+.medication-form__required {
+  color: var(--color-red-500);
+}
+
+.medication-form__field input[type="text"],
+.medication-form__field input[type="date"],
+.medication-form__field select,
+.medication-form__field textarea {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  color: var(--color-gray-800);
+  background: #fff;
+  transition: border-color 0.15s;
+}
+
+.medication-form__field input:focus,
+.medication-form__field select:focus,
+.medication-form__field textarea:focus {
+  outline: none;
+  border-color: var(--color-blue-400);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.medication-form__field textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+
+.medication-form__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+/* Photo Upload */
+
+.medication-form__photo-upload {
+  position: relative;
+}
+
+.medication-form__photo-input {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  opacity: 0;
+}
+
+.medication-form__photo-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem;
+  border: 2px dashed var(--color-gray-200);
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: center;
+  color: var(--color-gray-500);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.medication-form__photo-label:hover {
+  border-color: var(--color-blue-400);
+  background: var(--color-blue-50);
+}
+
+.medication-form__photo-hint {
+  font-size: 0.75rem;
+  color: var(--color-gray-400);
+}
+
+.medication-form__photo-preview {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--color-gray-200);
+}
+
+.medication-form__photo-preview img {
+  display: block;
+  width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+}
+
+.medication-form__photo-existing {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  color: var(--color-gray-500);
+  font-size: 0.875rem;
+}
+
+.medication-form__photo-remove {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.medication-form__photo-remove:hover {
+  background: rgba(0, 0, 0, 0.8);
+}
+
+/* Form Actions */
+
+.medication-form__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  padding-top: 0.5rem;
+}
+
+.medication-form__cancel {
+  padding: 0.6rem 1.25rem;
+  background: var(--color-gray-100);
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: var(--color-gray-600);
+}
+
+.medication-form__cancel:hover {
+  background: var(--color-gray-200);
+}
+
+.medication-form__submit {
+  padding: 0.6rem 1.25rem;
+  background: var(--color-blue-600);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.medication-form__submit:hover {
+  background: var(--color-blue-700);
+}
+
+.medication-form__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 600px) {
+  .medication-form__row {
+    grid-template-columns: 1fr;
+  }
+
+  .medications-page__title-row {
+    flex-direction: column;
+  }
+}

--- a/app/medications/[id]/edit/page.tsx
+++ b/app/medications/[id]/edit/page.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter, useParams } from "next/navigation";
+import NavHeader from "@/components/ui/NavHeader";
+
+const FREQUENCY_OPTIONS = [
+  { value: "once_daily", label: "Once daily" },
+  { value: "twice_daily", label: "Twice daily" },
+  { value: "three_times_daily", label: "Three times daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "as_needed", label: "As needed" },
+  { value: "other", label: "Other" },
+];
+
+const UNIT_OPTIONS = [
+  { value: "", label: "Select unit..." },
+  { value: "mg", label: "mg" },
+  { value: "mcg", label: "mcg" },
+  { value: "ml", label: "ml" },
+  { value: "tablets", label: "tablets" },
+  { value: "capsules", label: "capsules" },
+  { value: "drops", label: "drops" },
+  { value: "units", label: "units" },
+  { value: "other", label: "Other" },
+];
+
+const TIME_OPTIONS = [
+  { value: "", label: "Select time..." },
+  { value: "morning", label: "Morning" },
+  { value: "afternoon", label: "Afternoon" },
+  { value: "evening", label: "Evening" },
+  { value: "bedtime", label: "Bedtime" },
+  { value: "with_meals", label: "With meals" },
+  { value: "any_time", label: "Any time" },
+];
+
+export default function EditMedicationPage() {
+  const router = useRouter();
+  const params = useParams();
+  const medicationId = params.id as string;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [name, setName] = useState("");
+  const [dosage, setDosage] = useState("");
+  const [dosageUnit, setDosageUnit] = useState("");
+  const [frequency, setFrequency] = useState("once_daily");
+  const [timeOfDay, setTimeOfDay] = useState("");
+  const [prescribingDoctor, setPrescribingDoctor] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [notes, setNotes] = useState("");
+  const [hasPhoto, setHasPhoto] = useState(false);
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMedication = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/medications/${medicationId}`);
+      if (!response.ok) throw new Error("Medication not found");
+      const { medication } = await response.json();
+      setName(medication.name || "");
+      setDosage(medication.dosage || "");
+      setDosageUnit(medication.dosage_unit || "");
+      setFrequency(medication.frequency || "once_daily");
+      setTimeOfDay(medication.time_of_day || "");
+      setPrescribingDoctor(medication.prescribing_doctor || "");
+      setStartDate(medication.start_date || "");
+      setNotes(medication.notes || "");
+      setHasPhoto(!!medication.photo_path);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load medication");
+    } finally {
+      setLoading(false);
+    }
+  }, [medicationId]);
+
+  useEffect(() => {
+    fetchMedication();
+  }, [fetchMedication]);
+
+  const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const allowedTypes = ["image/png", "image/jpeg", "image/webp"];
+    if (!allowedTypes.includes(file.type)) {
+      setError("Invalid file type. Accepted: PNG, JPEG, WebP");
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setError("File too large. Maximum size is 5MB");
+      return;
+    }
+
+    setPhotoFile(file);
+    const reader = new FileReader();
+    reader.onload = () => setPhotoPreview(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemovePhoto = async () => {
+    if (hasPhoto) {
+      // Delete from server
+      try {
+        await fetch(`/api/medications/${medicationId}/photo`, {
+          method: "DELETE",
+        });
+        setHasPhoto(false);
+      } catch {
+        setError("Failed to remove photo");
+        return;
+      }
+    }
+    setPhotoFile(null);
+    setPhotoPreview(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError("Medication name is required");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/medications/${medicationId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          dosage: dosage.trim() || null,
+          dosage_unit: dosageUnit || null,
+          frequency,
+          time_of_day: timeOfDay || null,
+          prescribing_doctor: prescribingDoctor.trim() || null,
+          start_date: startDate || null,
+          notes: notes.trim() || null,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to update medication");
+      }
+
+      // Upload new photo if provided
+      if (photoFile) {
+        const formData = new FormData();
+        formData.append("file", photoFile);
+
+        const photoResponse = await fetch(
+          `/api/medications/${medicationId}/photo`,
+          { method: "POST", body: formData }
+        );
+
+        if (!photoResponse.ok) {
+          console.error("Photo upload failed");
+        }
+      }
+
+      router.push("/medications");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update medication");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="medications-page medications-page--loading">
+        <div className="medications-page__spinner" aria-label="Loading medication" />
+        <p>Loading medication...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="medications-page">
+      <div className="medications-page__header">
+        <NavHeader backHref="/medications" backLabel="Medications" />
+        <h1>Edit Medication</h1>
+      </div>
+
+      {error && (
+        <div className="medications-page__error" role="alert">
+          {error}
+          <button onClick={() => setError(null)} className="medications-page__dismiss">
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="medication-form">
+        <div className="medication-form__field">
+          <label htmlFor="med-name">
+            Medication Name <span className="medication-form__required">*</span>
+          </label>
+          <input
+            id="med-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g., Metformin"
+            maxLength={200}
+            required
+          />
+        </div>
+
+        <div className="medication-form__row">
+          <div className="medication-form__field">
+            <label htmlFor="med-dosage">Dosage</label>
+            <input
+              id="med-dosage"
+              type="text"
+              value={dosage}
+              onChange={(e) => setDosage(e.target.value)}
+              placeholder="e.g., 500"
+              maxLength={50}
+            />
+          </div>
+          <div className="medication-form__field">
+            <label htmlFor="med-unit">Unit</label>
+            <select
+              id="med-unit"
+              value={dosageUnit}
+              onChange={(e) => setDosageUnit(e.target.value)}
+            >
+              {UNIT_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="medication-form__row">
+          <div className="medication-form__field">
+            <label htmlFor="med-frequency">
+              Frequency <span className="medication-form__required">*</span>
+            </label>
+            <select
+              id="med-frequency"
+              value={frequency}
+              onChange={(e) => setFrequency(e.target.value)}
+              required
+            >
+              {FREQUENCY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="medication-form__field">
+            <label htmlFor="med-time">Time of Day</label>
+            <select
+              id="med-time"
+              value={timeOfDay}
+              onChange={(e) => setTimeOfDay(e.target.value)}
+            >
+              {TIME_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="medication-form__field">
+          <label htmlFor="med-doctor">Prescribing Doctor</label>
+          <input
+            id="med-doctor"
+            type="text"
+            value={prescribingDoctor}
+            onChange={(e) => setPrescribingDoctor(e.target.value)}
+            placeholder="e.g., Dr. Smith"
+            maxLength={200}
+          />
+        </div>
+
+        <div className="medication-form__field">
+          <label htmlFor="med-start-date">Start Date</label>
+          <input
+            id="med-start-date"
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            max={new Date().toISOString().split("T")[0]}
+          />
+        </div>
+
+        <div className="medication-form__field">
+          <label htmlFor="med-notes">Notes</label>
+          <textarea
+            id="med-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Any additional notes..."
+            maxLength={1000}
+            rows={3}
+          />
+        </div>
+
+        {/* Photo Upload */}
+        <div className="medication-form__field">
+          <label>Prescription Photo</label>
+          <div className="medication-form__photo-upload">
+            {(photoPreview || hasPhoto) ? (
+              <div className="medication-form__photo-preview">
+                {photoPreview ? (
+                  <img src={photoPreview} alt="Prescription photo preview" />
+                ) : (
+                  <div className="medication-form__photo-existing">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                      <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                      <circle cx="8.5" cy="8.5" r="1.5" />
+                      <polyline points="21 15 16 10 5 21" />
+                    </svg>
+                    <span>Photo on file</span>
+                  </div>
+                )}
+                <button
+                  type="button"
+                  onClick={handleRemovePhoto}
+                  className="medication-form__photo-remove"
+                >
+                  Remove
+                </button>
+              </div>
+            ) : (
+              <label htmlFor="med-photo" className="medication-form__photo-label">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M23 19a2 2 0 01-2 2H3a2 2 0 01-2-2V8a2 2 0 012-2h4l2-3h6l2 3h4a2 2 0 012 2z" />
+                  <circle cx="12" cy="13" r="4" />
+                </svg>
+                <span>Take or upload a photo</span>
+                <span className="medication-form__photo-hint">PNG, JPEG, or WebP. Max 5MB.</span>
+              </label>
+            )}
+            <input
+              ref={fileInputRef}
+              id="med-photo"
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              capture="environment"
+              onChange={handlePhotoChange}
+              className="medication-form__photo-input"
+            />
+          </div>
+        </div>
+
+        <div className="medication-form__actions">
+          <button
+            type="button"
+            onClick={() => router.push("/medications")}
+            className="medication-form__cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="medication-form__submit"
+            disabled={saving}
+          >
+            {saving ? "Saving..." : "Save Changes"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/app/medications/add/layout.tsx
+++ b/app/medications/add/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function AddMedicationLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/medications/add/page.tsx
+++ b/app/medications/add/page.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+import NavHeader from "@/components/ui/NavHeader";
+
+const FREQUENCY_OPTIONS = [
+  { value: "once_daily", label: "Once daily" },
+  { value: "twice_daily", label: "Twice daily" },
+  { value: "three_times_daily", label: "Three times daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "as_needed", label: "As needed" },
+  { value: "other", label: "Other" },
+];
+
+const UNIT_OPTIONS = [
+  { value: "", label: "Select unit..." },
+  { value: "mg", label: "mg" },
+  { value: "mcg", label: "mcg" },
+  { value: "ml", label: "ml" },
+  { value: "tablets", label: "tablets" },
+  { value: "capsules", label: "capsules" },
+  { value: "drops", label: "drops" },
+  { value: "units", label: "units" },
+  { value: "other", label: "Other" },
+];
+
+const TIME_OPTIONS = [
+  { value: "", label: "Select time..." },
+  { value: "morning", label: "Morning" },
+  { value: "afternoon", label: "Afternoon" },
+  { value: "evening", label: "Evening" },
+  { value: "bedtime", label: "Bedtime" },
+  { value: "with_meals", label: "With meals" },
+  { value: "any_time", label: "Any time" },
+];
+
+export default function AddMedicationPage() {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [name, setName] = useState("");
+  const [dosage, setDosage] = useState("");
+  const [dosageUnit, setDosageUnit] = useState("");
+  const [frequency, setFrequency] = useState("once_daily");
+  const [timeOfDay, setTimeOfDay] = useState("");
+  const [prescribingDoctor, setPrescribingDoctor] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [notes, setNotes] = useState("");
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [photoPreview, setPhotoPreview] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handlePhotoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const allowedTypes = ["image/png", "image/jpeg", "image/webp"];
+    if (!allowedTypes.includes(file.type)) {
+      setError("Invalid file type. Accepted: PNG, JPEG, WebP");
+      return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      setError("File too large. Maximum size is 5MB");
+      return;
+    }
+
+    setPhotoFile(file);
+    const reader = new FileReader();
+    reader.onload = () => setPhotoPreview(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemovePhoto = () => {
+    setPhotoFile(null);
+    setPhotoPreview(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      setError("Medication name is required");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      // Create medication
+      const response = await fetch("/api/medications", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          dosage: dosage.trim() || null,
+          dosage_unit: dosageUnit || null,
+          frequency,
+          time_of_day: timeOfDay || null,
+          prescribing_doctor: prescribingDoctor.trim() || null,
+          start_date: startDate || null,
+          notes: notes.trim() || null,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to create medication");
+      }
+
+      const { medication } = await response.json();
+
+      // Upload photo if provided
+      if (photoFile && medication.id) {
+        const formData = new FormData();
+        formData.append("file", photoFile);
+
+        const photoResponse = await fetch(
+          `/api/medications/${medication.id}/photo`,
+          { method: "POST", body: formData }
+        );
+
+        if (!photoResponse.ok) {
+          // Medication was created but photo failed — not a fatal error
+          console.error("Photo upload failed");
+        }
+      }
+
+      router.push("/medications");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create medication");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="medications-page">
+      <div className="medications-page__header">
+        <NavHeader backHref="/medications" backLabel="Medications" />
+        <h1>Add Medication</h1>
+      </div>
+
+      <p className="medications-page__disclaimer">
+        This is for your records only. Always follow your doctor&apos;s instructions.
+      </p>
+
+      {error && (
+        <div className="medications-page__error" role="alert">
+          {error}
+          <button onClick={() => setError(null)} className="medications-page__dismiss">
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="medication-form">
+        <div className="medication-form__field">
+          <label htmlFor="med-name">
+            Medication Name <span className="medication-form__required">*</span>
+          </label>
+          <input
+            id="med-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g., Metformin"
+            maxLength={200}
+            required
+          />
+        </div>
+
+        <div className="medication-form__row">
+          <div className="medication-form__field">
+            <label htmlFor="med-dosage">Dosage</label>
+            <input
+              id="med-dosage"
+              type="text"
+              value={dosage}
+              onChange={(e) => setDosage(e.target.value)}
+              placeholder="e.g., 500"
+              maxLength={50}
+            />
+          </div>
+          <div className="medication-form__field">
+            <label htmlFor="med-unit">Unit</label>
+            <select
+              id="med-unit"
+              value={dosageUnit}
+              onChange={(e) => setDosageUnit(e.target.value)}
+            >
+              {UNIT_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="medication-form__row">
+          <div className="medication-form__field">
+            <label htmlFor="med-frequency">
+              Frequency <span className="medication-form__required">*</span>
+            </label>
+            <select
+              id="med-frequency"
+              value={frequency}
+              onChange={(e) => setFrequency(e.target.value)}
+              required
+            >
+              {FREQUENCY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="medication-form__field">
+            <label htmlFor="med-time">Time of Day</label>
+            <select
+              id="med-time"
+              value={timeOfDay}
+              onChange={(e) => setTimeOfDay(e.target.value)}
+            >
+              {TIME_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="medication-form__field">
+          <label htmlFor="med-doctor">Prescribing Doctor</label>
+          <input
+            id="med-doctor"
+            type="text"
+            value={prescribingDoctor}
+            onChange={(e) => setPrescribingDoctor(e.target.value)}
+            placeholder="e.g., Dr. Smith"
+            maxLength={200}
+          />
+        </div>
+
+        <div className="medication-form__field">
+          <label htmlFor="med-start-date">Start Date</label>
+          <input
+            id="med-start-date"
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            max={new Date().toISOString().split("T")[0]}
+          />
+        </div>
+
+        <div className="medication-form__field">
+          <label htmlFor="med-notes">Notes</label>
+          <textarea
+            id="med-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Any additional notes..."
+            maxLength={1000}
+            rows={3}
+          />
+        </div>
+
+        {/* Photo Upload */}
+        <div className="medication-form__field">
+          <label>Prescription Photo</label>
+          <div className="medication-form__photo-upload">
+            {photoPreview ? (
+              <div className="medication-form__photo-preview">
+                <img src={photoPreview} alt="Prescription photo preview" />
+                <button
+                  type="button"
+                  onClick={handleRemovePhoto}
+                  className="medication-form__photo-remove"
+                >
+                  Remove
+                </button>
+              </div>
+            ) : (
+              <label htmlFor="med-photo" className="medication-form__photo-label">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M23 19a2 2 0 01-2 2H3a2 2 0 01-2-2V8a2 2 0 012-2h4l2-3h6l2 3h4a2 2 0 012 2z" />
+                  <circle cx="12" cy="13" r="4" />
+                </svg>
+                <span>Take or upload a photo</span>
+                <span className="medication-form__photo-hint">PNG, JPEG, or WebP. Max 5MB.</span>
+              </label>
+            )}
+            <input
+              ref={fileInputRef}
+              id="med-photo"
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              capture="environment"
+              onChange={handlePhotoChange}
+              className="medication-form__photo-input"
+            />
+          </div>
+        </div>
+
+        <div className="medication-form__actions">
+          <button
+            type="button"
+            onClick={() => router.push("/medications")}
+            className="medication-form__cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="medication-form__submit"
+            disabled={saving}
+          >
+            {saving ? "Saving..." : "Add Medication"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/app/medications/layout.tsx
+++ b/app/medications/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function MedicationsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/medications/page.tsx
+++ b/app/medications/page.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import NavHeader from "@/components/ui/NavHeader";
+
+interface Medication {
+  id: string;
+  name: string;
+  dosage: string | null;
+  dosage_unit: string | null;
+  frequency: string;
+  time_of_day: string | null;
+  prescribing_doctor: string | null;
+  start_date: string | null;
+  notes: string | null;
+  photo_path: string | null;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+const FREQUENCY_LABELS: Record<string, string> = {
+  once_daily: "Once daily",
+  twice_daily: "Twice daily",
+  three_times_daily: "3x daily",
+  weekly: "Weekly",
+  as_needed: "As needed",
+  other: "Other",
+};
+
+const TIME_LABELS: Record<string, string> = {
+  morning: "Morning",
+  afternoon: "Afternoon",
+  evening: "Evening",
+  bedtime: "Bedtime",
+  with_meals: "With meals",
+  any_time: "Any time",
+};
+
+export default function MedicationsPage() {
+  const [medications, setMedications] = useState<Medication[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [showInactive, setShowInactive] = useState(false);
+
+  const fetchMedications = useCallback(async () => {
+    try {
+      const response = await fetch("/api/medications");
+      if (!response.ok) throw new Error("Failed to load medications");
+      const data = await response.json();
+      setMedications(data.medications || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load medications");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMedications();
+  }, [fetchMedications]);
+
+  const handleToggleActive = async (med: Medication) => {
+    try {
+      const response = await fetch(`/api/medications/${med.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ active: !med.active }),
+      });
+      if (!response.ok) throw new Error("Failed to update medication");
+      await fetchMedications();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update");
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      const response = await fetch(`/api/medications/${id}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) throw new Error("Failed to delete medication");
+      setDeleteConfirm(null);
+      await fetchMedications();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete");
+    }
+  };
+
+  const activeMeds = medications.filter((m) => m.active);
+  const inactiveMeds = medications.filter((m) => !m.active);
+
+  if (loading) {
+    return (
+      <div className="medications-page medications-page--loading">
+        <div className="medications-page__spinner" aria-label="Loading medications" />
+        <p>Loading your medications...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="medications-page">
+      <div className="medications-page__header">
+        <NavHeader backLabel="Dashboard" />
+        <div className="medications-page__title-row">
+          <div>
+            <h1>Medications</h1>
+            <p>Track your prescriptions, dosages, and schedules.</p>
+          </div>
+          <Link href="/medications/add" className="medications-page__add-btn">
+            + Add Medication
+          </Link>
+        </div>
+      </div>
+
+      <p className="medications-page__disclaimer">
+        This is for your records only. Always follow your doctor&apos;s instructions.
+      </p>
+
+      {error && (
+        <div className="medications-page__error" role="alert">
+          {error}
+          <button onClick={() => setError(null)} className="medications-page__dismiss">
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {medications.length === 0 ? (
+        <div className="medications-page__empty">
+          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--color-gray-400)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 13.5h.008v.008H10.5v-.008zm0-3h.008v.008H10.5V12zm0-3h.008v.008H10.5V9z" />
+          </svg>
+          <h2>No medications yet</h2>
+          <p>Add your first medication to start tracking your prescriptions.</p>
+          <Link href="/medications/add" className="medications-page__add-btn">
+            + Add Medication
+          </Link>
+        </div>
+      ) : (
+        <>
+          {/* Active Medications */}
+          <section className="medications-page__section">
+            <h2 className="medications-page__section-title">
+              Active Medications ({activeMeds.length})
+            </h2>
+            {activeMeds.length === 0 ? (
+              <p className="medications-page__section-empty">No active medications.</p>
+            ) : (
+              <div className="medications-page__grid">
+                {activeMeds.map((med) => (
+                  <MedicationCard
+                    key={med.id}
+                    medication={med}
+                    onToggleActive={() => handleToggleActive(med)}
+                    onDelete={() => setDeleteConfirm(med.id)}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+
+          {/* Inactive Medications */}
+          {inactiveMeds.length > 0 && (
+            <section className="medications-page__section">
+              <button
+                className="medications-page__section-toggle"
+                onClick={() => setShowInactive(!showInactive)}
+                aria-expanded={showInactive}
+              >
+                <h2 className="medications-page__section-title">
+                  Inactive Medications ({inactiveMeds.length})
+                </h2>
+                <span className="medications-page__chevron" data-open={showInactive}>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <polyline points="6 9 12 15 18 9" />
+                  </svg>
+                </span>
+              </button>
+              {showInactive && (
+                <div className="medications-page__grid">
+                  {inactiveMeds.map((med) => (
+                    <MedicationCard
+                      key={med.id}
+                      medication={med}
+                      onToggleActive={() => handleToggleActive(med)}
+                      onDelete={() => setDeleteConfirm(med.id)}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
+        </>
+      )}
+
+      {/* Delete Confirmation Dialog */}
+      {deleteConfirm && (
+        <div className="medications-page__overlay" onClick={() => setDeleteConfirm(null)}>
+          <div
+            className="medications-page__dialog"
+            role="alertdialog"
+            aria-labelledby="delete-dialog-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="delete-dialog-title">Delete Medication?</h3>
+            <p>This will permanently remove this medication and its photo. This cannot be undone.</p>
+            <div className="medications-page__dialog-actions">
+              <button
+                onClick={() => setDeleteConfirm(null)}
+                className="medications-page__dialog-cancel"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => handleDelete(deleteConfirm)}
+                className="medications-page__dialog-delete"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MedicationCard({
+  medication,
+  onToggleActive,
+  onDelete,
+}: {
+  medication: Medication;
+  onToggleActive: () => void;
+  onDelete: () => void;
+}) {
+  const dosageText = [
+    medication.dosage,
+    medication.dosage_unit,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div className={`medication-card${medication.active ? "" : " medication-card--inactive"}`}>
+      <div className="medication-card__header">
+        <div className="medication-card__info">
+          <h3 className="medication-card__name">{medication.name}</h3>
+          {dosageText && (
+            <span className="medication-card__dosage">{dosageText}</span>
+          )}
+        </div>
+        <span className={`medication-card__status medication-card__status--${medication.active ? "active" : "inactive"}`}>
+          {medication.active ? "Active" : "Inactive"}
+        </span>
+      </div>
+
+      <div className="medication-card__details">
+        <div className="medication-card__detail">
+          <span className="medication-card__label">Frequency</span>
+          <span>{FREQUENCY_LABELS[medication.frequency] || medication.frequency}</span>
+        </div>
+        {medication.time_of_day && (
+          <div className="medication-card__detail">
+            <span className="medication-card__label">Time</span>
+            <span>{TIME_LABELS[medication.time_of_day] || medication.time_of_day}</span>
+          </div>
+        )}
+        {medication.prescribing_doctor && (
+          <div className="medication-card__detail">
+            <span className="medication-card__label">Doctor</span>
+            <span>{medication.prescribing_doctor}</span>
+          </div>
+        )}
+        {medication.start_date && (
+          <div className="medication-card__detail">
+            <span className="medication-card__label">Started</span>
+            <span>{new Date(medication.start_date).toLocaleDateString()}</span>
+          </div>
+        )}
+      </div>
+
+      {medication.notes && (
+        <p className="medication-card__notes">{medication.notes}</p>
+      )}
+
+      {medication.photo_path && (
+        <div className="medication-card__photo">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+            <circle cx="8.5" cy="8.5" r="1.5" />
+            <polyline points="21 15 16 10 5 21" />
+          </svg>
+          <span>Photo attached</span>
+        </div>
+      )}
+
+      <div className="medication-card__actions">
+        <Link
+          href={`/medications/${medication.id}/edit`}
+          className="medication-card__action medication-card__action--edit"
+        >
+          Edit
+        </Link>
+        <button
+          onClick={onToggleActive}
+          className="medication-card__action medication-card__action--toggle"
+        >
+          {medication.active ? "Deactivate" : "Reactivate"}
+        </button>
+        <button
+          onClick={onDelete}
+          className="medication-card__action medication-card__action--delete"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/NavHeader.tsx
+++ b/components/ui/NavHeader.tsx
@@ -69,6 +69,9 @@ export default function NavHeader({
         <Link href="/reports" className={linkClass("/reports")}>
           Reports
         </Link>
+        <Link href="/medications" className={linkClass("/medications")}>
+          Medications
+        </Link>
         <Link href="/profile" className={linkClass("/profile")}>
           <span className="nav-header__profile-link">
             {profileInfo && (

--- a/lib/audit/logger.ts
+++ b/lib/audit/logger.ts
@@ -8,9 +8,14 @@ export type AuditAction =
   | "report.delete"
   | "chat.message"
   | "chat.delete"
-  | "doctor_questions.generate";
+  | "doctor_questions.generate"
+  | "medication.create"
+  | "medication.update"
+  | "medication.delete"
+  | "medication.photo_upload"
+  | "medication.photo_delete";
 
-export type AuditResourceType = "report" | "chat_session" | "parsed_result";
+export type AuditResourceType = "report" | "chat_session" | "parsed_result" | "medication";
 
 interface AuditEvent {
   userId: string;

--- a/lib/claude/chat-prompts.ts
+++ b/lib/claude/chat-prompts.ts
@@ -41,17 +41,48 @@ function calculateAge(dateOfBirth: string): number {
   return age;
 }
 
-export function buildHealthContext(profile: {
-  gender?: string | null;
-  date_of_birth?: string | null;
-  height_inches?: number | null;
-  known_conditions?: string[] | null;
-  medications?: string | null;
-  smoking_status?: string | null;
-  family_history?: string[] | null;
-  activity_level?: string | null;
-  sleep_hours?: string | null;
-}): string {
+export interface StructuredMedication {
+  name: string;
+  dosage?: string | null;
+  dosage_unit?: string | null;
+  frequency: string;
+}
+
+const FREQUENCY_DISPLAY: Record<string, string> = {
+  once_daily: "daily",
+  twice_daily: "twice daily",
+  three_times_daily: "3x daily",
+  weekly: "weekly",
+  as_needed: "as needed",
+  other: "",
+};
+
+export function formatMedicationForContext(med: StructuredMedication): string {
+  const parts = [med.name];
+  if (med.dosage) {
+    parts.push(med.dosage + (med.dosage_unit ? med.dosage_unit : ""));
+  }
+  const freq = FREQUENCY_DISPLAY[med.frequency] || med.frequency;
+  if (freq) {
+    parts.push(`(${freq})`);
+  }
+  return parts.join(" ");
+}
+
+export function buildHealthContext(
+  profile: {
+    gender?: string | null;
+    date_of_birth?: string | null;
+    height_inches?: number | null;
+    known_conditions?: string[] | null;
+    medications?: string | null;
+    smoking_status?: string | null;
+    family_history?: string[] | null;
+    activity_level?: string | null;
+    sleep_hours?: string | null;
+  },
+  structuredMedications?: StructuredMedication[]
+): string {
   const parts: string[] = [];
 
   if (profile.gender) parts.push(`Gender: ${profile.gender}`);
@@ -67,9 +98,15 @@ export function buildHealthContext(profile: {
   if (profile.known_conditions?.length) {
     parts.push(`Known conditions: ${profile.known_conditions.join(", ")}`);
   }
-  if (profile.medications) {
+
+  // Prefer structured medications, fall back to free-text
+  if (structuredMedications && structuredMedications.length > 0) {
+    const medList = structuredMedications.map(formatMedicationForContext).join(", ");
+    parts.push(`Active medications: ${medList}`);
+  } else if (profile.medications) {
     parts.push(`Medications: ${profile.medications}`);
   }
+
   if (profile.smoking_status && profile.smoking_status !== "none") {
     parts.push(`Smoking: ${profile.smoking_status}`);
   }

--- a/supabase/migrations/014_medications.sql
+++ b/supabase/migrations/014_medications.sql
@@ -1,0 +1,28 @@
+-- Migration: Create medications table for structured medication tracking
+-- Ticket: #152 — Medication tracker
+
+CREATE TABLE medications (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name text NOT NULL,
+  dosage text,
+  dosage_unit text,
+  frequency text NOT NULL DEFAULT 'daily',
+  time_of_day text,
+  prescribing_doctor text,
+  start_date date,
+  notes text,
+  photo_path text,
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE INDEX idx_medications_user_id ON medications(user_id);
+
+ALTER TABLE medications ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own medications"
+  ON medications FOR ALL TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());

--- a/supabase/migrations/015_medication_photos_bucket.sql
+++ b/supabase/migrations/015_medication_photos_bucket.sql
@@ -1,0 +1,18 @@
+-- Migration: Create private storage bucket for medication/prescription photos
+-- Ticket: #152 — Medication tracker
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('medication-photos', 'medication-photos', false, 5242880, ARRAY['image/png', 'image/jpeg', 'image/webp'])
+ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY "Users can upload own medication photos"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'medication-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "Users can read own medication photos"
+  ON storage.objects FOR SELECT TO authenticated
+  USING (bucket_id = 'medication-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "Users can delete own medication photos"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (bucket_id = 'medication-photos' AND (storage.foldername(name))[1] = auth.uid()::text);


### PR DESCRIPTION
## Summary
Closes #152

- **Database**: Two new migrations — `medications` table with RLS + `medication-photos` private storage bucket with per-user folder policies
- **API**: Full CRUD at `/api/medications` and `/api/medications/[id]`, plus photo upload/delete at `/api/medications/[id]/photo` with magic byte validation
- **Pages**: Medications list (`/medications`) with active/inactive sections, add form (`/medications/add`), edit form (`/medications/[id]/edit`) — all with photo capture via camera or file upload
- **Navigation**: "Medications" link added to NavHeader (between Reports and Profile) and dashboard quick actions grid
- **Chat AI context**: Structured medication data (name, dosage, unit, frequency) loaded and formatted for AI chat context, with fallback to legacy free-text field
- **Audit**: New `medication.*` audit action types and `medication` resource type added to audit logger
- **Tests**: 21 new tests covering API routes, page component exports, chat context formatting with structured medications, and audit type completeness

## Test plan
- [x] All 815 tests pass (37 test files)
- [x] ESLint passes (0 errors, 2 warnings — `<img>` usage for photo previews is intentional since these are data URLs not optimizable by next/image)
- [x] TypeScript typecheck passes
- [ ] Manual: Navigate to /medications, verify empty state
- [ ] Manual: Add a medication with all fields + photo, verify it appears in active list
- [ ] Manual: Edit a medication, toggle active/inactive, delete with confirmation
- [ ] Manual: Chat with AI and verify medication context appears in responses
- [ ] Manual: Run migration `014_medications.sql` and `015_medication_photos_bucket.sql` against Supabase