### PR TITLE
fix(lint): markdownlint error in SKILL.md

### DIFF
--- a/.claude/skills/ui-ux-pro-max/SKILL.md
+++ b/.claude/skills/ui-ux-pro-max/SKILL.md
@@ -90,7 +90,6 @@ Search specific domains using the CLI tool below.
 
 ---
 
-
 ## Prerequisites
 
 Check if Python is installed:


### PR DESCRIPTION
Removes double blank line on line 93 of .claude/skills/ui-ux-pro-max/SKILL.md to fix failing CI.