### PR TITLE
fix(chat): daily tip opens chat with specific question + initial message support

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -7,8 +7,9 @@ import { Suspense } from "react";
 function ChatContent() {
   const searchParams = useSearchParams();
   const reportId = searchParams.get("report_id") ?? undefined;
+  const initialMessage = searchParams.get("message") ?? undefined;
 
-  return <ChatWindow reportId={reportId} />;
+  return <ChatWindow reportId={reportId} initialMessage={initialMessage} />;
 }
 
 export default function ChatPage() {

--- a/app/dashboard/daily-tip.tsx
+++ b/app/dashboard/daily-tip.tsx
@@ -189,7 +189,10 @@ export function DailyTip({ concerns }: DailyTipProps) {
         >
           Show Another Tip &rarr;
         </button>
-        <Link href="/chat" className="db-card__link">
+        <Link
+          href={`/chat?message=${encodeURIComponent("Tell me more about this health tip: " + currentTip.tip)}`}
+          className="db-card__link"
+        >
           Ask about this
         </Link>
       </div>

--- a/components/chat/ChatWindow.tsx
+++ b/components/chat/ChatWindow.tsx
@@ -13,9 +13,10 @@ import NavHeader from "@/components/ui/NavHeader";
 
 interface ChatWindowProps {
   reportId?: string;
+  initialMessage?: string;
 }
 
-export function ChatWindow({ reportId }: ChatWindowProps) {
+export function ChatWindow({ reportId, initialMessage }: ChatWindowProps) {
   const {
     messages,
     isLoading,
@@ -47,6 +48,15 @@ export function ChatWindow({ reportId }: ChatWindowProps) {
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, isLoading]);
+
+  // Auto-send initial message (e.g., from "Ask about this" on daily tip)
+  const initialMessageSentRef = useRef(false);
+  useEffect(() => {
+    if (initialMessage && !initialMessageSentRef.current && !isLoading && messages.length === 0) {
+      initialMessageSentRef.current = true;
+      sendMessage(initialMessage);
+    }
+  }, [initialMessage, isLoading, messages.length, sendMessage]);
 
   // Refresh sidebar when messages change (new message sent or session loaded)
   const prevMessageCountRef = useRef(0);


### PR DESCRIPTION
## Summary
- "Ask about this" on daily tips now opens chat with the tip pre-filled as a question
- Chat page accepts ?message= query param, auto-sends on load
- ChatWindow supports initialMessage prop

## Test plan
- [x] All 857 tests pass
- [ ] Click "Ask about this" on daily tip → opens chat with that tip as question

🤖 Generated with [Claude Code](https://claude.com/claude-code)