### PR TITLE
feat(insurance): add insurance card storage with photo upload

### DIFF
--- a/__tests__/audit-logging.test.ts
+++ b/__tests__/audit-logging.test.ts
@@ -174,6 +174,12 @@ describe("Audit Logger", () => {
         "medication.photo_upload",
         "medication.photo_delete",
         "chat.export_summary",
+        "insurance_card.create",
+        "insurance_card.update",
+        "insurance_card.delete",
+        "insurance_card.view",
+        "insurance_card.photo_upload",
+        "insurance_card.photo_delete",
       ];
 
       const resourceTypes: Record<AuditAction, AuditResourceType> = {
@@ -191,6 +197,12 @@ describe("Audit Logger", () => {
         "medication.delete": "medication",
         "medication.photo_upload": "medication",
         "medication.photo_delete": "medication",
+        "insurance_card.create": "insurance_card",
+        "insurance_card.update": "insurance_card",
+        "insurance_card.delete": "insurance_card",
+        "insurance_card.view": "insurance_card",
+        "insurance_card.photo_upload": "insurance_card",
+        "insurance_card.photo_delete": "insurance_card",
       };
 
       for (const action of actions) {

--- a/__tests__/insurance-cards.test.ts
+++ b/__tests__/insurance-cards.test.ts
@@ -1,0 +1,477 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Insurance Cards API Route — GET/POST ──────────────────────────
+
+describe("Insurance Cards API Route", () => {
+  it("exports GET and POST handlers", async () => {
+    const mod = await import("@/app/api/insurance-cards/route");
+    expect(mod.GET).toBeDefined();
+    expect(mod.POST).toBeDefined();
+    expect(typeof mod.GET).toBe("function");
+    expect(typeof mod.POST).toBe("function");
+  });
+});
+
+describe("Insurance Cards API — GET", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+      }),
+    }));
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { GET } = await import("@/app/api/insurance-cards/route");
+    const response = await GET(
+      new Request("http://localhost:3000/api/insurance-cards")
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 200 with insurance cards for authenticated user (self scope)", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const mockCards = [
+      {
+        id: "ic-1",
+        provider_name: "Blue Cross",
+        is_primary: true,
+      },
+    ];
+
+    const isMock = vi.fn().mockReturnValue({
+      order: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({
+          data: mockCards,
+          error: null,
+        }),
+      }),
+    });
+
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          is: isMock,
+        }),
+      }),
+    });
+
+    const { GET } = await import("@/app/api/insurance-cards/route");
+    const response = await GET(
+      new Request("http://localhost:3000/api/insurance-cards")
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.insurance_cards).toHaveLength(1);
+    expect(body.insurance_cards[0].provider_name).toBe("Blue Cross");
+    // Self scope => .is("family_member_id", null) called
+    expect(isMock).toHaveBeenCalledWith("family_member_id", null);
+  });
+
+  it("filters by family_member_id when query param provided", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const eqFamily = vi.fn().mockReturnValue({
+      order: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({
+          data: [],
+          error: null,
+        }),
+      }),
+    });
+
+    // First .eq (user_id) returns chain with .eq (family_member_id)
+    const firstEq = vi.fn().mockReturnValue({
+      eq: eqFamily,
+    });
+
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: firstEq,
+      }),
+    });
+
+    const { GET } = await import("@/app/api/insurance-cards/route");
+    const response = await GET(
+      new Request(
+        "http://localhost:3000/api/insurance-cards?family_member_id=fm-1"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(eqFamily).toHaveBeenCalledWith("family_member_id", "fm-1");
+  });
+});
+
+describe("Insurance Cards API — POST", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+      }),
+    }));
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { POST } = await import("@/app/api/insurance-cards/route");
+    const request = new Request("http://localhost:3000/api/insurance-cards", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider_name: "Test" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 400 when provider_name is missing", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const { POST } = await import("@/app/api/insurance-cards/route");
+    const request = new Request("http://localhost:3000/api/insurance-cards", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ member_id: "ABC123" }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("Provider name");
+  });
+
+  it("returns 201 on successful creation", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    const mockCard = {
+      id: "ic-1",
+      provider_name: "Blue Cross Blue Shield",
+      member_id: "ABC123",
+      is_primary: true,
+    };
+
+    mockFrom.mockReturnValue({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: mockCard,
+            error: null,
+          }),
+        }),
+      }),
+    });
+
+    const { POST } = await import("@/app/api/insurance-cards/route");
+    const request = new Request("http://localhost:3000/api/insurance-cards", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider_name: "Blue Cross Blue Shield",
+        member_id: "ABC123",
+        is_primary: true,
+      }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.insurance_card.provider_name).toBe("Blue Cross Blue Shield");
+  });
+
+  it("rejects invalid family_member_id not belonging to user", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    // Family member lookup returns null (not owned)
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "family_members") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: null,
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    });
+
+    const { POST } = await import("@/app/api/insurance-cards/route");
+    const request = new Request("http://localhost:3000/api/insurance-cards", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider_name: "Aetna",
+        family_member_id: "fm-other",
+      }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("family member");
+  });
+});
+
+// ── Single Insurance Card API — GET/PUT/DELETE ─────────────────
+
+describe("Single Insurance Card API Route", () => {
+  it("exports GET, PUT, and DELETE handlers", async () => {
+    const mod = await import("@/app/api/insurance-cards/[id]/route");
+    expect(mod.GET).toBeDefined();
+    expect(mod.PUT).toBeDefined();
+    expect(mod.DELETE).toBeDefined();
+  });
+});
+
+describe("Single Insurance Card API — DELETE", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+  let mockStorage: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+    mockStorage = { from: vi.fn() };
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+        storage: mockStorage,
+      }),
+    }));
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { DELETE } = await import("@/app/api/insurance-cards/[id]/route");
+    const request = new Request(
+      "http://localhost:3000/api/insurance-cards/ic-1",
+      { method: "DELETE" }
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: "ic-1" }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 when card does not exist", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    });
+
+    const { DELETE } = await import("@/app/api/insurance-cards/[id]/route");
+    const request = new Request(
+      "http://localhost:3000/api/insurance-cards/ic-999",
+      { method: "DELETE" }
+    );
+    const response = await DELETE(request, {
+      params: Promise.resolve({ id: "ic-999" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+});
+
+// ── Insurance Card Photo API ───────────────────────────────────
+
+describe("Insurance Card Photo API Route", () => {
+  it("exports POST and DELETE handlers", async () => {
+    const mod = await import("@/app/api/insurance-cards/[id]/photo/route");
+    expect(mod.POST).toBeDefined();
+    expect(mod.DELETE).toBeDefined();
+    expect(typeof mod.POST).toBe("function");
+    expect(typeof mod.DELETE).toBe("function");
+  });
+});
+
+describe("Insurance Card Photo API — POST", () => {
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockFrom: ReturnType<typeof vi.fn>;
+  let mockStorage: Record<string, ReturnType<typeof vi.fn>>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockGetUser = vi.fn();
+    mockFrom = vi.fn();
+    mockStorage = { from: vi.fn() };
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue({
+        auth: { getUser: mockGetUser },
+        from: mockFrom,
+        storage: mockStorage,
+      }),
+    }));
+  });
+
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const { POST } = await import("@/app/api/insurance-cards/[id]/photo/route");
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new File([new ArrayBuffer(1024)], "photo.png", { type: "image/png" })
+    );
+    formData.append("side", "front");
+    const request = new Request(
+      "http://localhost:3000/api/insurance-cards/ic-1/photo",
+      { method: "POST", body: formData }
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ id: "ic-1" }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns 404 when card does not belong to user", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1" } },
+    });
+
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: "Not found" },
+            }),
+          }),
+        }),
+      }),
+    });
+
+    const { POST } = await import("@/app/api/insurance-cards/[id]/photo/route");
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new File([new ArrayBuffer(1024)], "photo.png", { type: "image/png" })
+    );
+    formData.append("side", "front");
+    const request = new Request(
+      "http://localhost:3000/api/insurance-cards/ic-999/photo",
+      { method: "POST", body: formData }
+    );
+
+    const response = await POST(request, {
+      params: Promise.resolve({ id: "ic-999" }),
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+});
+
+// ── Insurance Card Photo URL API ───────────────────────────────
+
+describe("Insurance Card Photo URL API", () => {
+  it("exports GET handler", async () => {
+    const mod = await import(
+      "@/app/api/insurance-cards/[id]/photo-url/route"
+    );
+    expect(mod.GET).toBeDefined();
+    expect(typeof mod.GET).toBe("function");
+  });
+});
+
+// ── Page Components ───────────────────────────────────────────
+
+describe("Insurance Cards Page", () => {
+  it("exports a default component", async () => {
+    const mod = await import("@/app/insurance/page");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+});
+
+describe("Add Insurance Card Page", () => {
+  it("exports a default component", async () => {
+    const mod = await import("@/app/insurance/add/page");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+});
+
+describe("Edit Insurance Card Page", () => {
+  it("exports a default component", async () => {
+    const mod = await import("@/app/insurance/[id]/edit/page");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+});
+
+describe("Insurance Card Show Page", () => {
+  it("exports a default component", async () => {
+    const mod = await import("@/app/insurance/[id]/show/page");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+});
+
+// ── Audit Logger — insurance_card actions ─────────────────────
+
+describe("Audit Logger — insurance_card types", () => {
+  it("exports logger module cleanly with insurance_card types", async () => {
+    const mod = await import("@/lib/audit/logger");
+    expect(mod.logAuditEvent).toBeDefined();
+    expect(typeof mod.logAuditEvent).toBe("function");
+  });
+});

--- a/app/api/insurance-cards/[id]/photo-url/route.ts
+++ b/app/api/insurance-cards/[id]/photo-url/route.ts
@@ -1,0 +1,61 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+const BUCKET = "insurance-photos";
+const SIGNED_URL_TTL_SECONDS = 300; // 5 minutes
+
+/**
+ * Return short-lived signed URLs for the front and back insurance card photos.
+ * Photos live in a private bucket, so clients cannot fetch them directly.
+ * The URL is valid for 5 minutes.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id } = await params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: card } = await supabase
+    .from("insurance_cards")
+    .select("front_photo_path, back_photo_path")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!card) {
+    return NextResponse.json(
+      { error: "Insurance card not found" },
+      { status: 404 }
+    );
+  }
+
+  const result: {
+    front_url: string | null;
+    back_url: string | null;
+  } = { front_url: null, back_url: null };
+
+  if (card.front_photo_path) {
+    const { data } = await supabase.storage
+      .from(BUCKET)
+      .createSignedUrl(card.front_photo_path, SIGNED_URL_TTL_SECONDS);
+    result.front_url = data?.signedUrl ?? null;
+  }
+
+  if (card.back_photo_path) {
+    const { data } = await supabase.storage
+      .from(BUCKET)
+      .createSignedUrl(card.back_photo_path, SIGNED_URL_TTL_SECONDS);
+    result.back_url = data?.signedUrl ?? null;
+  }
+
+  return NextResponse.json(result);
+}

--- a/app/api/insurance-cards/[id]/photo/route.ts
+++ b/app/api/insurance-cards/[id]/photo/route.ts
@@ -1,0 +1,267 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { logAuditEvent, getClientIp } from "@/lib/audit/logger";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/webp"];
+const BUCKET = "insurance-photos";
+
+type Side = "front" | "back";
+
+function isSide(value: unknown): value is Side {
+  return value === "front" || value === "back";
+}
+
+function getExtension(mimeType: string): string {
+  const map: Record<string, string> = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp",
+  };
+  return map[mimeType] || "png";
+}
+
+/**
+ * Validate file content by checking magic bytes (file signatures).
+ * Prevents MIME type spoofing.
+ */
+async function validateMagicBytes(file: File): Promise<boolean> {
+  const buffer = await file.slice(0, 4).arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+
+  // JPEG: starts with 0xFF 0xD8 0xFF
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return true;
+
+  // PNG: starts with 0x89 0x50 0x4E 0x47
+  if (
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  )
+    return true;
+
+  // WebP: starts with RIFF (0x52 0x49 0x46 0x46)
+  if (
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46
+  )
+    return true;
+
+  return false;
+}
+
+function pathColumnForSide(side: Side): "front_photo_path" | "back_photo_path" {
+  return side === "front" ? "front_photo_path" : "back_photo_path";
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id } = await params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Verify card belongs to user
+  const { data: card } = await supabase
+    .from("insurance_cards")
+    .select("id, front_photo_path, back_photo_path")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!card) {
+    return NextResponse.json(
+      { error: "Insurance card not found" },
+      { status: 404 }
+    );
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid form data" },
+      { status: 400 }
+    );
+  }
+
+  const sideField = formData.get("side");
+  if (!isSide(sideField)) {
+    return NextResponse.json(
+      { error: "Invalid side. Must be 'front' or 'back'" },
+      { status: 400 }
+    );
+  }
+  const side: Side = sideField;
+
+  const file = formData.get("file");
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json(
+      { error: "No file provided" },
+      { status: 400 }
+    );
+  }
+
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      { error: "Invalid file type. Accepted: PNG, JPEG, WebP" },
+      { status: 400 }
+    );
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { error: "File too large. Maximum size is 5MB" },
+      { status: 413 }
+    );
+  }
+
+  const validContent = await validateMagicBytes(file);
+  if (!validContent) {
+    return NextResponse.json(
+      { error: "File content does not match its type" },
+      { status: 400 }
+    );
+  }
+
+  const column = pathColumnForSide(side);
+  const existingPath = card[column];
+
+  // Delete existing photo for this side if present
+  if (existingPath) {
+    await supabase.storage.from(BUCKET).remove([existingPath]);
+  }
+
+  const ext = getExtension(file.type);
+  const filePath = `${user.id}/${id}-${side}.${ext}`;
+
+  const { error: uploadError } = await supabase.storage
+    .from(BUCKET)
+    .upload(filePath, file, {
+      contentType: file.type,
+      upsert: true,
+    });
+
+  if (uploadError) {
+    return NextResponse.json(
+      { error: "Failed to upload photo" },
+      { status: 500 }
+    );
+  }
+
+  const { error: updateError } = await supabase
+    .from("insurance_cards")
+    .update({
+      [column]: filePath,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: "Failed to update insurance card" },
+      { status: 500 }
+    );
+  }
+
+  logAuditEvent({
+    userId: user.id,
+    action: "insurance_card.photo_upload",
+    resourceType: "insurance_card",
+    resourceId: id,
+    ipAddress: getClientIp(request),
+  });
+
+  return NextResponse.json({ side, path: filePath }, { status: 200 });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id } = await params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const sideParam = searchParams.get("side");
+  if (!isSide(sideParam)) {
+    return NextResponse.json(
+      { error: "Invalid side. Must be 'front' or 'back'" },
+      { status: 400 }
+    );
+  }
+  const side: Side = sideParam;
+
+  const { data: card } = await supabase
+    .from("insurance_cards")
+    .select("front_photo_path, back_photo_path")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!card) {
+    return NextResponse.json(
+      { error: "Insurance card not found" },
+      { status: 404 }
+    );
+  }
+
+  const column = pathColumnForSide(side);
+  const existingPath = card[column];
+
+  if (!existingPath) {
+    return NextResponse.json(
+      { error: "No photo to delete" },
+      { status: 400 }
+    );
+  }
+
+  await supabase.storage.from(BUCKET).remove([existingPath]);
+
+  const { error: updateError } = await supabase
+    .from("insurance_cards")
+    .update({
+      [column]: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (updateError) {
+    return NextResponse.json(
+      { error: "Failed to update insurance card" },
+      { status: 500 }
+    );
+  }
+
+  logAuditEvent({
+    userId: user.id,
+    action: "insurance_card.photo_delete",
+    resourceType: "insurance_card",
+    resourceId: id,
+    ipAddress: getClientIp(request),
+  });
+
+  return NextResponse.json({ side, path: null }, { status: 200 });
+}

--- a/app/api/insurance-cards/[id]/route.ts
+++ b/app/api/insurance-cards/[id]/route.ts
@@ -1,0 +1,232 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { logAuditEvent, getClientIp } from "@/lib/audit/logger";
+
+const MAX_TEXT_LENGTH = 500;
+const MAX_NOTES_LENGTH = 2000;
+
+function sanitizeText(
+  value: unknown,
+  maxLength = MAX_TEXT_LENGTH
+): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, maxLength);
+}
+
+function sanitizeDate(value: unknown): string | null {
+  if (typeof value !== "string" || !value) return null;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  return value;
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id } = await params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: insurance_card, error } = await supabase
+    .from("insurance_cards")
+    .select("*")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (error || !insurance_card) {
+    return NextResponse.json(
+      { error: "Insurance card not found" },
+      { status: 404 }
+    );
+  }
+
+  logAuditEvent({
+    userId: user.id,
+    action: "insurance_card.view",
+    resourceType: "insurance_card",
+    resourceId: id,
+    ipAddress: getClientIp(request),
+  });
+
+  return NextResponse.json({ insurance_card });
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id } = await params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  const updates: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  };
+
+  if (body.provider_name !== undefined) {
+    const providerName = sanitizeText(body.provider_name);
+    if (!providerName) {
+      return NextResponse.json(
+        { error: "Provider name cannot be empty" },
+        { status: 400 }
+      );
+    }
+    updates.provider_name = providerName;
+  }
+
+  if (body.plan_type !== undefined) updates.plan_type = sanitizeText(body.plan_type);
+  if (body.member_id !== undefined) updates.member_id = sanitizeText(body.member_id);
+  if (body.group_number !== undefined) updates.group_number = sanitizeText(body.group_number);
+  if (body.rx_bin !== undefined) updates.rx_bin = sanitizeText(body.rx_bin);
+  if (body.rx_pcn !== undefined) updates.rx_pcn = sanitizeText(body.rx_pcn);
+  if (body.rx_group !== undefined) updates.rx_group = sanitizeText(body.rx_group);
+  if (body.policy_holder_name !== undefined) {
+    updates.policy_holder_name = sanitizeText(body.policy_holder_name);
+  }
+  if (body.effective_date !== undefined) {
+    updates.effective_date = sanitizeDate(body.effective_date);
+  }
+  if (body.customer_service_phone !== undefined) {
+    updates.customer_service_phone = sanitizeText(body.customer_service_phone);
+  }
+  if (body.notes !== undefined) {
+    updates.notes = sanitizeText(body.notes, MAX_NOTES_LENGTH);
+  }
+  if (body.is_primary !== undefined) {
+    updates.is_primary = Boolean(body.is_primary);
+  }
+
+  if (body.family_member_id !== undefined) {
+    if (body.family_member_id === null || body.family_member_id === "") {
+      updates.family_member_id = null;
+    } else if (typeof body.family_member_id === "string") {
+      const { data: fm } = await supabase
+        .from("family_members")
+        .select("id")
+        .eq("id", body.family_member_id)
+        .eq("owner_id", user.id)
+        .single();
+      if (!fm) {
+        return NextResponse.json(
+          { error: "Invalid family member" },
+          { status: 400 }
+        );
+      }
+      updates.family_member_id = fm.id;
+    }
+  }
+
+  const { data: insurance_card, error } = await supabase
+    .from("insurance_cards")
+    .update(updates)
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .select()
+    .single();
+
+  if (error || !insurance_card) {
+    return NextResponse.json(
+      { error: "Insurance card not found" },
+      { status: 404 }
+    );
+  }
+
+  logAuditEvent({
+    userId: user.id,
+    action: "insurance_card.update",
+    resourceType: "insurance_card",
+    resourceId: id,
+    ipAddress: getClientIp(request),
+  });
+
+  return NextResponse.json({ insurance_card });
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const supabase = await createClient();
+  const { id } = await params;
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Fetch card to get photo paths for cleanup
+  const { data: card } = await supabase
+    .from("insurance_cards")
+    .select("front_photo_path, back_photo_path")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!card) {
+    return NextResponse.json(
+      { error: "Insurance card not found" },
+      { status: 404 }
+    );
+  }
+
+  // Clean up photos from storage if present
+  const photosToRemove: string[] = [];
+  if (card.front_photo_path) photosToRemove.push(card.front_photo_path);
+  if (card.back_photo_path) photosToRemove.push(card.back_photo_path);
+  if (photosToRemove.length > 0) {
+    await supabase.storage.from("insurance-photos").remove(photosToRemove);
+  }
+
+  const { error } = await supabase
+    .from("insurance_cards")
+    .delete()
+    .eq("id", id)
+    .eq("user_id", user.id);
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to delete insurance card" },
+      { status: 500 }
+    );
+  }
+
+  logAuditEvent({
+    userId: user.id,
+    action: "insurance_card.delete",
+    resourceType: "insurance_card",
+    resourceId: id,
+    ipAddress: getClientIp(request),
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/insurance-cards/route.ts
+++ b/app/api/insurance-cards/route.ts
@@ -1,0 +1,148 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { logAuditEvent, getClientIp } from "@/lib/audit/logger";
+
+const MAX_TEXT_LENGTH = 500;
+const MAX_NOTES_LENGTH = 2000;
+
+function sanitizeText(
+  value: unknown,
+  maxLength = MAX_TEXT_LENGTH
+): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, maxLength);
+}
+
+function sanitizeDate(value: unknown): string | null {
+  if (typeof value !== "string" || !value) return null;
+  // Expect YYYY-MM-DD
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  return value;
+}
+
+export async function GET(request: Request) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const familyMemberId = searchParams.get("family_member_id");
+
+  let query = supabase
+    .from("insurance_cards")
+    .select("*")
+    .eq("user_id", user.id);
+
+  if (familyMemberId) {
+    query = query.eq("family_member_id", familyMemberId);
+  } else {
+    query = query.is("family_member_id", null);
+  }
+
+  const { data: insurance_cards, error } = await query
+    .order("is_primary", { ascending: false })
+    .order("provider_name", { ascending: true });
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to load insurance cards" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ insurance_cards });
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  const providerName = sanitizeText(body.provider_name);
+  if (!providerName) {
+    return NextResponse.json(
+      { error: "Provider name is required" },
+      { status: 400 }
+    );
+  }
+
+  let familyMemberId: string | null = null;
+  if (typeof body.family_member_id === "string" && body.family_member_id) {
+    // Verify the family member belongs to this user
+    const { data: fm } = await supabase
+      .from("family_members")
+      .select("id")
+      .eq("id", body.family_member_id)
+      .eq("owner_id", user.id)
+      .single();
+    if (!fm) {
+      return NextResponse.json(
+        { error: "Invalid family member" },
+        { status: 400 }
+      );
+    }
+    familyMemberId = fm.id;
+  }
+
+  const { data: insurance_card, error } = await supabase
+    .from("insurance_cards")
+    .insert({
+      user_id: user.id,
+      family_member_id: familyMemberId,
+      provider_name: providerName,
+      plan_type: sanitizeText(body.plan_type),
+      member_id: sanitizeText(body.member_id),
+      group_number: sanitizeText(body.group_number),
+      rx_bin: sanitizeText(body.rx_bin),
+      rx_pcn: sanitizeText(body.rx_pcn),
+      rx_group: sanitizeText(body.rx_group),
+      policy_holder_name: sanitizeText(body.policy_holder_name),
+      effective_date: sanitizeDate(body.effective_date),
+      customer_service_phone: sanitizeText(body.customer_service_phone),
+      notes: sanitizeText(body.notes, MAX_NOTES_LENGTH),
+      is_primary: body.is_primary === undefined ? true : Boolean(body.is_primary),
+    })
+    .select()
+    .single();
+
+  if (error || !insurance_card) {
+    return NextResponse.json(
+      { error: "Failed to create insurance card" },
+      { status: 500 }
+    );
+  }
+
+  logAuditEvent({
+    userId: user.id,
+    action: "insurance_card.create",
+    resourceType: "insurance_card",
+    resourceId: insurance_card.id,
+    ipAddress: getClientIp(request),
+  });
+
+  return NextResponse.json({ insurance_card }, { status: 201 });
+}

