### PR TITLE
feat(clinical-summary): unify report summary with chat conversations

### DIFF
--- a/__tests__/report-clinical-summary.test.ts
+++ b/__tests__/report-clinical-summary.test.ts
@@ -86,6 +86,92 @@ describe("Report Clinical Summary Export (#151)", () => {
         "a doctor should read this in 3 minutes"
       );
     });
+
+    it("includes conditional PATIENT CONCERNS DISCUSSED section for chat", () => {
+      expect(REPORT_SUMMARY_SYSTEM_PROMPT).toContain(
+        "PATIENT CONCERNS DISCUSSED"
+      );
+    });
+
+    it("includes DISCUSSION POINTS FROM CHAT section", () => {
+      expect(REPORT_SUMMARY_SYSTEM_PROMPT).toContain(
+        "DISCUSSION POINTS FROM CHAT"
+      );
+    });
+
+    it("includes QUESTIONS PATIENT WANTS TO ASK DOCTOR section", () => {
+      expect(REPORT_SUMMARY_SYSTEM_PROMPT).toContain(
+        "QUESTIONS PATIENT WANTS TO ASK DOCTOR"
+      );
+    });
+
+    it("instructs to focus on lab data only when no chat exists", () => {
+      expect(REPORT_SUMMARY_SYSTEM_PROMPT).toContain(
+        "omit the \"PATIENT CONCERNS DISCUSSED\" and \"DISCUSSION POINTS FROM CHAT\" sections entirely"
+      );
+    });
+
+    it("prohibits quoting chat messages verbatim", () => {
+      expect(REPORT_SUMMARY_SYSTEM_PROMPT).toContain(
+        "Do NOT"
+      );
+      expect(REPORT_SUMMARY_SYSTEM_PROMPT).toContain(
+        "summarize them"
+      );
+    });
+  });
+
+  describe("API route chat integration", () => {
+    const routeSrc = fs.readFileSync(
+      path.resolve(
+        process.cwd(),
+        "app/api/reports/[id]/clinical-summary/route.ts"
+      ),
+      "utf-8"
+    );
+
+    it("loads chat_sessions filtered by report_id and user_id", () => {
+      expect(routeSrc).toContain('.from("chat_sessions")');
+      expect(routeSrc).toContain('.eq("report_id", reportId)');
+      expect(routeSrc).toContain('.eq("user_id", user.id)');
+    });
+
+    it("loads chat_messages for the discovered sessions", () => {
+      expect(routeSrc).toContain('.from("chat_messages")');
+      expect(routeSrc).toContain('.in("session_id"');
+    });
+
+    it("only appends chat context when sessions exist", () => {
+      // Guard clause ensures empty sessions list does not break the API
+      expect(routeSrc).toMatch(
+        /chatSessions && chatSessions\.length > 0/
+      );
+    });
+
+    it("only appends chat context when messages exist", () => {
+      // Guard clause ensures sessions without any messages do not break the API
+      expect(routeSrc).toMatch(/messages && messages\.length > 0/);
+    });
+
+    it("passes chat context to Claude via the user message", () => {
+      expect(routeSrc).toContain("chatContext");
+      expect(routeSrc).toContain("userMessage");
+    });
+
+    it("labels chat turns as Patient / AI Assistant (no internal IDs leaked)", () => {
+      expect(routeSrc).toContain('"Patient"');
+      expect(routeSrc).toContain('"AI Assistant"');
+      // Must not select or expose chat message IDs in the transcript
+      expect(routeSrc).not.toMatch(
+        /select\(\s*"[^"]*\bid\b[^"]*"\s*\)\s*\.in\("session_id"/
+      );
+    });
+
+    it("uses the PATIENT CHAT CONVERSATIONS header", () => {
+      expect(routeSrc).toContain(
+        "PATIENT CHAT CONVERSATIONS ABOUT THIS REPORT:"
+      );
+    });
   });
 
   describe("disclaimer", () => {

--- a/app/api/reports/[id]/clinical-summary/route.ts
+++ b/app/api/reports/[id]/clinical-summary/route.ts
@@ -160,10 +160,57 @@ HEALTH CREDIT SCORE: ${healthScore.score}/850 (${healthScore.label})
 Breakdown: ${healthScore.breakdown.green} normal, ${healthScore.breakdown.yellow} borderline, ${healthScore.breakdown.red} needs attention
 ${healthScore.topConcerns.length > 0 ? `Top concerns: ${healthScore.topConcerns.join(", ")}` : ""}`;
 
+  // Load chat conversations tied to this report so the summary can
+  // integrate patient-raised concerns alongside the raw lab data.
+  const { data: chatSessions } = await supabase
+    .from("chat_sessions")
+    .select("id, title, created_at")
+    .eq("user_id", user.id)
+    .eq("report_id", reportId)
+    .order("created_at", { ascending: false });
+
+  let chatContext = "";
+  if (chatSessions && chatSessions.length > 0) {
+    const sessionIds = chatSessions.map((s) => s.id);
+    const { data: messages } = await supabase
+      .from("chat_messages")
+      .select("session_id, role, content, created_at")
+      .in("session_id", sessionIds)
+      .order("created_at", { ascending: true });
+
+    if (messages && messages.length > 0) {
+      const lines: string[] = [
+        "",
+        "",
+        "PATIENT CHAT CONVERSATIONS ABOUT THIS REPORT:",
+      ];
+      for (const session of chatSessions) {
+        const sessionMsgs = messages.filter((m) => m.session_id === session.id);
+        if (sessionMsgs.length === 0) continue;
+        const dateLabel = new Date(session.created_at)
+          .toISOString()
+          .slice(0, 10);
+        lines.push("", `Session from ${dateLabel}:`);
+        for (const msg of sessionMsgs) {
+          const role = msg.role === "user" ? "Patient" : "AI Assistant";
+          lines.push(`${role}: ${msg.content}`);
+        }
+      }
+      // Only attach the block if at least one session actually had messages.
+      if (lines.length > 3) {
+        chatContext = lines.join("\n");
+      }
+    }
+  }
+
   let systemPrompt = REPORT_SUMMARY_SYSTEM_PROMPT;
   if (healthContext) {
     systemPrompt += `\n\n${healthContext}`;
   }
+
+  const userMessage = chatContext
+    ? `Here is the lab report to summarize:\n\n${reportBlock}${chatContext}`
+    : `Here is the lab report to summarize:\n\n${reportBlock}`;
 
   // Call Claude to generate the structured summary
   const claude = getClaudeClient();
@@ -176,7 +223,7 @@ ${healthScore.topConcerns.length > 0 ? `Top concerns: ${healthScore.topConcerns.
       messages: [
         {
           role: "user",
-          content: `Here is the lab report to summarize:\n\n${reportBlock}`,
+          content: userMessage,
         },
       ],
     });

--- a/lib/claude/summary-prompt.ts
+++ b/lib/claude/summary-prompt.ts
@@ -50,7 +50,7 @@ export const CLINICAL_SUMMARY_DISCLAIMER =
  * SOAP-style notes a doctor, caregiver, or family member can read in
  * a few minutes. Implements ticket #151.
  */
-export const REPORT_SUMMARY_SYSTEM_PROMPT = `You are a medical documentation assistant. Generate structured clinical summary notes from this patient's lab report. These notes will be shared with the patient's doctor, caregiver, or healthcare team.
+export const REPORT_SUMMARY_SYSTEM_PROMPT = `You are a medical documentation assistant. Generate structured clinical summary notes from this patient's lab report AND any chat conversations the patient had about that report. These unified notes will be shared with the patient's doctor, caregiver, or healthcare team.
 
 Format the output EXACTLY as follows (use these exact headings):
 
@@ -83,6 +83,16 @@ BORDERLINE VALUES
 NORMAL FINDINGS
 • Brief summary of green/normal biomarkers (just count by category)
 
+PATIENT CONCERNS DISCUSSED (only include if chat conversations exist)
+• Summarize what the patient asked about
+• What specific values or topics they focused on
+• Any personal context they shared (lifestyle, symptoms, family history)
+
+DISCUSSION POINTS FROM CHAT (only include if chat conversations exist)
+• Key explanations provided to the patient
+• Lifestyle recommendations discussed
+• Actions the patient was encouraged to take
+
 RECOMMENDED FOLLOW-UP TESTS
 • Based on flagged values, list 3-5 specific tests that would provide more context
 • Include why each test matters
@@ -94,10 +104,17 @@ SUGGESTED DISCUSSION POINTS WITH PROVIDER
 4. Follow-up timeline recommendations
 5. Any family history considerations
 
+QUESTIONS PATIENT WANTS TO ASK DOCTOR
+• Generate 3-5 questions based on BOTH the lab data AND the chat conversation
+• Prioritize concerns the patient explicitly raised in chat
+• If no chat exists, derive questions from the lab data alone
+
 PATIENT'S HEALTH CREDIT SCORE
 • Include score (300-850) and what it means
 
-Do NOT include raw biomarker JSON dumps. Format for readability.
+If chat conversations are provided, integrate insights from them into the clinical notes — connect patient-raised concerns to the corresponding lab values. If no chat conversations are provided, omit the "PATIENT CONCERNS DISCUSSED" and "DISCUSSION POINTS FROM CHAT" sections entirely and focus only on the lab data.
+
+Do NOT include raw biomarker JSON dumps. Do NOT quote chat messages verbatim — summarize them. Format for readability.
 Write in third person ("Patient has..." not "You have...").
 Keep it concise — a doctor should read this in 3 minutes.
 Use professional medical documentation style but avoid complex jargon.`;


### PR DESCRIPTION
## Summary
- Extends the report clinical summary API (`/api/reports/[id]/clinical-summary`) to also load any `chat_sessions` tied to the report and their messages, folding conversational context into the Claude prompt.
- Updates `REPORT_SUMMARY_SYSTEM_PROMPT` with conditional sections for patient concerns, discussion points, and doctor questions derived from chat context.
- Adds 10 new tests covering the prompt additions and API-level chat wiring.

## Details
When a patient has chatted with the AI about a specific report, those conversations are now included in the clinical summary generation. The resulting SOAP note is a unified export combining lab data + patient-raised concerns. When no chat sessions exist, the summary works exactly as before (lab data only).

### Files changed
- `lib/claude/summary-prompt.ts` — added PATIENT CONCERNS DISCUSSED, DISCUSSION POINTS FROM CHAT, QUESTIONS PATIENT WANTS TO ASK DOCTOR sections (conditional on chat presence)
- `app/api/reports/[id]/clinical-summary/route.ts` — loads chat_sessions + chat_messages for the report, builds chat context string, passes it to Claude
- `__tests__/report-clinical-summary.test.ts` — new tests for prompt sections and API chat integration

### Edge cases handled
- No chat sessions for the report (uses report data only)
- Chat sessions exist but have no messages (skipped cleanly)
- Message IDs and internal details are not exposed in the transcript

## Test plan
- [x] `npm run lint` passes (0 errors)
- [x] `npm run typecheck` passes
- [x] `npx vitest run` — all 965 tests pass (44 files)
- [x] Pre-push hook passes
- [ ] Manual: verify clinical summary with a report that has linked chat sessions
- [ ] Manual: verify clinical summary still works for reports with no chat history

Generated with [Claude Code](https://claude.com/claude-code)