### PR TITLE
fix(dashboard): clear score breakdown, fun tips, retry on overload

### DIFF
--- a/app/dashboard/daily-tip.tsx
+++ b/app/dashboard/daily-tip.tsx
@@ -1,6 +1,21 @@
 "use client";
 
+import { useState, useCallback } from "react";
 import Link from "next/link";
+
+/**
+ * Category emojis for fun visual flair.
+ */
+const CATEGORY_EMOJIS: Record<string, string> = {
+  cholesterol: "\u2764\ufe0f",
+  glucose: "\ud83c\udf6c",
+  blood_pressure: "\ud83e\ude78",
+  liver: "\ud83e\udec0",
+  kidney: "\ud83e\udea8",
+  thyroid: "\ud83e\udd8b",
+  iron: "\ud83e\uddf2",
+  general: "\u2728",
+};
 
 /**
  * Daily health tips organized by biomarker category.
@@ -108,30 +123,33 @@ function getCategoriesFromBiomarkers(
   return Array.from(categories);
 }
 
-/**
- * Select a daily tip based on the day of year and flagged biomarkers.
- * Changes daily but is personalized to the user's health concerns.
- */
-function selectDailyTip(
-  concerns: Array<{ name: string; flag: string }>
-): string {
-  const dayOfYear = Math.floor(
-    (Date.now() - new Date(new Date().getFullYear(), 0, 0).getTime()) /
-      (1000 * 60 * 60 * 24)
-  );
+interface TipWithCategory {
+  tip: string;
+  category: string;
+  emoji: string;
+}
 
-  // Build pool: flagged-category tips first, then general
+/**
+ * Build the full tip pool with category info.
+ */
+function buildTipPool(
+  concerns: Array<{ name: string; flag: string }>
+): TipWithCategory[] {
   const categories = getCategoriesFromBiomarkers(concerns);
-  const pool: string[] = [];
+  const pool: TipWithCategory[] = [];
 
   for (const cat of categories) {
     if (TIPS_BY_CATEGORY[cat]) {
-      pool.push(...TIPS_BY_CATEGORY[cat]);
+      for (const tip of TIPS_BY_CATEGORY[cat]) {
+        pool.push({ tip, category: cat, emoji: CATEGORY_EMOJIS[cat] || "\u2728" });
+      }
     }
   }
-  pool.push(...TIPS_BY_CATEGORY.general);
+  for (const tip of TIPS_BY_CATEGORY.general) {
+    pool.push({ tip, category: "general", emoji: CATEGORY_EMOJIS.general });
+  }
 
-  return pool[dayOfYear % pool.length];
+  return pool;
 }
 
 interface DailyTipProps {
@@ -139,24 +157,42 @@ interface DailyTipProps {
 }
 
 export function DailyTip({ concerns }: DailyTipProps) {
-  const tip = selectDailyTip(concerns);
+  const pool = buildTipPool(concerns);
+  const dayOfYear = Math.floor(
+    (Date.now() - new Date(new Date().getFullYear(), 0, 0).getTime()) /
+      (1000 * 60 * 60 * 24)
+  );
+
+  const [tipIndex, setTipIndex] = useState(dayOfYear % pool.length);
+  const currentTip = pool[tipIndex] || pool[0];
+
+  const showNextTip = useCallback(() => {
+    setTipIndex((prev) => (prev + 1) % pool.length);
+  }, [pool.length]);
+
+  if (!currentTip) return null;
 
   return (
     <div className="db-card db-daily-tip">
       <div className="db-daily-tip__header">
-        <span className="db-daily-tip__icon" aria-hidden="true">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M9 18h6" />
-            <path d="M10 22h4" />
-            <path d="M12 2a7 7 0 0 0-4 12.7V17h8v-2.3A7 7 0 0 0 12 2z" />
-          </svg>
+        <span className="db-daily-tip__emoji" aria-hidden="true">
+          {currentTip.emoji}
         </span>
         <span className="db-card__title">Daily Health Tip</span>
       </div>
-      <p className="db-daily-tip__text">&ldquo;{tip}&rdquo;</p>
-      <Link href="/chat" className="db-card__link">
-        More Tips &rarr;
-      </Link>
+      <p className="db-daily-tip__text">&ldquo;{currentTip.tip}&rdquo;</p>
+      <div className="db-daily-tip__footer">
+        <button
+          className="db-daily-tip__next-btn"
+          onClick={showNextTip}
+          type="button"
+        >
+          Show Another Tip &rarr;
+        </button>
+        <Link href="/chat" className="db-card__link">
+          Ask about this
+        </Link>
+      </div>
     </div>
   );
 }

--- a/app/dashboard/health-score.tsx
+++ b/app/dashboard/health-score.tsx
@@ -235,17 +235,44 @@ export function HealthScore({
       <div className="health-score health-score--credit health-score--compact db-card">
         <h3 className="db-card__title">Health Credit Score</h3>
         <CreditScoreGauge score={data.score} label={data.label} />
+        <div className="health-score__ranges">
+          <div className="health-score__range health-score__range--poor">
+            <span className="health-score__range-score">300-579</span>
+            <span className="health-score__range-label">Poor</span>
+          </div>
+          <div className="health-score__range health-score__range--fair">
+            <span className="health-score__range-score">580-669</span>
+            <span className="health-score__range-label">Fair</span>
+          </div>
+          <div className="health-score__range health-score__range--good">
+            <span className="health-score__range-score">670-739</span>
+            <span className="health-score__range-label">Good</span>
+          </div>
+          <div className="health-score__range health-score__range--very-good">
+            <span className="health-score__range-score">740-799</span>
+            <span className="health-score__range-label">Very Good</span>
+          </div>
+          <div className="health-score__range health-score__range--excellent">
+            <span className="health-score__range-score">800-850</span>
+            <span className="health-score__range-label">Excellent</span>
+          </div>
+        </div>
         <div className="health-score__breakdown-summary">
           <span className="health-score__breakdown-item health-score__breakdown-item--green">
-            {green}N
+            {green} Normal
           </span>
           <span className="health-score__breakdown-item health-score__breakdown-item--yellow">
-            {yellow}B
+            {yellow} Borderline
           </span>
           <span className="health-score__breakdown-item health-score__breakdown-item--red">
-            {red}R
+            {red} Needs Attention
           </span>
         </div>
+        {data.reportId && (
+          <Link href={`/reports/${data.reportId}`} className="health-score__report-link">
+            Based on: {data.reportName}
+          </Link>
+        )}
       </div>
     );
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -748,12 +748,39 @@ button[type="submit"]:disabled {
   flex-shrink: 0;
 }
 
+.db-daily-tip__emoji {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
 .db-daily-tip__text {
   font-size: 0.95rem;
   color: var(--color-gray-700);
   line-height: 1.5;
   font-style: italic;
   margin: 0;
+}
+
+.db-daily-tip__footer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.db-daily-tip__next-btn {
+  background: none;
+  border: none;
+  color: var(--color-green-600);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.2s;
+}
+
+.db-daily-tip__next-btn:hover {
+  color: var(--color-green-700);
 }
 
 /* =========================
@@ -908,6 +935,52 @@ button[type="submit"]:disabled {
 }
 
 /* Breakdown summary (Normal / Borderline / Needs Attention) */
+.health-score__ranges {
+  display: flex;
+  justify-content: center;
+  gap: 0.125rem;
+  margin-bottom: 1rem;
+  width: 100%;
+  max-width: 360px;
+}
+
+.health-score__range {
+  flex: 1;
+  text-align: center;
+  padding: 0.375rem 0.25rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.65rem;
+  line-height: 1.3;
+}
+
+.health-score__range-score {
+  display: block;
+  font-weight: 700;
+  font-size: 0.7rem;
+}
+
+.health-score__range-label {
+  display: block;
+  font-weight: 500;
+}
+
+.health-score__range--poor { background: #fef2f2; color: #991b1b; }
+.health-score__range--fair { background: #fff7ed; color: #9a3412; }
+.health-score__range--good { background: #fefce8; color: #854d0e; }
+.health-score__range--very-good { background: #f0fdf4; color: #166534; }
+.health-score__range--excellent { background: #dcfce7; color: #14532d; }
+
+.health-score__report-link {
+  font-size: 0.75rem;
+  color: var(--color-green-600);
+  text-decoration: none;
+  margin-top: 0.5rem;
+}
+
+.health-score__report-link:hover {
+  text-decoration: underline;
+}
+
 .health-score__breakdown-summary {
   display: flex;
   flex-wrap: wrap;

--- a/app/reports/[id]/page.tsx
+++ b/app/reports/[id]/page.tsx
@@ -80,25 +80,48 @@ export default function ReportResultsPage() {
   const handleReanalyze = useCallback(async () => {
     setIsReanalyzing(true);
     setError(null);
-    try {
-      const response = await fetch("/api/parse", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ report_id: reportId }),
-      });
-      if (!response.ok) {
-        const data = await response.json();
-        throw new Error(data.error || "Re-analysis failed");
+
+    const MAX_RETRIES = 3;
+    let lastError = "";
+
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const response = await fetch("/api/parse", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ report_id: reportId }),
+        });
+
+        if (response.ok) {
+          await fetchReport();
+          return; // Success!
+        }
+
+        const data = await response.json().catch(() => ({ error: "Unknown error" }));
+
+        // Check for overloaded/rate limit — retry after delay
+        if (response.status === 529 || response.status === 429 ||
+            (data.error && (data.error.includes("Overloaded") || data.error.includes("overloaded") || data.error.includes("rate")))) {
+          lastError = "Our AI is busy right now. Retrying...";
+          if (attempt < MAX_RETRIES) {
+            await new Promise((r) => setTimeout(r, 3000 * attempt)); // 3s, 6s, 9s
+            continue;
+          }
+        }
+
+        lastError = data.error || "Re-analysis failed";
+        break;
+      } catch {
+        lastError = "Network error. Please check your connection.";
+        if (attempt < MAX_RETRIES) {
+          await new Promise((r) => setTimeout(r, 2000));
+          continue;
+        }
       }
-      // Reload report to show updated results
-      await fetchReport();
-    } catch (err) {
-      setError(
-        err instanceof Error ? err.message : "Re-analysis failed. Please try again."
-      );
-    } finally {
-      setIsReanalyzing(false);
     }
+
+    setError(lastError || "Re-analysis failed. The AI may be temporarily busy — please try again in a minute.");
+    setIsReanalyzing(false);
   }, [reportId, fetchReport]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
Three fixes:

1. **Health Credit Score breakdown** — replaced cryptic "6N 1B 4R" with full words + score range breakdown (300-579 Poor, 580-669 Fair, 670-739 Good, 740-799 Very Good, 800-850 Excellent)
2. **Daily Tip** — category emojis, "Show Another Tip" button cycles through tips, "Ask about this" links to chat
3. **Re-analyze retry** — retries up to 3x on Claude API overload (529/429) with increasing delay, shows friendly "AI is busy" message

## Test plan
- [x] All 815 tests pass
- [ ] Score shows full range breakdown
- [ ] "Show Another Tip" cycles tips
- [ ] Re-analyze retries on overload

🤖 Generated with [Claude Code](https://claude.com/claude-code)