### PR TITLE
feat(parse): few-shot example library for extraction accuracy (#135)

### DIFF
--- a/__tests__/few-shot-examples.test.ts
+++ b/__tests__/few-shot-examples.test.ts
@@ -1,0 +1,568 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  anonymizeExtraction,
+  type RawBiomarker,
+} from "@/lib/health/anonymize-extraction";
+import {
+  meetsQualityThreshold,
+} from "@/lib/health/example-library";
+import {
+  PARSE_REPORT_SYSTEM_PROMPT,
+  buildParsePrompt,
+} from "@/lib/claude/prompts";
+
+// ── Anonymization ─────────────────────────────────────────────────────
+
+describe("Anonymize extraction (#135)", () => {
+  const sampleBiomarkers: RawBiomarker[] = [
+    {
+      name: "Total Cholesterol",
+      value: 237,
+      unit: "mg/dL",
+      reference_low: null,
+      reference_high: 200,
+      flag: "red",
+      confidence: 0.95,
+    },
+    {
+      name: "LDL Cholesterol",
+      value: 162,
+      unit: "mg/dL",
+      reference_low: null,
+      reference_high: 100,
+      flag: "red",
+      confidence: 0.9,
+    },
+    {
+      name: "HDL Cholesterol",
+      value: 52,
+      unit: "mg/dL",
+      reference_low: 40,
+      reference_high: 60,
+      flag: "green",
+      confidence: 0.92,
+    },
+    {
+      name: "Glucose (Fasting)",
+      value: 98,
+      unit: "mg/dL",
+      reference_low: 70,
+      reference_high: 100,
+      flag: "green",
+      confidence: 0.88,
+    },
+  ];
+
+  it("replaces actual values with placeholder values", () => {
+    const result = anonymizeExtraction(sampleBiomarkers);
+
+    // Original Total Cholesterol was 237, but placeholder should differ
+    const totalChol = result.biomarkers.find(
+      (b) => b.name === "Total Cholesterol"
+    );
+    expect(totalChol).toBeDefined();
+    expect(totalChol!.value).not.toBe(237);
+    // Should be 75% of reference_high (200) = 150
+    expect(totalChol!.value).toBe(150);
+  });
+
+  it("preserves biomarker names exactly", () => {
+    const result = anonymizeExtraction(sampleBiomarkers);
+    const names = result.biomarkers.map((b) => b.name);
+    expect(names).toEqual([
+      "Total Cholesterol",
+      "LDL Cholesterol",
+      "HDL Cholesterol",
+      "Glucose (Fasting)",
+    ]);
+  });
+
+  it("preserves units exactly", () => {
+    const result = anonymizeExtraction(sampleBiomarkers);
+    for (const b of result.biomarkers) {
+      expect(b.unit).toBe("mg/dL");
+    }
+  });
+
+  it("preserves reference ranges", () => {
+    const result = anonymizeExtraction(sampleBiomarkers);
+
+    const hdl = result.biomarkers.find((b) => b.name === "HDL Cholesterol");
+    expect(hdl!.reference_low).toBe(40);
+    expect(hdl!.reference_high).toBe(60);
+
+    const totalChol = result.biomarkers.find(
+      (b) => b.name === "Total Cholesterol"
+    );
+    expect(totalChol!.reference_low).toBeNull();
+    expect(totalChol!.reference_high).toBe(200);
+  });
+
+  it("preserves biomarker count and order", () => {
+    const result = anonymizeExtraction(sampleBiomarkers);
+    expect(result.biomarkers).toHaveLength(4);
+    expect(result.biomarkers[0].name).toBe("Total Cholesterol");
+    expect(result.biomarkers[3].name).toBe("Glucose (Fasting)");
+  });
+
+  it("sets all flags to green (placeholder values are within range)", () => {
+    const result = anonymizeExtraction(sampleBiomarkers);
+    for (const b of result.biomarkers) {
+      expect(b.flag).toBe("green");
+    }
+  });
+
+  it("removes confidence scores", () => {
+    const result = anonymizeExtraction(sampleBiomarkers);
+    for (const b of result.biomarkers) {
+      expect(b).not.toHaveProperty("confidence");
+    }
+  });
+
+  it("generates placeholder using midpoint when both bounds exist", () => {
+    const result = anonymizeExtraction(sampleBiomarkers);
+    // HDL: low=40, high=60 => midpoint = 50
+    const hdl = result.biomarkers.find((b) => b.name === "HDL Cholesterol");
+    expect(hdl!.value).toBe(50);
+  });
+
+  it("generates placeholder using 75% of high bound when only high exists", () => {
+    const result = anonymizeExtraction(sampleBiomarkers);
+    // LDL: high=100, no low => 100 * 0.75 = 75
+    const ldl = result.biomarkers.find((b) => b.name === "LDL Cholesterol");
+    expect(ldl!.value).toBe(75);
+  });
+
+  it("generates placeholder using 125% of low bound when only low exists", () => {
+    const biomarkers: RawBiomarker[] = [
+      {
+        name: "Test Marker",
+        value: 55,
+        unit: "U/L",
+        reference_low: 10,
+        reference_high: null,
+        flag: "green",
+      },
+    ];
+    const result = anonymizeExtraction(biomarkers);
+    // low=10, no high => 10 * 1.25 = 12.5
+    expect(result.biomarkers[0].value).toBe(12.5);
+  });
+
+  it("rounds values when no reference range exists", () => {
+    const biomarkers: RawBiomarker[] = [
+      {
+        name: "Unknown Marker",
+        value: 147.3,
+        unit: "units",
+        reference_low: null,
+        reference_high: null,
+        flag: "unknown",
+      },
+    ];
+    const result = anonymizeExtraction(biomarkers);
+    // >= 100 => round to nearest 10 => 150
+    expect(result.biomarkers[0].value).toBe(150);
+  });
+
+  it("generates a descriptive summary without PHI", () => {
+    const result = anonymizeExtraction(sampleBiomarkers);
+    expect(result.summary).toContain("lipid panel");
+    expect(result.summary).toContain("glucose/diabetes markers");
+    // Should NOT contain any patient-specific info
+    expect(result.summary).not.toContain("237");
+    expect(result.summary).not.toContain("162");
+  });
+
+  it("generates generic summary for unrecognized biomarkers", () => {
+    const biomarkers: RawBiomarker[] = [
+      {
+        name: "Exotic Marker A",
+        value: 5,
+        unit: "pg/mL",
+        reference_low: 2,
+        reference_high: 8,
+        flag: "green",
+      },
+      {
+        name: "Exotic Marker B",
+        value: 12,
+        unit: "ng/dL",
+        reference_low: null,
+        reference_high: 20,
+        flag: "green",
+      },
+      {
+        name: "Exotic Marker C",
+        value: 100,
+        unit: "IU/mL",
+        reference_low: 50,
+        reference_high: 150,
+        flag: "green",
+      },
+    ];
+    const result = anonymizeExtraction(biomarkers);
+    expect(result.summary).toContain("3 biomarker results");
+  });
+
+  it("handles empty biomarker array", () => {
+    const result = anonymizeExtraction([]);
+    expect(result.biomarkers).toHaveLength(0);
+    expect(result.summary).toContain("0 biomarker results");
+  });
+
+  it("identifies CBC biomarkers in summary", () => {
+    const cbcBiomarkers: RawBiomarker[] = [
+      { name: "WBC", value: 7.5, unit: "K/uL", reference_low: 4.5, reference_high: 11.0, flag: "green" },
+      { name: "RBC", value: 4.8, unit: "M/uL", reference_low: 4.2, reference_high: 5.9, flag: "green" },
+      { name: "Hemoglobin", value: 14.5, unit: "g/dL", reference_low: 12.0, reference_high: 17.5, flag: "green" },
+    ];
+    const result = anonymizeExtraction(cbcBiomarkers);
+    expect(result.summary).toContain("CBC");
+  });
+
+  it("identifies thyroid panel in summary", () => {
+    const thyroidBiomarkers: RawBiomarker[] = [
+      { name: "TSH", value: 2.5, unit: "mIU/L", reference_low: 0.4, reference_high: 4.0, flag: "green" },
+      { name: "Free T4", value: 1.2, unit: "ng/dL", reference_low: 0.8, reference_high: 1.8, flag: "green" },
+    ];
+    const result = anonymizeExtraction(thyroidBiomarkers);
+    expect(result.summary).toContain("thyroid panel");
+  });
+});
+
+// ── Quality Threshold ─────────────────────────────────────────────────
+
+describe("Quality threshold for storing examples (#135)", () => {
+  it("accepts extraction with >= 3 biomarkers and good confidence", () => {
+    const biomarkers: RawBiomarker[] = [
+      { name: "A", value: 1, unit: "mg/dL", reference_low: 0, reference_high: 2, flag: "green", confidence: 0.9 },
+      { name: "B", value: 2, unit: "mg/dL", reference_low: 0, reference_high: 3, flag: "green", confidence: 0.85 },
+      { name: "C", value: 3, unit: "mg/dL", reference_low: 0, reference_high: 5, flag: "green", confidence: 0.8 },
+    ];
+    expect(meetsQualityThreshold(biomarkers)).toBe(true);
+  });
+
+  it("rejects extraction with < 3 biomarkers", () => {
+    const biomarkers: RawBiomarker[] = [
+      { name: "A", value: 1, unit: "mg/dL", reference_low: 0, reference_high: 2, flag: "green", confidence: 0.95 },
+      { name: "B", value: 2, unit: "mg/dL", reference_low: 0, reference_high: 3, flag: "green", confidence: 0.9 },
+    ];
+    expect(meetsQualityThreshold(biomarkers)).toBe(false);
+  });
+
+  it("rejects extraction with low average confidence", () => {
+    const biomarkers: RawBiomarker[] = [
+      { name: "A", value: 1, unit: "mg/dL", reference_low: 0, reference_high: 2, flag: "green", confidence: 0.5 },
+      { name: "B", value: 2, unit: "mg/dL", reference_low: 0, reference_high: 3, flag: "green", confidence: 0.4 },
+      { name: "C", value: 3, unit: "mg/dL", reference_low: 0, reference_high: 5, flag: "green", confidence: 0.6 },
+    ];
+    // avg = 0.5 < 0.7
+    expect(meetsQualityThreshold(biomarkers)).toBe(false);
+  });
+
+  it("accepts extraction at exactly the threshold (avg confidence = 0.7)", () => {
+    const biomarkers: RawBiomarker[] = [
+      { name: "A", value: 1, unit: "mg/dL", reference_low: 0, reference_high: 2, flag: "green", confidence: 0.7 },
+      { name: "B", value: 2, unit: "mg/dL", reference_low: 0, reference_high: 3, flag: "green", confidence: 0.7 },
+      { name: "C", value: 3, unit: "mg/dL", reference_low: 0, reference_high: 5, flag: "green", confidence: 0.7 },
+    ];
+    expect(meetsQualityThreshold(biomarkers)).toBe(true);
+  });
+
+  it("defaults missing confidence to 1.0", () => {
+    const biomarkers: RawBiomarker[] = [
+      { name: "A", value: 1, unit: "mg/dL", reference_low: 0, reference_high: 2, flag: "green" },
+      { name: "B", value: 2, unit: "mg/dL", reference_low: 0, reference_high: 3, flag: "green" },
+      { name: "C", value: 3, unit: "mg/dL", reference_low: 0, reference_high: 5, flag: "green" },
+    ];
+    expect(meetsQualityThreshold(biomarkers)).toBe(true);
+  });
+
+  it("rejects empty array", () => {
+    expect(meetsQualityThreshold([])).toBe(false);
+  });
+});
+
+// ── Build Parse Prompt ────────────────────────────────────────────────
+
+describe("buildParsePrompt with few-shot examples (#135)", () => {
+  it("returns base prompt when no hints or examples", () => {
+    const prompt = buildParsePrompt();
+    expect(prompt).toBe(PARSE_REPORT_SYSTEM_PROMPT);
+  });
+
+  it("includes FORMAT HINTS when provided", () => {
+    const prompt = buildParsePrompt("Quest uses H/L flags.");
+    expect(prompt).toContain("FORMAT HINTS:");
+    expect(prompt).toContain("Quest uses H/L flags.");
+  });
+
+  it("includes few-shot examples when provided", () => {
+    const examples = 'Here are examples of successfully extracted results:\n\nExample 1:\n{"biomarkers": []}';
+    const prompt = buildParsePrompt(undefined, examples);
+    expect(prompt).toContain("Here are examples of successfully extracted results:");
+    expect(prompt).toContain("Example 1:");
+  });
+
+  it("includes both hints and examples when both provided", () => {
+    const hints = "Quest uses H/L flags.";
+    const examples = 'Here are examples of successfully extracted results:\n\nExample 1:\n{"biomarkers": []}';
+    const prompt = buildParsePrompt(hints, examples);
+    expect(prompt).toContain("FORMAT HINTS:");
+    expect(prompt).toContain(hints);
+    expect(prompt).toContain("Here are examples of successfully extracted results:");
+  });
+
+  it("hints appear before examples in the prompt", () => {
+    const hints = "Quest uses H/L flags.";
+    const examples = "Here are examples of successfully extracted results:";
+    const prompt = buildParsePrompt(hints, examples);
+    const hintsIndex = prompt.indexOf("FORMAT HINTS:");
+    const examplesIndex = prompt.indexOf("Here are examples");
+    expect(hintsIndex).toBeLessThan(examplesIndex);
+  });
+
+  it("empty example string is not appended", () => {
+    const prompt = buildParsePrompt(undefined, "");
+    expect(prompt).toBe(PARSE_REPORT_SYSTEM_PROMPT);
+  });
+});
+
+// ── Example Library (findMatchingExamples) ────────────────────────────
+
+describe("findMatchingExamples (#135)", () => {
+  let mockSupabase: ReturnType<typeof createMockSupabase>;
+
+  function createMockSupabase(queryResults: Record<string, { data: unknown[] | null }> = {}) {
+    const chainable = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockImplementation(() => {
+        // Default: return empty result
+        return Promise.resolve({ data: [], error: null });
+      }),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+      update: vi.fn().mockReturnThis(),
+    };
+
+    return {
+      from: vi.fn().mockReturnValue(chainable),
+      _chainable: chainable,
+      _setQueryResult: (data: unknown[] | null) => {
+        chainable.limit.mockResolvedValue({ data, error: null });
+      },
+      _setCountResult: (count: number) => {
+        chainable.select.mockReturnValue({
+          ...chainable,
+          eq: vi.fn().mockReturnValue({
+            ...chainable,
+            is: vi.fn().mockResolvedValue({ count, error: null }),
+            then: undefined,
+          }),
+          is: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ count, error: null }),
+          }),
+        });
+      },
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase = createMockSupabase();
+  });
+
+  it("returns empty string when no examples found", async () => {
+    const { findMatchingExamples } = await import("@/lib/health/example-library");
+    mockSupabase._setQueryResult([]);
+
+    const result = await findMatchingExamples(
+      mockSupabase as unknown as Parameters<typeof findMatchingExamples>[0],
+      "Quest Diagnostics",
+      "pdf"
+    );
+    expect(result).toBe("");
+  });
+
+  it("returns formatted examples when provider matches", async () => {
+    const { findMatchingExamples } = await import("@/lib/health/example-library");
+
+    const exampleData = [
+      {
+        id: "ex1",
+        lab_provider: "Quest Diagnostics",
+        file_type: "pdf",
+        biomarker_count: 5,
+        anonymized_extraction: {
+          biomarkers: [
+            { name: "Total Cholesterol", value: 150, unit: "mg/dL", reference_low: null, reference_high: 200, flag: "green" },
+          ],
+          summary: "Lab report containing lipid panel results.",
+        },
+        quality_score: 0.9,
+        usage_count: 3,
+      },
+    ];
+
+    mockSupabase._setQueryResult(exampleData);
+
+    const result = await findMatchingExamples(
+      mockSupabase as unknown as Parameters<typeof findMatchingExamples>[0],
+      "Quest Diagnostics",
+      "pdf"
+    );
+
+    expect(result).toContain("Here are examples of successfully extracted results");
+    expect(result).toContain("Example 1:");
+    expect(result).toContain("Total Cholesterol");
+    expect(result).toContain("Use these examples as a reference");
+  });
+
+  it("queries by lab_provider first", async () => {
+    const { findMatchingExamples } = await import("@/lib/health/example-library");
+    mockSupabase._setQueryResult([]);
+
+    await findMatchingExamples(
+      mockSupabase as unknown as Parameters<typeof findMatchingExamples>[0],
+      "Quest Diagnostics",
+      "pdf"
+    );
+
+    // First call should query extraction_examples
+    expect(mockSupabase.from).toHaveBeenCalledWith("extraction_examples");
+    // eq should be called with lab_provider
+    expect(mockSupabase._chainable.eq).toHaveBeenCalledWith("lab_provider", "Quest Diagnostics");
+  });
+
+  it("falls back to file_type when no provider match", async () => {
+    const { findMatchingExamples } = await import("@/lib/health/example-library");
+    mockSupabase._setQueryResult([]);
+
+    await findMatchingExamples(
+      mockSupabase as unknown as Parameters<typeof findMatchingExamples>[0],
+      null,
+      "pdf"
+    );
+
+    // Should query by file_type since provider is null
+    expect(mockSupabase._chainable.eq).toHaveBeenCalledWith("file_type", "pdf");
+  });
+
+  it("limits to max 2 examples", async () => {
+    const { findMatchingExamples } = await import("@/lib/health/example-library");
+    mockSupabase._setQueryResult([]);
+
+    await findMatchingExamples(
+      mockSupabase as unknown as Parameters<typeof findMatchingExamples>[0],
+      "Quest Diagnostics",
+      "pdf",
+      5 // request 5, but should be capped at 2
+    );
+
+    expect(mockSupabase._chainable.limit).toHaveBeenCalledWith(2);
+  });
+});
+
+// ── Parse Route Integration ───────────────────────────────────────────
+
+describe("Parse route integrates few-shot examples (#135)", () => {
+  it("parse route imports example library functions", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const routeSource = fs.readFileSync(
+      path.resolve("app/api/parse/route.ts"),
+      "utf-8"
+    );
+    expect(routeSource).toContain("findMatchingExamples");
+    expect(routeSource).toContain("storeExtractionExample");
+    expect(routeSource).toContain("incrementExampleUsage");
+  });
+
+  it("parse route calls buildParsePrompt with examples", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const routeSource = fs.readFileSync(
+      path.resolve("app/api/parse/route.ts"),
+      "utf-8"
+    );
+    expect(routeSource).toContain("buildParsePrompt(filenameDetection.hints, fewShotExamples");
+  });
+
+  it("parse route passes system prompt to parseReportWithClaude", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const routeSource = fs.readFileSync(
+      path.resolve("app/api/parse/route.ts"),
+      "utf-8"
+    );
+    expect(routeSource).toContain("systemPrompt");
+    expect(routeSource).toContain("parseReportWithClaude(");
+  });
+
+  it("parse route stores examples after successful parse", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const routeSource = fs.readFileSync(
+      path.resolve("app/api/parse/route.ts"),
+      "utf-8"
+    );
+    expect(routeSource).toContain("storeExtractionExample(supabase");
+  });
+});
+
+// ── Database Migration ────────────────────────────────────────────────
+
+describe("Database migration (#135)", () => {
+  it("creates extraction_examples table", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const migrationSource = fs.readFileSync(
+      path.resolve("supabase/migrations/022_extraction_examples.sql"),
+      "utf-8"
+    );
+    expect(migrationSource).toContain("CREATE TABLE extraction_examples");
+  });
+
+  it("table has required columns", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const migrationSource = fs.readFileSync(
+      path.resolve("supabase/migrations/022_extraction_examples.sql"),
+      "utf-8"
+    );
+    expect(migrationSource).toContain("id uuid PRIMARY KEY");
+    expect(migrationSource).toContain("lab_provider text");
+    expect(migrationSource).toContain("file_type text NOT NULL");
+    expect(migrationSource).toContain("biomarker_count integer NOT NULL");
+    expect(migrationSource).toContain("anonymized_extraction jsonb NOT NULL");
+    expect(migrationSource).toContain("quality_score numeric NOT NULL");
+    expect(migrationSource).toContain("verified boolean NOT NULL DEFAULT false");
+    expect(migrationSource).toContain("usage_count integer NOT NULL DEFAULT 0");
+  });
+
+  it("has NO RLS (no user_id, shared anonymized data)", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const migrationSource = fs.readFileSync(
+      path.resolve("supabase/migrations/022_extraction_examples.sql"),
+      "utf-8"
+    );
+    expect(migrationSource).not.toContain("user_id");
+    expect(migrationSource).not.toContain("ENABLE ROW LEVEL SECURITY");
+    expect(migrationSource).not.toContain("CREATE POLICY");
+  });
+
+  it("has indexes for provider and quality score", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const migrationSource = fs.readFileSync(
+      path.resolve("supabase/migrations/022_extraction_examples.sql"),
+      "utf-8"
+    );
+    expect(migrationSource).toContain("idx_extraction_examples_provider");
+    expect(migrationSource).toContain("idx_extraction_examples_quality");
+  });
+});