--- a/app/dashboard/dashboard-grid.tsx
+++ b/app/dashboard/dashboard-grid.tsx
@@ -111,6 +111,13 @@ export function DashboardGrid({ displayName }: DashboardGridProps) {
               </svg>
               Medications
             </Link>
+            <Link href="/insurance" className="db-action">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect x="2" y="5" width="20" height="14" rx="2" />
+                <line x1="2" y1="10" x2="22" y2="10" />
+              </svg>
+              Insurance
+            </Link>
             <Link href="/profile" className="db-action">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                 <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -38,6 +38,7 @@ export default async function DashboardPage() {
           <Link href="/chat" className="dashboard-header__link">Chat</Link>
           <Link href="/reports" className="dashboard-header__link">Reports</Link>
           <Link href="/medications" className="dashboard-header__link">Medications</Link>
+          <Link href="/insurance" className="dashboard-header__link">Insurance</Link>
           <Link href="/family" className="dashboard-header__link">Family</Link>
           <Link href="/profile" className="dashboard-header__link">Profile</Link>
         </nav>

--- a/app/globals.css
+++ b/app/globals.css
@@ -7403,3 +7403,756 @@ button.chat-send-button[type="submit"]:disabled {
     background: white;
   }
 }
+
+/* =========================
+   Insurance Cards
+   ========================= */
+
+.insurance-page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.insurance-page--loading {
+  text-align: center;
+  padding: 4rem 1.5rem;
+  color: var(--color-gray-500);
+}
+
+.insurance-page__spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--color-gray-200);
+  border-top-color: var(--color-blue-500);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 1rem;
+}
+
+.insurance-page__header h1 {
+  font-size: 1.875rem;
+  font-weight: 700;
+  margin: 0.5rem 0 0.25rem;
+  color: var(--color-gray-900);
+}
+
+.insurance-page__header p {
+  margin: 0;
+  color: var(--color-gray-500);
+}
+
+.insurance-page__title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.insurance-page__add-btn {
+  padding: 0.6rem 1.25rem;
+  background: var(--color-blue-600);
+  color: #fff;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.insurance-page__add-btn:hover {
+  background: var(--color-blue-700);
+}
+
+.insurance-page__filter {
+  margin: 1.5rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.insurance-page__filter label {
+  font-size: 0.875rem;
+  color: var(--color-gray-600);
+}
+
+.insurance-page__filter select {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  background: #fff;
+}
+
+.insurance-page__error {
+  margin: 1rem 0;
+  padding: 0.75rem 1rem;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  border-radius: 8px;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.insurance-page__dismiss {
+  background: none;
+  border: none;
+  color: #991b1b;
+  font-size: 0.75rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.insurance-page__empty {
+  text-align: center;
+  padding: 3rem 1.5rem;
+  border: 2px dashed var(--color-gray-200);
+  border-radius: 16px;
+  margin-top: 2rem;
+}
+
+.insurance-page__empty h2 {
+  margin: 1rem 0 0.5rem;
+  color: var(--color-gray-700);
+}
+
+.insurance-page__empty p {
+  margin: 0 0 1.5rem;
+  color: var(--color-gray-500);
+}
+
+.insurance-page__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 2rem;
+}
+
+/* Insurance Card */
+
+.insurance-card {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 1.25rem;
+  padding: 1.25rem;
+  background: #fff;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 16px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  transition: box-shadow 0.15s;
+}
+
+.insurance-card:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.insurance-card__photo {
+  width: 200px;
+  height: 130px;
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--color-gray-100);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.insurance-card__photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.insurance-card__photo-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--color-gray-400);
+  font-size: 0.75rem;
+}
+
+.insurance-card__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.insurance-card__header-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.insurance-card__provider {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--color-gray-900);
+  margin: 0;
+}
+
+.insurance-card__badge {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.insurance-card__badge--primary {
+  background: var(--color-blue-50);
+  color: var(--color-blue-700);
+}
+
+.insurance-card__badge--secondary {
+  background: var(--color-gray-100);
+  color: var(--color-gray-600);
+}
+
+.insurance-card__plan {
+  font-size: 0.875rem;
+  color: var(--color-gray-500);
+  margin: 0 0 0.25rem;
+}
+
+.insurance-card__detail {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.insurance-card__label {
+  color: var(--color-gray-500);
+  font-weight: 500;
+  min-width: 80px;
+}
+
+.insurance-card__value {
+  color: var(--color-gray-800);
+  font-family: var(--font-mono, monospace);
+}
+
+.insurance-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.insurance-card__action {
+  padding: 0.4rem 0.85rem;
+  background: var(--color-gray-100);
+  border: none;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-gray-700);
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+  transition: background 0.15s;
+}
+
+.insurance-card__action:hover {
+  background: var(--color-gray-200);
+}
+
+.insurance-card__action--primary {
+  background: var(--color-blue-600);
+  color: #fff;
+}
+
+.insurance-card__action--primary:hover {
+  background: var(--color-blue-700);
+}
+
+.insurance-card__action--danger {
+  color: #991b1b;
+}
+
+.insurance-card__action--danger:hover {
+  background: #fee2e2;
+}
+
+/* Delete dialog */
+
+.insurance-page__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.insurance-page__dialog {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  max-width: 400px;
+  width: 100%;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+}
+
+.insurance-page__dialog h3 {
+  margin: 0 0 0.5rem;
+  color: var(--color-gray-900);
+}
+
+.insurance-page__dialog p {
+  margin: 0 0 1.25rem;
+  color: var(--color-gray-600);
+  font-size: 0.875rem;
+}
+
+.insurance-page__dialog-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.insurance-page__dialog-cancel,
+.insurance-page__dialog-delete {
+  padding: 0.6rem 1.25rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.insurance-page__dialog-cancel {
+  background: var(--color-gray-100);
+  color: var(--color-gray-700);
+}
+
+.insurance-page__dialog-delete {
+  background: #dc2626;
+  color: #fff;
+}
+
+.insurance-page__dialog-delete:hover {
+  background: #b91c1c;
+}
+
+/* Insurance Form */
+
+.insurance-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.insurance-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.insurance-form__field label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-gray-700);
+}
+
+.insurance-form__field input,
+.insurance-form__field select,
+.insurance-form__field textarea {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  background: #fff;
+  font-family: inherit;
+}
+
+.insurance-form__field input:focus,
+.insurance-form__field select:focus,
+.insurance-form__field textarea:focus {
+  outline: none;
+  border-color: var(--color-blue-400);
+  box-shadow: 0 0 0 3px var(--color-blue-50);
+}
+
+.insurance-form__required {
+  color: #dc2626;
+}
+
+.insurance-form__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.insurance-form__row:has(> .insurance-form__field:nth-child(3)) {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.insurance-form__fieldset {
+  border: 1px solid var(--color-gray-200);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.insurance-form__fieldset legend {
+  padding: 0 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-gray-600);
+}
+
+.insurance-form__radio-group {
+  display: flex;
+  gap: 1rem;
+}
+
+.insurance-form__radio {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.875rem;
+  color: var(--color-gray-700);
+  cursor: pointer;
+}
+
+.insurance-form__photo-upload {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.insurance-form__photo-box {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.insurance-form__photo-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--color-gray-500);
+}
+
+.insurance-form__photo-input {
+  display: none;
+}
+
+.insurance-form__photo-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem 1rem;
+  border: 2px dashed var(--color-gray-300);
+  border-radius: 12px;
+  background: var(--color-gray-50, #fafafa);
+  cursor: pointer;
+  text-align: center;
+  gap: 0.35rem;
+  color: var(--color-gray-600);
+  font-size: 0.875rem;
+  transition: all 0.15s;
+  min-height: 140px;
+}
+
+.insurance-form__photo-label:hover {
+  border-color: var(--color-blue-400);
+  background: var(--color-blue-50);
+}
+
+.insurance-form__photo-hint {
+  font-size: 0.75rem;
+  color: var(--color-gray-400);
+}
+
+.insurance-form__photo-preview {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--color-gray-200);
+  min-height: 140px;
+}
+
+.insurance-form__photo-preview img {
+  display: block;
+  width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+}
+
+.insurance-form__photo-remove {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.insurance-form__photo-remove:hover {
+  background: rgba(0, 0, 0, 0.8);
+}
+
+.insurance-form__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  padding-top: 0.5rem;
+}
+
+.insurance-form__cancel {
+  padding: 0.6rem 1.25rem;
+  background: var(--color-gray-100);
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: var(--color-gray-600);
+}
+
+.insurance-form__cancel:hover {
+  background: var(--color-gray-200);
+}
+
+.insurance-form__submit {
+  padding: 0.6rem 1.25rem;
+  background: var(--color-blue-600);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.insurance-form__submit:hover {
+  background: var(--color-blue-700);
+}
+
+.insurance-form__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Quick Show Page */
+
+.insurance-show {
+  min-height: 100vh;
+  background: #0f172a;
+  color: #fff;
+  padding: 1.5rem 1rem 3rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.insurance-show--loading,
+.insurance-show--error {
+  justify-content: center;
+  text-align: center;
+}
+
+.insurance-show__spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(255, 255, 255, 0.2);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 1rem;
+}
+
+.insurance-show--error button {
+  margin-top: 1rem;
+  padding: 0.6rem 1.25rem;
+  background: #fff;
+  color: #0f172a;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.insurance-show__header {
+  width: 100%;
+  max-width: 600px;
+  margin-bottom: 1.5rem;
+}
+
+.insurance-show__back {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  text-decoration: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.insurance-show__back:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.insurance-show__title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.insurance-show__title h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.insurance-show__badge {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.insurance-show__badge--primary {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.insurance-show__badge--secondary {
+  background: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.insurance-show__photo-wrapper {
+  width: 100%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.insurance-show__photo {
+  width: 100%;
+  max-width: 600px;
+  max-height: 70vh;
+  object-fit: contain;
+  border-radius: 16px;
+  background: #fff;
+  cursor: pointer;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+.insurance-show__photo-missing {
+  width: 100%;
+  max-width: 600px;
+  padding: 4rem 2rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.insurance-show__flip-btn {
+  padding: 0.6rem 1.25rem;
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.insurance-show__flip-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.insurance-show__info {
+  width: 100%;
+  max-width: 600px;
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.insurance-show__info-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 10px;
+}
+
+.insurance-show__info-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.6);
+  font-weight: 600;
+}
+
+.insurance-show__info-value {
+  font-size: 1rem;
+  color: #fff;
+}
+
+.insurance-show__info-value--big {
+  font-size: 1.375rem;
+  font-weight: 700;
+  font-family: var(--font-mono, monospace);
+  letter-spacing: 0.03em;
+}
+
+@media (max-width: 640px) {
+  .insurance-card {
+    grid-template-columns: 1fr;
+  }
+
+  .insurance-card__photo {
+    width: 100%;
+    height: 160px;
+  }
+
+  .insurance-form__row {
+    grid-template-columns: 1fr;
+  }
+
+  .insurance-form__row:has(> .insurance-form__field:nth-child(3)) {
+    grid-template-columns: 1fr;
+  }
+
+  .insurance-form__photo-upload {
+    grid-template-columns: 1fr;
+  }
+
+  .insurance-page__title-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/app/insurance/[id]/edit/layout.tsx
+++ b/app/insurance/[id]/edit/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function EditInsuranceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/insurance/[id]/edit/page.tsx
+++ b/app/insurance/[id]/edit/page.tsx
@@ -1,0 +1,554 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter, useParams } from "next/navigation";
+import NavHeader from "@/components/ui/NavHeader";
+
+interface FamilyMember {
+  id: string;
+  display_name: string;
+}
+
+export default function EditInsuranceCardPage() {
+  const router = useRouter();
+  const params = useParams();
+  const cardId = params.id as string;
+  const frontInputRef = useRef<HTMLInputElement>(null);
+  const backInputRef = useRef<HTMLInputElement>(null);
+
+  const [familyMembers, setFamilyMembers] = useState<FamilyMember[]>([]);
+  const [providerName, setProviderName] = useState("");
+  const [planType, setPlanType] = useState("");
+  const [memberId, setMemberId] = useState("");
+  const [groupNumber, setGroupNumber] = useState("");
+  const [rxBin, setRxBin] = useState("");
+  const [rxPcn, setRxPcn] = useState("");
+  const [rxGroup, setRxGroup] = useState("");
+  const [policyHolderName, setPolicyHolderName] = useState("");
+  const [effectiveDate, setEffectiveDate] = useState("");
+  const [phone, setPhone] = useState("");
+  const [notes, setNotes] = useState("");
+  const [familyMemberId, setFamilyMemberId] = useState("");
+  const [isPrimary, setIsPrimary] = useState(true);
+  const [frontUrl, setFrontUrl] = useState<string | null>(null);
+  const [backUrl, setBackUrl] = useState<string | null>(null);
+  const [hasFront, setHasFront] = useState(false);
+  const [hasBack, setHasBack] = useState(false);
+  const [frontFile, setFrontFile] = useState<File | null>(null);
+  const [backFile, setBackFile] = useState<File | null>(null);
+  const [frontPreview, setFrontPreview] = useState<string | null>(null);
+  const [backPreview, setBackPreview] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchFamilyMembers = useCallback(async () => {
+    try {
+      const response = await fetch("/api/family-members");
+      if (!response.ok) return;
+      const data = await response.json();
+      setFamilyMembers(data.family_members || []);
+    } catch {
+      // silent
+    }
+  }, []);
+
+  const fetchCard = useCallback(async () => {
+    try {
+      const response = await fetch(`/api/insurance-cards/${cardId}`);
+      if (!response.ok) throw new Error("Insurance card not found");
+      const { insurance_card } = await response.json();
+      setProviderName(insurance_card.provider_name || "");
+      setPlanType(insurance_card.plan_type || "");
+      setMemberId(insurance_card.member_id || "");
+      setGroupNumber(insurance_card.group_number || "");
+      setRxBin(insurance_card.rx_bin || "");
+      setRxPcn(insurance_card.rx_pcn || "");
+      setRxGroup(insurance_card.rx_group || "");
+      setPolicyHolderName(insurance_card.policy_holder_name || "");
+      setEffectiveDate(insurance_card.effective_date || "");
+      setPhone(insurance_card.customer_service_phone || "");
+      setNotes(insurance_card.notes || "");
+      setFamilyMemberId(insurance_card.family_member_id || "");
+      setIsPrimary(insurance_card.is_primary ?? true);
+      setHasFront(!!insurance_card.front_photo_path);
+      setHasBack(!!insurance_card.back_photo_path);
+
+      // Fetch signed URLs for any existing photos
+      if (insurance_card.front_photo_path || insurance_card.back_photo_path) {
+        const urlRes = await fetch(`/api/insurance-cards/${cardId}/photo-url`);
+        if (urlRes.ok) {
+          const urlData = await urlRes.json();
+          setFrontUrl(urlData.front_url ?? null);
+          setBackUrl(urlData.back_url ?? null);
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load card");
+    } finally {
+      setLoading(false);
+    }
+  }, [cardId]);
+
+  useEffect(() => {
+    fetchFamilyMembers();
+    fetchCard();
+  }, [fetchFamilyMembers, fetchCard]);
+
+  const validatePhoto = (file: File): string | null => {
+    const allowedTypes = ["image/png", "image/jpeg", "image/webp"];
+    if (!allowedTypes.includes(file.type)) {
+      return "Invalid file type. Accepted: PNG, JPEG, WebP";
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      return "File too large. Maximum size is 5MB";
+    }
+    return null;
+  };
+
+  const handlePhotoChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    side: "front" | "back"
+  ) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const err = validatePhoto(file);
+    if (err) {
+      setError(err);
+      return;
+    }
+    setError(null);
+    if (side === "front") {
+      setFrontFile(file);
+    } else {
+      setBackFile(file);
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (side === "front") {
+        setFrontPreview(reader.result as string);
+      } else {
+        setBackPreview(reader.result as string);
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemovePhoto = async (side: "front" | "back") => {
+    const hasExisting = side === "front" ? hasFront : hasBack;
+    if (hasExisting) {
+      try {
+        await fetch(
+          `/api/insurance-cards/${cardId}/photo?side=${side}`,
+          { method: "DELETE" }
+        );
+        if (side === "front") {
+          setHasFront(false);
+          setFrontUrl(null);
+        } else {
+          setHasBack(false);
+          setBackUrl(null);
+        }
+      } catch {
+        setError("Failed to remove photo");
+        return;
+      }
+    }
+    if (side === "front") {
+      setFrontFile(null);
+      setFrontPreview(null);
+      if (frontInputRef.current) frontInputRef.current.value = "";
+    } else {
+      setBackFile(null);
+      setBackPreview(null);
+      if (backInputRef.current) backInputRef.current.value = "";
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!providerName.trim()) {
+      setError("Provider name is required");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/insurance-cards/${cardId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider_name: providerName.trim(),
+          plan_type: planType.trim() || null,
+          member_id: memberId.trim() || null,
+          group_number: groupNumber.trim() || null,
+          rx_bin: rxBin.trim() || null,
+          rx_pcn: rxPcn.trim() || null,
+          rx_group: rxGroup.trim() || null,
+          policy_holder_name: policyHolderName.trim() || null,
+          effective_date: effectiveDate || null,
+          customer_service_phone: phone.trim() || null,
+          notes: notes.trim() || null,
+          family_member_id: familyMemberId || null,
+          is_primary: isPrimary,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to update insurance card");
+      }
+
+      const uploadPromises: Promise<unknown>[] = [];
+      if (frontFile) {
+        const fd = new FormData();
+        fd.append("file", frontFile);
+        fd.append("side", "front");
+        uploadPromises.push(
+          fetch(`/api/insurance-cards/${cardId}/photo`, {
+            method: "POST",
+            body: fd,
+          })
+        );
+      }
+      if (backFile) {
+        const fd = new FormData();
+        fd.append("file", backFile);
+        fd.append("side", "back");
+        uploadPromises.push(
+          fetch(`/api/insurance-cards/${cardId}/photo`, {
+            method: "POST",
+            body: fd,
+          })
+        );
+      }
+      await Promise.all(uploadPromises);
+
+      router.push("/insurance");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to update insurance card"
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="insurance-page insurance-page--loading">
+        <div className="insurance-page__spinner" aria-label="Loading insurance card" />
+        <p>Loading insurance card...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="insurance-page">
+      <div className="insurance-page__header">
+        <NavHeader backHref="/insurance" backLabel="Insurance" />
+        <h1>Edit Insurance Card</h1>
+      </div>
+
+      {error && (
+        <div className="insurance-page__error" role="alert">
+          {error}
+          <button
+            onClick={() => setError(null)}
+            className="insurance-page__dismiss"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="insurance-form">
+        <div className="insurance-form__field">
+          <label htmlFor="ic-provider">
+            Provider Name <span className="insurance-form__required">*</span>
+          </label>
+          <input
+            id="ic-provider"
+            type="text"
+            value={providerName}
+            onChange={(e) => setProviderName(e.target.value)}
+            maxLength={200}
+            required
+          />
+        </div>
+
+        <div className="insurance-form__row">
+          <div className="insurance-form__field">
+            <label htmlFor="ic-plan-type">Plan Type</label>
+            <input
+              id="ic-plan-type"
+              type="text"
+              value={planType}
+              onChange={(e) => setPlanType(e.target.value)}
+              maxLength={100}
+            />
+          </div>
+          <div className="insurance-form__field">
+            <label htmlFor="ic-member-id">Member ID</label>
+            <input
+              id="ic-member-id"
+              type="text"
+              value={memberId}
+              onChange={(e) => setMemberId(e.target.value)}
+              maxLength={100}
+            />
+          </div>
+        </div>
+
+        <div className="insurance-form__row">
+          <div className="insurance-form__field">
+            <label htmlFor="ic-group">Group Number</label>
+            <input
+              id="ic-group"
+              type="text"
+              value={groupNumber}
+              onChange={(e) => setGroupNumber(e.target.value)}
+              maxLength={100}
+            />
+          </div>
+          <div className="insurance-form__field">
+            <label htmlFor="ic-policy-holder">Policy Holder Name</label>
+            <input
+              id="ic-policy-holder"
+              type="text"
+              value={policyHolderName}
+              onChange={(e) => setPolicyHolderName(e.target.value)}
+              maxLength={200}
+            />
+          </div>
+        </div>
+
+        <fieldset className="insurance-form__fieldset">
+          <legend>Pharmacy / RX (optional)</legend>
+          <div className="insurance-form__row">
+            <div className="insurance-form__field">
+              <label htmlFor="ic-rxbin">RX BIN</label>
+              <input
+                id="ic-rxbin"
+                type="text"
+                value={rxBin}
+                onChange={(e) => setRxBin(e.target.value)}
+                maxLength={50}
+              />
+            </div>
+            <div className="insurance-form__field">
+              <label htmlFor="ic-rxpcn">RX PCN</label>
+              <input
+                id="ic-rxpcn"
+                type="text"
+                value={rxPcn}
+                onChange={(e) => setRxPcn(e.target.value)}
+                maxLength={50}
+              />
+            </div>
+            <div className="insurance-form__field">
+              <label htmlFor="ic-rxgroup">RX Group</label>
+              <input
+                id="ic-rxgroup"
+                type="text"
+                value={rxGroup}
+                onChange={(e) => setRxGroup(e.target.value)}
+                maxLength={50}
+              />
+            </div>
+          </div>
+        </fieldset>
+
+        <div className="insurance-form__row">
+          <div className="insurance-form__field">
+            <label htmlFor="ic-effective">Effective Date</label>
+            <input
+              id="ic-effective"
+              type="date"
+              value={effectiveDate}
+              onChange={(e) => setEffectiveDate(e.target.value)}
+            />
+          </div>
+          <div className="insurance-form__field">
+            <label htmlFor="ic-phone">Customer Service Phone</label>
+            <input
+              id="ic-phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              maxLength={50}
+            />
+          </div>
+        </div>
+
+        {familyMembers.length > 0 && (
+          <div className="insurance-form__field">
+            <label htmlFor="ic-family">For</label>
+            <select
+              id="ic-family"
+              value={familyMemberId}
+              onChange={(e) => setFamilyMemberId(e.target.value)}
+            >
+              <option value="">Myself</option>
+              {familyMembers.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.display_name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div className="insurance-form__field">
+          <label>Primary or Secondary</label>
+          <div className="insurance-form__radio-group">
+            <label className="insurance-form__radio">
+              <input
+                type="radio"
+                name="is_primary"
+                checked={isPrimary}
+                onChange={() => setIsPrimary(true)}
+              />
+              <span>Primary</span>
+            </label>
+            <label className="insurance-form__radio">
+              <input
+                type="radio"
+                name="is_primary"
+                checked={!isPrimary}
+                onChange={() => setIsPrimary(false)}
+              />
+              <span>Secondary</span>
+            </label>
+          </div>
+        </div>
+
+        <div className="insurance-form__field">
+          <label htmlFor="ic-notes">Notes</label>
+          <textarea
+            id="ic-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            maxLength={2000}
+            rows={3}
+          />
+        </div>
+
+        <div className="insurance-form__field">
+          <label>Card Photos</label>
+          <div className="insurance-form__photo-upload">
+            <EditPhotoUploadBox
+              side="front"
+              inputRef={frontInputRef}
+              preview={frontPreview}
+              existingUrl={frontUrl}
+              hasExisting={hasFront}
+              onChange={(e) => handlePhotoChange(e, "front")}
+              onRemove={() => handleRemovePhoto("front")}
+            />
+            <EditPhotoUploadBox
+              side="back"
+              inputRef={backInputRef}
+              preview={backPreview}
+              existingUrl={backUrl}
+              hasExisting={hasBack}
+              onChange={(e) => handlePhotoChange(e, "back")}
+              onRemove={() => handleRemovePhoto("back")}
+            />
+          </div>
+        </div>
+
+        <div className="insurance-form__actions">
+          <button
+            type="button"
+            onClick={() => router.push("/insurance")}
+            className="insurance-form__cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="insurance-form__submit"
+            disabled={saving}
+          >
+            {saving ? "Saving..." : "Save Changes"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function EditPhotoUploadBox({
+  side,
+  inputRef,
+  preview,
+  existingUrl,
+  hasExisting,
+  onChange,
+  onRemove,
+}: {
+  side: "front" | "back";
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  preview: string | null;
+  existingUrl: string | null;
+  hasExisting: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onRemove: () => void;
+}) {
+  const inputId = `ic-photo-${side}`;
+  const label = side === "front" ? "Front" : "Back";
+  const showPreview = preview || (hasExisting && existingUrl);
+  return (
+    <div className="insurance-form__photo-box">
+      <span className="insurance-form__photo-title">{label}</span>
+      {showPreview ? (
+        <div className="insurance-form__photo-preview">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={preview || existingUrl || ""}
+            alt={`Insurance card ${label.toLowerCase()}`}
+          />
+          <button
+            type="button"
+            onClick={onRemove}
+            className="insurance-form__photo-remove"
+          >
+            Remove
+          </button>
+        </div>
+      ) : (
+        <label htmlFor={inputId} className="insurance-form__photo-label">
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M23 19a2 2 0 01-2 2H3a2 2 0 01-2-2V8a2 2 0 012-2h4l2-3h6l2 3h4a2 2 0 012 2z" />
+            <circle cx="12" cy="13" r="4" />
+          </svg>
+          <span>Take or upload {label.toLowerCase()} photo</span>
+          <span className="insurance-form__photo-hint">
+            PNG, JPEG, or WebP. Max 5MB.
+          </span>
+        </label>
+      )}
+      <input
+        ref={inputRef}
+        id={inputId}
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        capture="environment"
+        onChange={onChange}
+        className="insurance-form__photo-input"
+      />
+    </div>
+  );
+}

--- a/app/insurance/[id]/show/layout.tsx
+++ b/app/insurance/[id]/show/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function ShowInsuranceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/insurance/[id]/show/page.tsx
+++ b/app/insurance/[id]/show/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+
+interface InsuranceCard {
+  id: string;
+  provider_name: string;
+  plan_type: string | null;
+  member_id: string | null;
+  group_number: string | null;
+  policy_holder_name: string | null;
+  customer_service_phone: string | null;
+  is_primary: boolean;
+  front_photo_path: string | null;
+  back_photo_path: string | null;
+}
+
+export default function InsuranceShowPage() {
+  const router = useRouter();
+  const params = useParams();
+  const cardId = params.id as string;
+
+  const [card, setCard] = useState<InsuranceCard | null>(null);
+  const [frontUrl, setFrontUrl] = useState<string | null>(null);
+  const [backUrl, setBackUrl] = useState<string | null>(null);
+  const [showingBack, setShowingBack] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/insurance-cards/${cardId}`);
+      if (!res.ok) throw new Error("Insurance card not found");
+      const { insurance_card } = await res.json();
+      setCard(insurance_card);
+
+      if (insurance_card.front_photo_path || insurance_card.back_photo_path) {
+        const urlRes = await fetch(`/api/insurance-cards/${cardId}/photo-url`);
+        if (urlRes.ok) {
+          const urlData = await urlRes.json();
+          setFrontUrl(urlData.front_url ?? null);
+          setBackUrl(urlData.back_url ?? null);
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load card");
+    } finally {
+      setLoading(false);
+    }
+  }, [cardId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="insurance-show insurance-show--loading">
+        <div className="insurance-show__spinner" aria-label="Loading insurance card" />
+        <p>Loading card...</p>
+      </div>
+    );
+  }
+
+  if (error || !card) {
+    return (
+      <div className="insurance-show insurance-show--error">
+        <p>{error || "Insurance card not found"}</p>
+        <button onClick={() => router.push("/insurance")}>Back to cards</button>
+      </div>
+    );
+  }
+
+  const currentUrl = showingBack ? backUrl : frontUrl;
+  const canFlip = Boolean(backUrl);
+
+  return (
+    <div className="insurance-show">
+      <header className="insurance-show__header">
+        <Link href="/insurance" className="insurance-show__back">
+          {"< Back"}
+        </Link>
+        <div className="insurance-show__title">
+          <h1>{card.provider_name}</h1>
+          <span
+            className={`insurance-show__badge insurance-show__badge--${
+              card.is_primary ? "primary" : "secondary"
+            }`}
+          >
+            {card.is_primary ? "Primary" : "Secondary"}
+          </span>
+        </div>
+      </header>
+
+      <div className="insurance-show__photo-wrapper">
+        {currentUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={currentUrl}
+            alt={`${card.provider_name} card ${showingBack ? "back" : "front"}`}
+            className="insurance-show__photo"
+            onClick={() => canFlip && setShowingBack(!showingBack)}
+          />
+        ) : (
+          <div className="insurance-show__photo-missing">
+            <p>No {showingBack ? "back" : "front"} photo uploaded.</p>
+          </div>
+        )}
+        {canFlip && (
+          <button
+            type="button"
+            className="insurance-show__flip-btn"
+            onClick={() => setShowingBack(!showingBack)}
+          >
+            {showingBack ? "Show Front" : "Show Back"}
+          </button>
+        )}
+      </div>
+
+      <div className="insurance-show__info">
+        {card.plan_type && (
+          <div className="insurance-show__info-row">
+            <span className="insurance-show__info-label">Plan</span>
+            <span className="insurance-show__info-value">{card.plan_type}</span>
+          </div>
+        )}
+        {card.member_id && (
+          <div className="insurance-show__info-row">
+            <span className="insurance-show__info-label">Member ID</span>
+            <span className="insurance-show__info-value insurance-show__info-value--big">
+              {card.member_id}
+            </span>
+          </div>
+        )}
+        {card.group_number && (
+          <div className="insurance-show__info-row">
+            <span className="insurance-show__info-label">Group</span>
+            <span className="insurance-show__info-value insurance-show__info-value--big">
+              {card.group_number}
+            </span>
+          </div>
+        )}
+        {card.policy_holder_name && (
+          <div className="insurance-show__info-row">
+            <span className="insurance-show__info-label">Policy Holder</span>
+            <span className="insurance-show__info-value">
+              {card.policy_holder_name}
+            </span>
+          </div>
+        )}
+        {card.customer_service_phone && (
+          <div className="insurance-show__info-row">
+            <span className="insurance-show__info-label">Customer Service</span>
+            <span className="insurance-show__info-value">
+              {card.customer_service_phone}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/insurance/add/layout.tsx
+++ b/app/insurance/add/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function AddInsuranceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/insurance/add/page.tsx
+++ b/app/insurance/add/page.tsx
@@ -1,0 +1,478 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import NavHeader from "@/components/ui/NavHeader";
+
+interface FamilyMember {
+  id: string;
+  display_name: string;
+}
+
+export default function AddInsuranceCardPage() {
+  const router = useRouter();
+  const frontInputRef = useRef<HTMLInputElement>(null);
+  const backInputRef = useRef<HTMLInputElement>(null);
+
+  const [familyMembers, setFamilyMembers] = useState<FamilyMember[]>([]);
+  const [providerName, setProviderName] = useState("");
+  const [planType, setPlanType] = useState("");
+  const [memberId, setMemberId] = useState("");
+  const [groupNumber, setGroupNumber] = useState("");
+  const [rxBin, setRxBin] = useState("");
+  const [rxPcn, setRxPcn] = useState("");
+  const [rxGroup, setRxGroup] = useState("");
+  const [policyHolderName, setPolicyHolderName] = useState("");
+  const [effectiveDate, setEffectiveDate] = useState("");
+  const [phone, setPhone] = useState("");
+  const [notes, setNotes] = useState("");
+  const [familyMemberId, setFamilyMemberId] = useState("");
+  const [isPrimary, setIsPrimary] = useState(true);
+  const [frontFile, setFrontFile] = useState<File | null>(null);
+  const [backFile, setBackFile] = useState<File | null>(null);
+  const [frontPreview, setFrontPreview] = useState<string | null>(null);
+  const [backPreview, setBackPreview] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchFamilyMembers = useCallback(async () => {
+    try {
+      const response = await fetch("/api/family-members");
+      if (!response.ok) return;
+      const data = await response.json();
+      setFamilyMembers(data.family_members || []);
+    } catch {
+      // Silent
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchFamilyMembers();
+  }, [fetchFamilyMembers]);
+
+  const validatePhoto = (file: File): string | null => {
+    const allowedTypes = ["image/png", "image/jpeg", "image/webp"];
+    if (!allowedTypes.includes(file.type)) {
+      return "Invalid file type. Accepted: PNG, JPEG, WebP";
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      return "File too large. Maximum size is 5MB";
+    }
+    return null;
+  };
+
+  const handlePhotoChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    side: "front" | "back"
+  ) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const err = validatePhoto(file);
+    if (err) {
+      setError(err);
+      return;
+    }
+    setError(null);
+    if (side === "front") {
+      setFrontFile(file);
+    } else {
+      setBackFile(file);
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (side === "front") {
+        setFrontPreview(reader.result as string);
+      } else {
+        setBackPreview(reader.result as string);
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemovePhoto = (side: "front" | "back") => {
+    if (side === "front") {
+      setFrontFile(null);
+      setFrontPreview(null);
+      if (frontInputRef.current) frontInputRef.current.value = "";
+    } else {
+      setBackFile(null);
+      setBackPreview(null);
+      if (backInputRef.current) backInputRef.current.value = "";
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!providerName.trim()) {
+      setError("Provider name is required");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/insurance-cards", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider_name: providerName.trim(),
+          plan_type: planType.trim() || null,
+          member_id: memberId.trim() || null,
+          group_number: groupNumber.trim() || null,
+          rx_bin: rxBin.trim() || null,
+          rx_pcn: rxPcn.trim() || null,
+          rx_group: rxGroup.trim() || null,
+          policy_holder_name: policyHolderName.trim() || null,
+          effective_date: effectiveDate || null,
+          customer_service_phone: phone.trim() || null,
+          notes: notes.trim() || null,
+          family_member_id: familyMemberId || null,
+          is_primary: isPrimary,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        throw new Error(data.error || "Failed to create insurance card");
+      }
+
+      const { insurance_card } = await response.json();
+
+      // Upload photos if provided
+      const uploadPromises: Promise<unknown>[] = [];
+      if (frontFile && insurance_card.id) {
+        const fd = new FormData();
+        fd.append("file", frontFile);
+        fd.append("side", "front");
+        uploadPromises.push(
+          fetch(`/api/insurance-cards/${insurance_card.id}/photo`, {
+            method: "POST",
+            body: fd,
+          })
+        );
+      }
+      if (backFile && insurance_card.id) {
+        const fd = new FormData();
+        fd.append("file", backFile);
+        fd.append("side", "back");
+        uploadPromises.push(
+          fetch(`/api/insurance-cards/${insurance_card.id}/photo`, {
+            method: "POST",
+            body: fd,
+          })
+        );
+      }
+      await Promise.all(uploadPromises);
+
+      router.push("/insurance");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to create insurance card"
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="insurance-page">
+      <div className="insurance-page__header">
+        <NavHeader backHref="/insurance" backLabel="Insurance" />
+        <h1>Add Insurance Card</h1>
+      </div>
+
+      {error && (
+        <div className="insurance-page__error" role="alert">
+          {error}
+          <button
+            onClick={() => setError(null)}
+            className="insurance-page__dismiss"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="insurance-form">
+        <div className="insurance-form__field">
+          <label htmlFor="ic-provider">
+            Provider Name <span className="insurance-form__required">*</span>
+          </label>
+          <input
+            id="ic-provider"
+            type="text"
+            value={providerName}
+            onChange={(e) => setProviderName(e.target.value)}
+            placeholder="e.g., Blue Cross Blue Shield"
+            maxLength={200}
+            required
+          />
+        </div>
+
+        <div className="insurance-form__row">
+          <div className="insurance-form__field">
+            <label htmlFor="ic-plan-type">Plan Type</label>
+            <input
+              id="ic-plan-type"
+              type="text"
+              value={planType}
+              onChange={(e) => setPlanType(e.target.value)}
+              placeholder="e.g., PPO, HMO, Medicare Part B"
+              maxLength={100}
+            />
+          </div>
+          <div className="insurance-form__field">
+            <label htmlFor="ic-member-id">Member ID</label>
+            <input
+              id="ic-member-id"
+              type="text"
+              value={memberId}
+              onChange={(e) => setMemberId(e.target.value)}
+              placeholder="Member ID"
+              maxLength={100}
+            />
+          </div>
+        </div>
+
+        <div className="insurance-form__row">
+          <div className="insurance-form__field">
+            <label htmlFor="ic-group">Group Number</label>
+            <input
+              id="ic-group"
+              type="text"
+              value={groupNumber}
+              onChange={(e) => setGroupNumber(e.target.value)}
+              maxLength={100}
+            />
+          </div>
+          <div className="insurance-form__field">
+            <label htmlFor="ic-policy-holder">Policy Holder Name</label>
+            <input
+              id="ic-policy-holder"
+              type="text"
+              value={policyHolderName}
+              onChange={(e) => setPolicyHolderName(e.target.value)}
+              placeholder="If not yourself"
+              maxLength={200}
+            />
+          </div>
+        </div>
+
+        <fieldset className="insurance-form__fieldset">
+          <legend>Pharmacy / RX (optional)</legend>
+          <div className="insurance-form__row">
+            <div className="insurance-form__field">
+              <label htmlFor="ic-rxbin">RX BIN</label>
+              <input
+                id="ic-rxbin"
+                type="text"
+                value={rxBin}
+                onChange={(e) => setRxBin(e.target.value)}
+                maxLength={50}
+              />
+            </div>
+            <div className="insurance-form__field">
+              <label htmlFor="ic-rxpcn">RX PCN</label>
+              <input
+                id="ic-rxpcn"
+                type="text"
+                value={rxPcn}
+                onChange={(e) => setRxPcn(e.target.value)}
+                maxLength={50}
+              />
+            </div>
+            <div className="insurance-form__field">
+              <label htmlFor="ic-rxgroup">RX Group</label>
+              <input
+                id="ic-rxgroup"
+                type="text"
+                value={rxGroup}
+                onChange={(e) => setRxGroup(e.target.value)}
+                maxLength={50}
+              />
+            </div>
+          </div>
+        </fieldset>
+
+        <div className="insurance-form__row">
+          <div className="insurance-form__field">
+            <label htmlFor="ic-effective">Effective Date</label>
+            <input
+              id="ic-effective"
+              type="date"
+              value={effectiveDate}
+              onChange={(e) => setEffectiveDate(e.target.value)}
+            />
+          </div>
+          <div className="insurance-form__field">
+            <label htmlFor="ic-phone">Customer Service Phone</label>
+            <input
+              id="ic-phone"
+              type="tel"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              placeholder="1-800-555-0100"
+              maxLength={50}
+            />
+          </div>
+        </div>
+
+        {familyMembers.length > 0 && (
+          <div className="insurance-form__field">
+            <label htmlFor="ic-family">For</label>
+            <select
+              id="ic-family"
+              value={familyMemberId}
+              onChange={(e) => setFamilyMemberId(e.target.value)}
+            >
+              <option value="">Myself</option>
+              {familyMembers.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.display_name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div className="insurance-form__field">
+          <label>Primary or Secondary</label>
+          <div className="insurance-form__radio-group">
+            <label className="insurance-form__radio">
+              <input
+                type="radio"
+                name="is_primary"
+                checked={isPrimary}
+                onChange={() => setIsPrimary(true)}
+              />
+              <span>Primary</span>
+            </label>
+            <label className="insurance-form__radio">
+              <input
+                type="radio"
+                name="is_primary"
+                checked={!isPrimary}
+                onChange={() => setIsPrimary(false)}
+              />
+              <span>Secondary</span>
+            </label>
+          </div>
+        </div>
+
+        <div className="insurance-form__field">
+          <label htmlFor="ic-notes">Notes</label>
+          <textarea
+            id="ic-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="Any additional notes..."
+            maxLength={2000}
+            rows={3}
+          />
+        </div>
+
+        <div className="insurance-form__field">
+          <label>Card Photos</label>
+          <div className="insurance-form__photo-upload">
+            <PhotoUploadBox
+              side="front"
+              preview={frontPreview}
+              inputRef={frontInputRef}
+              onChange={(e) => handlePhotoChange(e, "front")}
+              onRemove={() => handleRemovePhoto("front")}
+            />
+            <PhotoUploadBox
+              side="back"
+              preview={backPreview}
+              inputRef={backInputRef}
+              onChange={(e) => handlePhotoChange(e, "back")}
+              onRemove={() => handleRemovePhoto("back")}
+            />
+          </div>
+        </div>
+
+        <div className="insurance-form__actions">
+          <button
+            type="button"
+            onClick={() => router.push("/insurance")}
+            className="insurance-form__cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="insurance-form__submit"
+            disabled={saving}
+          >
+            {saving ? "Saving..." : "Add Insurance Card"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function PhotoUploadBox({
+  side,
+  preview,
+  inputRef,
+  onChange,
+  onRemove,
+}: {
+  side: "front" | "back";
+  preview: string | null;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onRemove: () => void;
+}) {
+  const inputId = `ic-photo-${side}`;
+  const label = side === "front" ? "Front" : "Back";
+  return (
+    <div className="insurance-form__photo-box">
+      <span className="insurance-form__photo-title">{label}</span>
+      {preview ? (
+        <div className="insurance-form__photo-preview">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={preview} alt={`Insurance card ${label.toLowerCase()} preview`} />
+          <button
+            type="button"
+            onClick={onRemove}
+            className="insurance-form__photo-remove"
+          >
+            Remove
+          </button>
+        </div>
+      ) : (
+        <label htmlFor={inputId} className="insurance-form__photo-label">
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M23 19a2 2 0 01-2 2H3a2 2 0 01-2-2V8a2 2 0 012-2h4l2-3h6l2 3h4a2 2 0 012 2z" />
+            <circle cx="12" cy="13" r="4" />
+          </svg>
+          <span>Take or upload {label.toLowerCase()} photo</span>
+          <span className="insurance-form__photo-hint">
+            PNG, JPEG, or WebP. Max 5MB.
+          </span>
+        </label>
+      )}
+      <input
+        ref={inputRef}
+        id={inputId}
+        type="file"
+        accept="image/png,image/jpeg,image/webp"
+        capture="environment"
+        onChange={onChange}
+        className="insurance-form__photo-input"
+      />
+    </div>
+  );
+}

--- a/app/insurance/layout.tsx
+++ b/app/insurance/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function InsuranceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/insurance/page.tsx
+++ b/app/insurance/page.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import NavHeader from "@/components/ui/NavHeader";
+
+interface InsuranceCard {
+  id: string;
+  family_member_id: string | null;
+  provider_name: string;
+  plan_type: string | null;
+  member_id: string | null;
+  group_number: string | null;
+  rx_bin: string | null;
+  rx_pcn: string | null;
+  rx_group: string | null;
+  policy_holder_name: string | null;
+  effective_date: string | null;
+  customer_service_phone: string | null;
+  notes: string | null;
+  front_photo_path: string | null;
+  back_photo_path: string | null;
+  is_primary: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface FamilyMember {
+  id: string;
+  display_name: string;
+}
+
+export default function InsuranceCardsPage() {
+  const [cards, setCards] = useState<InsuranceCard[]>([]);
+  const [familyMembers, setFamilyMembers] = useState<FamilyMember[]>([]);
+  const [activeFilter, setActiveFilter] = useState<string>("self");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [photoUrls, setPhotoUrls] = useState<Record<string, string | null>>({});
+
+  const fetchFamilyMembers = useCallback(async () => {
+    try {
+      const response = await fetch("/api/family-members");
+      if (!response.ok) return;
+      const data = await response.json();
+      setFamilyMembers(data.family_members || []);
+    } catch {
+      // Silent — family members are optional
+    }
+  }, []);
+
+  const fetchCards = useCallback(async () => {
+    setLoading(true);
+    try {
+      const url =
+        activeFilter === "self"
+          ? "/api/insurance-cards"
+          : `/api/insurance-cards?family_member_id=${activeFilter}`;
+      const response = await fetch(url);
+      if (!response.ok) throw new Error("Failed to load insurance cards");
+      const data = await response.json();
+      const loadedCards: InsuranceCard[] = data.insurance_cards || [];
+      setCards(loadedCards);
+
+      // Fetch signed URLs for front photos in parallel
+      const urlMap: Record<string, string | null> = {};
+      await Promise.all(
+        loadedCards.map(async (card) => {
+          if (card.front_photo_path) {
+            try {
+              const res = await fetch(`/api/insurance-cards/${card.id}/photo-url`);
+              if (res.ok) {
+                const json = await res.json();
+                urlMap[card.id] = json.front_url ?? null;
+              }
+            } catch {
+              urlMap[card.id] = null;
+            }
+          }
+        })
+      );
+      setPhotoUrls(urlMap);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load cards");
+    } finally {
+      setLoading(false);
+    }
+  }, [activeFilter]);
+
+  useEffect(() => {
+    fetchFamilyMembers();
+  }, [fetchFamilyMembers]);
+
+  useEffect(() => {
+    fetchCards();
+  }, [fetchCards]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      const response = await fetch(`/api/insurance-cards/${id}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) throw new Error("Failed to delete insurance card");
+      setDeleteConfirm(null);
+      await fetchCards();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete");
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="insurance-page insurance-page--loading">
+        <div className="insurance-page__spinner" aria-label="Loading insurance cards" />
+        <p>Loading your insurance cards...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="insurance-page">
+      <div className="insurance-page__header">
+        <NavHeader backLabel="Dashboard" />
+        <div className="insurance-page__title-row">
+          <div>
+            <h1>Insurance Cards</h1>
+            <p>Keep your insurance info on hand for every doctor visit.</p>
+          </div>
+          <Link href="/insurance/add" className="insurance-page__add-btn">
+            + Add Insurance Card
+          </Link>
+        </div>
+      </div>
+
+      {familyMembers.length > 0 && (
+        <div className="insurance-page__filter">
+          <label htmlFor="family-filter">Show cards for:</label>
+          <select
+            id="family-filter"
+            value={activeFilter}
+            onChange={(e) => setActiveFilter(e.target.value)}
+          >
+            <option value="self">Myself</option>
+            {familyMembers.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.display_name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {error && (
+        <div className="insurance-page__error" role="alert">
+          {error}
+          <button
+            onClick={() => setError(null)}
+            className="insurance-page__dismiss"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {cards.length === 0 ? (
+        <div className="insurance-page__empty">
+          <svg
+            width="48"
+            height="48"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--color-gray-400)"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="2" y="5" width="20" height="14" rx="2" />
+            <line x1="2" y1="10" x2="22" y2="10" />
+          </svg>
+          <h2>No insurance cards yet</h2>
+          <p>
+            Add your first insurance card so you always have it when you need
+            it.
+          </p>
+          <Link href="/insurance/add" className="insurance-page__add-btn">
+            + Add Insurance Card
+          </Link>
+        </div>
+      ) : (
+        <div className="insurance-page__list">
+          {cards.map((card) => (
+            <InsuranceCardItem
+              key={card.id}
+              card={card}
+              frontUrl={photoUrls[card.id] ?? null}
+              onDelete={() => setDeleteConfirm(card.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {deleteConfirm && (
+        <div
+          className="insurance-page__overlay"
+          onClick={() => setDeleteConfirm(null)}
+        >
+          <div
+            className="insurance-page__dialog"
+            role="alertdialog"
+            aria-labelledby="ic-delete-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="ic-delete-title">Delete Insurance Card?</h3>
+            <p>
+              This will permanently remove this insurance card and its photos.
+              This cannot be undone.
+            </p>
+            <div className="insurance-page__dialog-actions">
+              <button
+                onClick={() => setDeleteConfirm(null)}
+                className="insurance-page__dialog-cancel"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => handleDelete(deleteConfirm)}
+                className="insurance-page__dialog-delete"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function InsuranceCardItem({
+  card,
+  frontUrl,
+  onDelete,
+}: {
+  card: InsuranceCard;
+  frontUrl: string | null;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="insurance-card">
+      <div className="insurance-card__photo">
+        {frontUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={frontUrl} alt={`${card.provider_name} card front`} />
+        ) : (
+          <div className="insurance-card__photo-placeholder">
+            <svg
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <rect x="2" y="5" width="20" height="14" rx="2" />
+              <line x1="2" y1="10" x2="22" y2="10" />
+            </svg>
+            <span>No photo</span>
+          </div>
+        )}
+      </div>
+      <div className="insurance-card__info">
+        <div className="insurance-card__header-row">
+          <h3 className="insurance-card__provider">{card.provider_name}</h3>
+          <span
+            className={`insurance-card__badge insurance-card__badge--${
+              card.is_primary ? "primary" : "secondary"
+            }`}
+          >
+            {card.is_primary ? "Primary" : "Secondary"}
+          </span>
+        </div>
+        {card.plan_type && (
+          <p className="insurance-card__plan">{card.plan_type}</p>
+        )}
+        {card.member_id && (
+          <p className="insurance-card__detail">
+            <span className="insurance-card__label">Member ID</span>
+            <span className="insurance-card__value">{card.member_id}</span>
+          </p>
+        )}
+        {card.group_number && (
+          <p className="insurance-card__detail">
+            <span className="insurance-card__label">Group</span>
+            <span className="insurance-card__value">{card.group_number}</span>
+          </p>
+        )}
+        <div className="insurance-card__actions">
+          <Link
+            href={`/insurance/${card.id}/show`}
+            className="insurance-card__action insurance-card__action--primary"
+          >
+            Quick Show
+          </Link>
+          <Link
+            href={`/insurance/${card.id}/edit`}
+            className="insurance-card__action"
+          >
+            Edit
+          </Link>
+          <button
+            onClick={onDelete}
+            className="insurance-card__action insurance-card__action--danger"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/NavHeader.tsx
+++ b/components/ui/NavHeader.tsx
@@ -72,6 +72,9 @@ export default function NavHeader({
         <Link href="/medications" className={linkClass("/medications")}>
           Medications
         </Link>
+        <Link href="/insurance" className={linkClass("/insurance")}>
+          Insurance
+        </Link>
         <Link href="/family" className={linkClass("/family")}>
           Family
         </Link>

--- a/lib/audit/logger.ts
+++ b/lib/audit/logger.ts
@@ -14,9 +14,20 @@ export type AuditAction =
   | "medication.update"
   | "medication.delete"
   | "medication.photo_upload"
-  | "medication.photo_delete";
+  | "medication.photo_delete"
+  | "insurance_card.create"
+  | "insurance_card.update"
+  | "insurance_card.delete"
+  | "insurance_card.view"
+  | "insurance_card.photo_upload"
+  | "insurance_card.photo_delete";
 
-export type AuditResourceType = "report" | "chat_session" | "parsed_result" | "medication";
+export type AuditResourceType =
+  | "report"
+  | "chat_session"
+  | "parsed_result"
+  | "medication"
+  | "insurance_card";
 
 interface AuditEvent {
   userId: string;

--- a/supabase/migrations/018_insurance_cards.sql
+++ b/supabase/migrations/018_insurance_cards.sql
@@ -1,0 +1,41 @@
+-- Migration: Insurance cards storage
+-- Ticket: #167 — Insurance card storage with photo upload and details
+--
+-- Creates the insurance_cards table for storing insurance provider details and
+-- photo references. Photos themselves live in the `insurance-photos` private
+-- storage bucket (see 019_insurance_photos_bucket.sql).
+--
+-- Insurance data is sensitive PII/PHI — RLS is enforced so users can only
+-- access their own cards. Photos use per-user folder scoping in storage.
+
+CREATE TABLE insurance_cards (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  family_member_id uuid REFERENCES family_members(id) ON DELETE SET NULL,
+  provider_name text NOT NULL,
+  plan_type text,
+  member_id text,
+  group_number text,
+  rx_bin text,
+  rx_pcn text,
+  rx_group text,
+  policy_holder_name text,
+  effective_date date,
+  customer_service_phone text,
+  notes text,
+  front_photo_path text,
+  back_photo_path text,
+  is_primary boolean NOT NULL DEFAULT true,
+  created_at timestamptz DEFAULT now() NOT NULL,
+  updated_at timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE INDEX idx_insurance_cards_user_id ON insurance_cards(user_id);
+CREATE INDEX idx_insurance_cards_family_member_id ON insurance_cards(family_member_id);
+
+ALTER TABLE insurance_cards ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can manage own insurance cards"
+  ON insurance_cards FOR ALL TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());

--- a/supabase/migrations/019_insurance_photos_bucket.sql
+++ b/supabase/migrations/019_insurance_photos_bucket.sql
@@ -1,0 +1,26 @@
+-- Migration: Private storage bucket for insurance card photos
+-- Ticket: #167 — Insurance card storage with photo upload and details
+--
+-- Insurance card photos are sensitive — stored in a PRIVATE bucket with
+-- per-user folder scoping enforced by RLS. Path format:
+--   insurance-photos/{userId}/{cardId}-{side}.{ext}
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('insurance-photos', 'insurance-photos', false, 5242880, ARRAY['image/png', 'image/jpeg', 'image/webp'])
+ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY "Users can upload own insurance photos"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'insurance-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "Users can read own insurance photos"
+  ON storage.objects FOR SELECT TO authenticated
+  USING (bucket_id = 'insurance-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "Users can update own insurance photos"
+  ON storage.objects FOR UPDATE TO authenticated
+  USING (bucket_id = 'insurance-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "Users can delete own insurance photos"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (bucket_id = 'insurance-photos' AND (storage.foldername(name))[1] = auth.uid()::text);


### PR DESCRIPTION
## Summary

Closes #167 — Insurance card storage with photo upload and details.

Users can now store their insurance cards in HealthChat AI and pull them up instantly at any doctor visit, even when they've left the physical card at home.

- **Database**: new `insurance_cards` table (provider, plan type, member/group IDs, RX BIN/PCN/Group, policy holder, effective date, customer service phone, notes, front/back photo paths, primary/secondary flag) with RLS scoped per user and optional `family_member_id` linkage. Private `insurance-photos` storage bucket with per-user folder RLS.
- **API**: `GET/POST /api/insurance-cards`, `GET/PUT/DELETE /api/insurance-cards/[id]`, `POST/DELETE /api/insurance-cards/[id]/photo` (front/back side), and `GET /api/insurance-cards/[id]/photo-url` returning short-lived 5-minute signed URLs so the private bucket can be rendered client-side. Photo upload validates magic bytes, MIME type, and enforces a 5MB size cap.
- **Pages**: list (`/insurance`), add (`/insurance/add`), edit (`/insurance/[id]/edit`), and the full-screen **Quick Show** page (`/insurance/[id]/show`) — tap the photo to flip between front and back, with member ID and group displayed in large text for check-in desks. All routes are `force-dynamic`.
- **Navigation**: Insurance link added to `NavHeader` and the dashboard header nav, plus an Insurance quick-action tile in the dashboard grid.
- **Audit**: logger extended with `insurance_card.*` actions for HIPAA tracking on create/update/delete/view/photo.
- **Tests**: 20 new tests covering CRUD, auth gates, family-member scoping, photo upload handler, photo-url handler, and page component exports.

## Test plan

- [x] `npm run lint` — 0 errors (only pre-existing img warnings)
- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 912/912 tests passing (20 new)
- [ ] Apply migrations 018 and 019 to the Supabase branch and verify RLS blocks cross-user access
- [ ] Smoke: add insurance card with front + back photo, edit it, open Quick Show, flip the card, delete it
- [ ] Smoke: filter by family member on the list page
- [ ] Smoke: confirm dashboard quick-action and header nav link navigate to `/insurance`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>