### PR TITLE
fix(build): wrap useSearchParams in Suspense boundaries

### DIFF
--- a/app/family/add/page.tsx
+++ b/app/family/add/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import NavHeader from "@/components/ui/NavHeader";
 
@@ -14,6 +14,14 @@ const RELATIONSHIPS = [
 ];
 
 export default function AddFamilyMemberPage() {
+  return (
+    <Suspense fallback={<div className="family-page">Loading...</div>}>
+      <AddFamilyMemberForm />
+    </Suspense>
+  );
+}
+
+function AddFamilyMemberForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const editId = searchParams.get("edit");

--- a/app/glossary/page.tsx
+++ b/app/glossary/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import NavHeader from "@/components/ui/NavHeader";
@@ -23,6 +23,14 @@ const CATEGORY_ORDER: GlossaryEntry["category"][] = [
 ];
 
 export default function GlossaryPage() {
+  return (
+    <Suspense fallback={<div className="glossary-page">Loading...</div>}>
+      <GlossaryContent />
+    </Suspense>
+  );
+}
+
+function GlossaryContent() {
   const searchParams = useSearchParams();
   const initialQuery = searchParams.get("q") ?? "";
   const [query, setQuery] = useState(initialQuery);

--- a/app/reports/compare/page.tsx
+++ b/app/reports/compare/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import NavHeader from "@/components/ui/NavHeader";
@@ -58,6 +58,14 @@ function getDateFilterCutoff(filter: DateFilter): Date | null {
 }
 
 export default function ComparePage() {
+  return (
+    <Suspense fallback={<div className="compare-page">Loading...</div>}>
+      <CompareContent />
+    </Suspense>
+  );
+}
+
+function CompareContent() {
   const searchParams = useSearchParams();
 
   const [reports, setReports] = useState<Report[]>([]);


### PR DESCRIPTION
## Summary
Deploy was failing with "Error occurred prerendering page /family/add" because Next.js 15 requires \`useSearchParams()\` to be wrapped in a Suspense boundary.

Fixed 3 pages that use useSearchParams without Suspense:
- /family/add
- /glossary
- /reports/compare

## Test plan
- [x] \`npm run build\` succeeds locally
- [x] All 932 tests pass
- [ ] Render deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)