--- a/app/api/parse/route.ts
+++ b/app/api/parse/route.ts
@@ -1,8 +1,10 @@
 import { createClient } from "@/lib/supabase/server";
 import { parseReportWithClaude } from "@/lib/claude/parse-report";
+import { buildParsePrompt } from "@/lib/claude/prompts";
 import { applyServerSideFlags } from "@/lib/health/flag-biomarker";
 import { normalizeBiomarkerName } from "@/lib/health/normalize-biomarker";
 import { detectLabFormatFromFilename, resolveLabProvider } from "@/lib/health/detect-lab-format";
+import { findMatchingExamples, storeExtractionExample, incrementExampleUsage } from "@/lib/health/example-library";
 import { logAuditEvent, getClientIp } from "@/lib/audit/logger";
 import { NextResponse } from "next/server";
 
@@ -118,12 +120,25 @@ export async function POST(request: Request) {
       console.log("[PARSE] Keyword detection matched:", filenameDetection.provider, "confidence:", filenameDetection.confidence);
     }
 
-    // Parse with Claude Vision (with format-specific hints if detected)
+    // Fetch few-shot examples for this lab format (#135)
+    const fewShotExamples = await findMatchingExamples(
+      supabase,
+      filenameDetection.provider,
+      report.file_type
+    );
+    if (fewShotExamples) {
+      console.log("[PARSE] Found few-shot examples for prompt augmentation");
+    }
+
+    // Build system prompt with hints + few-shot examples (#134 + #135)
+    const systemPrompt = buildParsePrompt(filenameDetection.hints, fewShotExamples || undefined);
+
+    // Parse with Claude Vision
     console.log("[PARSE] File downloaded, size:", arrayBuffer.byteLength, "bytes. Sending to Claude Vision...");
     const parsed = await parseReportWithClaude(
       base64,
       mediaType as "application/pdf" | "image/png" | "image/jpeg",
-      filenameDetection.hints
+      systemPrompt
     );
 
     console.log("[PARSE] Claude returned", parsed.biomarkers.length, "biomarkers. Applying server-side risk flags...");
@@ -262,6 +277,20 @@ export async function POST(request: Request) {
       .from("reports")
       .update(reportUpdate)
       .eq("id", report.id);
+
+    // Few-shot example library: store anonymized extraction + track usage (#135)
+    // Fire-and-forget — errors here should not break the parse pipeline.
+    const finalLabProvider = labProvider.provider;
+    storeExtractionExample(supabase, finalLabProvider, report.file_type, parsed.biomarkers)
+      .then((stored) => {
+        if (stored) console.log("[FEW-SHOT] Stored new extraction example for provider:", finalLabProvider ?? "unknown");
+      })
+      .catch((err) => console.error("[FEW-SHOT] Error storing example:", err));
+
+    if (fewShotExamples) {
+      incrementExampleUsage(supabase, filenameDetection.provider, report.file_type)
+        .catch((err) => console.error("[FEW-SHOT] Error incrementing usage:", err));
+    }
 
     // Audit log: report parse (fire-and-forget)
     logAuditEvent({

--- a/lib/claude/parse-report.ts
+++ b/lib/claude/parse-report.ts
@@ -26,12 +26,12 @@ export interface ParsedReportResult {
  *
  * @param fileBase64 - Base64-encoded file content
  * @param mediaType - MIME type of the file
- * @param labHints - Optional format-specific hints from lab detection (#134)
+ * @param systemPromptOverride - Optional pre-built system prompt (includes hints + few-shot examples from #135)
  */
 export async function parseReportWithClaude(
   fileBase64: string,
   mediaType: "image/jpeg" | "image/png" | "application/pdf",
-  labHints?: string
+  systemPromptOverride?: string
 ): Promise<ParsedReportResult> {
   const client = getClaudeClient();
 
@@ -54,7 +54,7 @@ export async function parseReportWithClaude(
           },
         };
 
-  const systemPrompt = buildParsePrompt(labHints);
+  const systemPrompt = systemPromptOverride ?? buildParsePrompt();
 
   const response = await client.messages.create({
     model: "claude-sonnet-4-20250514",

--- a/lib/claude/prompts.ts
+++ b/lib/claude/prompts.ts
@@ -31,12 +31,16 @@ Respond ONLY with valid JSON in this exact format:
 
 /**
  * Build the final parse prompt, optionally appending format-specific hints
- * when a lab provider has been detected via keyword matching (#134).
+ * when a lab provider has been detected via keyword matching (#134),
+ * and few-shot examples from the extraction example library (#135).
  */
-export function buildParsePrompt(labHints?: string): string {
+export function buildParsePrompt(labHints?: string, fewShotExamples?: string): string {
   let prompt = PARSE_REPORT_SYSTEM_PROMPT;
   if (labHints) {
     prompt += `\n\nFORMAT HINTS: This report appears to be from a specific lab provider. ${labHints}`;
+  }
+  if (fewShotExamples) {
+    prompt += `\n\n${fewShotExamples}`;
   }
   return prompt;
 }

--- a/lib/health/anonymize-extraction.ts
+++ b/lib/health/anonymize-extraction.ts
@@ -1,0 +1,166 @@
+/**
+ * Anonymize parsed biomarker extractions for few-shot example storage (#135).
+ *
+ * Removes all PHI (actual patient values) and replaces them with
+ * representative placeholder values within normal range. Keeps biomarker
+ * names, units, reference ranges, and structure so examples demonstrate
+ * the expected output format without exposing real patient data.
+ */
+
+export interface RawBiomarker {
+  name: string;
+  value: number;
+  unit: string;
+  reference_low: number | null;
+  reference_high: number | null;
+  flag: string;
+  confidence?: number;
+}
+
+export interface AnonymizedExtraction {
+  biomarkers: Array<{
+    name: string;
+    value: number;
+    unit: string;
+    reference_low: number | null;
+    reference_high: number | null;
+    flag: string;
+  }>;
+  summary: string;
+}
+
+/**
+ * Generate a representative placeholder value within normal range.
+ *
+ * Strategy:
+ * - If both reference bounds exist, use the midpoint.
+ * - If only high exists, use 75% of the high bound.
+ * - If only low exists, use 125% of the low bound.
+ * - If neither exists, use a rounded value based on the original
+ *   (rounded to remove precision that could identify a patient).
+ */
+function generatePlaceholderValue(
+  referenceLow: number | null,
+  referenceHigh: number | null,
+  originalValue: number
+): number {
+  if (referenceLow != null && referenceHigh != null) {
+    // Midpoint of normal range
+    const mid = (referenceLow + referenceHigh) / 2;
+    return Math.round(mid * 10) / 10;
+  }
+  if (referenceHigh != null) {
+    // 75% of upper bound (safely within range)
+    return Math.round(referenceHigh * 0.75 * 10) / 10;
+  }
+  if (referenceLow != null) {
+    // 125% of lower bound (safely above minimum)
+    return Math.round(referenceLow * 1.25 * 10) / 10;
+  }
+  // No reference range — round the original value to remove identifying precision
+  if (Math.abs(originalValue) >= 100) {
+    return Math.round(originalValue / 10) * 10;
+  }
+  if (Math.abs(originalValue) >= 10) {
+    return Math.round(originalValue);
+  }
+  return Math.round(originalValue * 10) / 10;
+}
+
+/**
+ * Generate a generic summary from the biomarker list.
+ *
+ * Does NOT use the original summary (which might contain patient-specific
+ * language). Instead, builds a structure-only description.
+ */
+function generateAnonymizedSummary(biomarkers: RawBiomarker[]): string {
+  const categories = new Set<string>();
+
+  for (const b of biomarkers) {
+    const lower = b.name.toLowerCase();
+    if (
+      lower.includes("cholesterol") ||
+      lower.includes("ldl") ||
+      lower.includes("hdl") ||
+      lower.includes("triglyceride")
+    ) {
+      categories.add("lipid panel");
+    } else if (
+      lower.includes("glucose") ||
+      lower.includes("a1c") ||
+      lower.includes("hemoglobin a1c")
+    ) {
+      categories.add("glucose/diabetes markers");
+    } else if (
+      lower.includes("creatinine") ||
+      lower.includes("bun") ||
+      lower.includes("gfr") ||
+      lower.includes("sodium") ||
+      lower.includes("potassium") ||
+      lower.includes("chloride") ||
+      lower.includes("calcium") ||
+      lower.includes("albumin") ||
+      lower.includes("bilirubin") ||
+      lower.includes("protein")
+    ) {
+      categories.add("metabolic panel");
+    } else if (
+      lower.includes("wbc") ||
+      lower.includes("rbc") ||
+      lower.includes("hemoglobin") ||
+      lower.includes("hematocrit") ||
+      lower.includes("platelet") ||
+      lower.includes("mcv") ||
+      lower.includes("mch")
+    ) {
+      categories.add("CBC");
+    } else if (
+      lower.includes("tsh") ||
+      lower.includes("t3") ||
+      lower.includes("t4") ||
+      lower.includes("thyroid")
+    ) {
+      categories.add("thyroid panel");
+    } else if (
+      lower.includes("alt") ||
+      lower.includes("ast") ||
+      lower.includes("alkaline phosphatase") ||
+      lower.includes("ggt")
+    ) {
+      categories.add("liver function");
+    }
+  }
+
+  if (categories.size === 0) {
+    return `Lab report containing ${biomarkers.length} biomarker results.`;
+  }
+
+  const categoryList = Array.from(categories).join(", ");
+  return `Lab report containing ${categoryList} results.`;
+}
+
+/**
+ * Anonymize a parsed biomarker extraction for storage as a few-shot example.
+ *
+ * - Keeps: biomarker names, units, reference ranges, structure, order
+ * - Replaces: actual values with representative placeholders within normal range
+ * - Removes: confidence scores (not relevant for examples), any PHI
+ * - Sets: all flags to "green" (placeholder values are within normal range)
+ */
+export function anonymizeExtraction(
+  biomarkers: RawBiomarker[]
+): AnonymizedExtraction {
+  const anonymizedBiomarkers = biomarkers.map((b) => ({
+    name: b.name,
+    value: generatePlaceholderValue(b.reference_low, b.reference_high, b.value),
+    unit: b.unit,
+    reference_low: b.reference_low,
+    reference_high: b.reference_high,
+    flag: "green" as const,
+  }));
+
+  return {
+    biomarkers: anonymizedBiomarkers,
+    summary: generateAnonymizedSummary(biomarkers),
+  };
+}

--- a/lib/health/example-library.ts
+++ b/lib/health/example-library.ts
@@ -1,0 +1,212 @@
+/**
+ * Few-shot example library — query and format extraction examples (#135).
+ *
+ * Retrieves anonymized extraction examples from the database and formats
+ * them as a few-shot prompt section for improved parsing accuracy.
+ */
+
+import { SupabaseClient } from "@supabase/supabase-js";
+import type { AnonymizedExtraction, RawBiomarker } from "./anonymize-extraction";
+import { anonymizeExtraction } from "./anonymize-extraction";
+
+/** Maximum examples to include in a prompt (context window management) */
+const MAX_PROMPT_EXAMPLES = 2;
+
+/** Maximum examples stored per lab provider (prevent bloat) */
+const MAX_EXAMPLES_PER_PROVIDER = 5;
+
+/** Minimum biomarker count for an extraction to be stored as an example */
+const MIN_BIOMARKER_COUNT = 3;
+
+/** Minimum average confidence for an extraction to be stored as an example */
+const MIN_AVG_CONFIDENCE = 0.7;
+
+interface ExtractionExampleRow {
+  id: string;
+  lab_provider: string | null;
+  file_type: string;
+  biomarker_count: number;
+  anonymized_extraction: AnonymizedExtraction;
+  quality_score: number;
+  usage_count: number;
+}
+
+/**
+ * Find matching few-shot examples and format them as a prompt section.
+ *
+ * Match priority:
+ * 1. lab_provider match (most relevant — same lab format)
+ * 2. file_type match (fallback — at least similar document type)
+ *
+ * Returns a formatted prompt string, or empty string if no examples found.
+ */
+export async function findMatchingExamples(
+  supabase: SupabaseClient,
+  labProvider: string | null,
+  fileType: string,
+  maxExamples: number = MAX_PROMPT_EXAMPLES
+): Promise<string> {
+  const limit = Math.min(maxExamples, MAX_PROMPT_EXAMPLES);
+  let examples: ExtractionExampleRow[] = [];
+
+  // Priority 1: Match by lab provider
+  if (labProvider) {
+    const { data } = await supabase
+      .from("extraction_examples")
+      .select("id, lab_provider, file_type, biomarker_count, anonymized_extraction, quality_score, usage_count")
+      .eq("lab_provider", labProvider)
+      .order("quality_score", { ascending: false })
+      .limit(limit);
+
+    if (data && data.length > 0) {
+      examples = data as ExtractionExampleRow[];
+    }
+  }
+
+  // Priority 2: Fall back to file type match if no provider-specific examples
+  if (examples.length === 0) {
+    const { data } = await supabase
+      .from("extraction_examples")
+      .select("id, lab_provider, file_type, biomarker_count, anonymized_extraction, quality_score, usage_count")
+      .eq("file_type", fileType)
+      .order("quality_score", { ascending: false })
+      .limit(limit);
+
+    if (data && data.length > 0) {
+      examples = data as ExtractionExampleRow[];
+    }
+  }
+
+  if (examples.length === 0) {
+    return "";
+  }
+
+  // Format as a few-shot prompt section
+  const exampleBlocks = examples.map((ex, i) => {
+    const json = JSON.stringify(ex.anonymized_extraction, null, 2);
+    return `Example ${i + 1}:\n${json}`;
+  });
+
+  return [
+    "Here are examples of successfully extracted results from similar reports:",
+    "",
+    ...exampleBlocks,
+    "",
+    "Use these examples as a reference for the expected output format and biomarker naming conventions.",
+  ].join("\n");
+}
+
+/**
+ * Check whether a parsed extraction meets quality thresholds for storage.
+ *
+ * Requirements:
+ * - At least MIN_BIOMARKER_COUNT biomarkers extracted
+ * - Average confidence >= MIN_AVG_CONFIDENCE
+ */
+export function meetsQualityThreshold(
+  biomarkers: RawBiomarker[]
+): boolean {
+  if (biomarkers.length < MIN_BIOMARKER_COUNT) {
+    return false;
+  }
+
+  const avgConfidence =
+    biomarkers.reduce((sum, b) => sum + (b.confidence ?? 1.0), 0) /
+    biomarkers.length;
+
+  // Use epsilon comparison to handle floating-point precision issues
+  return avgConfidence >= MIN_AVG_CONFIDENCE - 1e-9;
+}
+
+/**
+ * Store an anonymized extraction example if quality thresholds are met
+ * and we haven't exceeded the per-provider limit.
+ *
+ * Returns true if a new example was stored, false otherwise.
+ */
+export async function storeExtractionExample(
+  supabase: SupabaseClient,
+  labProvider: string | null,
+  fileType: string,
+  biomarkers: RawBiomarker[]
+): Promise<boolean> {
+  // Check quality threshold
+  if (!meetsQualityThreshold(biomarkers)) {
+    return false;
+  }
+
+  // Check per-provider limit
+  if (labProvider) {
+    const { count } = await supabase
+      .from("extraction_examples")
+      .select("id", { count: "exact", head: true })
+      .eq("lab_provider", labProvider);
+
+    if (count != null && count >= MAX_EXAMPLES_PER_PROVIDER) {
+      return false;
+    }
+  } else {
+    // For null provider, check by file type to avoid unbounded growth
+    const { count } = await supabase
+      .from("extraction_examples")
+      .select("id", { count: "exact", head: true })
+      .is("lab_provider", null)
+      .eq("file_type", fileType);
+
+    if (count != null && count >= MAX_EXAMPLES_PER_PROVIDER) {
+      return false;
+    }
+  }
+
+  // Anonymize and store
+  const anonymized = anonymizeExtraction(biomarkers);
+
+  const avgConfidence =
+    biomarkers.reduce((sum, b) => sum + (b.confidence ?? 1.0), 0) /
+    biomarkers.length;
+
+  const { error } = await supabase.from("extraction_examples").insert({
+    lab_provider: labProvider,
+    file_type: fileType,
+    biomarker_count: biomarkers.length,
+    anonymized_extraction: anonymized,
+    quality_score: Math.round(avgConfidence * 100) / 100,
+  });
+
+  if (error) {
+    console.error("[FEW-SHOT] Failed to store extraction example:", error.message);
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Increment usage_count on examples that were used in a parse.
+ * Fire-and-forget — errors are logged but don't break the pipeline.
+ */
+export async function incrementExampleUsage(
+  supabase: SupabaseClient,
+  labProvider: string | null,
+  fileType: string
+): Promise<void> {
+  // We increment all examples that would have been matched,
+  // since we don't track which specific examples were used in the prompt.
+  if (labProvider) {
+    const { data } = await supabase
+      .from("extraction_examples")
+      .select("id, usage_count")
+      .eq("lab_provider", labProvider)
+      .order("quality_score", { ascending: false })
+      .limit(MAX_PROMPT_EXAMPLES);
+
+    if (data) {
+      for (const row of data) {
+        await supabase
+          .from("extraction_examples")
+          .update({ usage_count: (row.usage_count ?? 0) + 1 })
+          .eq("id", row.id);
+      }
+    }
+  }
+}

--- a/supabase/migrations/022_extraction_examples.sql
+++ b/supabase/migrations/022_extraction_examples.sql
@@ -1,0 +1,19 @@
+-- Migration: extraction_examples table for few-shot example library (#135)
+-- Stores anonymized extraction templates used as few-shot prompt examples.
+-- No per-user column, no RLS — examples are anonymized and shared globally.
+-- They contain structure only (biomarker names, units, layout), never PHI.
+
+CREATE TABLE extraction_examples (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  lab_provider text,
+  file_type text NOT NULL,
+  biomarker_count integer NOT NULL,
+  anonymized_extraction jsonb NOT NULL,
+  quality_score numeric NOT NULL DEFAULT 0.8,
+  verified boolean NOT NULL DEFAULT false,
+  usage_count integer NOT NULL DEFAULT 0,
+  created_at timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE INDEX idx_extraction_examples_provider ON extraction_examples(lab_provider);
+CREATE INDEX idx_extraction_examples_quality ON extraction_examples(quality_score DESC);


### PR DESCRIPTION
## Summary
Closes #135

Implements a few-shot example library that stores anonymized extraction templates from successful parses and includes 1-2 matching examples in the Claude prompt for similar lab formats, improving extraction accuracy through few-shot learning.

**Key design decisions:**
- **No PHI:** Examples contain only structure (biomarker names, units, reference ranges) with placeholder values -- actual patient values are anonymized
- **No RLS:** The `extraction_examples` table is shared across all users since it contains no user-identifiable data
- **Quality gating:** Only extractions with >= 3 biomarkers and average confidence >= 0.7 are stored
- **Bounded storage:** Max 5 examples per lab provider to prevent bloat
- **Context management:** Max 2 examples in prompt to avoid token bloat
- **Fire-and-forget:** Example storage/usage tracking never blocks the parse pipeline

### Changes
- **Migration:** `supabase/migrations/022_extraction_examples.sql` -- new shared table with provider + quality indexes
- **Anonymization:** `lib/health/anonymize-extraction.ts` -- replaces values with midpoint/normal-range placeholders, generates structure-only summaries
- **Example library:** `lib/health/example-library.ts` -- matching (provider > file_type fallback), quality thresholds, storage limits, usage tracking
- **Prompt update:** `lib/claude/prompts.ts` -- `buildParsePrompt()` now accepts optional few-shot examples parameter
- **Parse function:** `lib/claude/parse-report.ts` -- accepts pre-built system prompt instead of raw hints
- **Route integration:** `app/api/parse/route.ts` -- fetches examples before parse, stores examples after successful parse
- **Tests:** 41 new tests covering anonymization, quality checks, prompt building, and integration

## Test plan
- [x] 41 new tests in `__tests__/few-shot-examples.test.ts` all pass
- [x] All 1047 existing tests continue to pass (46 test files)
- [x] ESLint: 0 errors, 0 new warnings
- [x] TypeScript: no type errors in source code
- [x] Pre-push hook (lint + full test suite) passes

## Parent issue
Part 3 of #96 (Adaptive report parsing) decomposition

Generated with [Claude Code](https://claude.ai/claude-code)