### PR TITLE
feat(search): add cross-report biomarker search with synonym matching (#148)

### DIFF
--- a/__tests__/search.test.ts
+++ b/__tests__/search.test.ts
@@ -1,0 +1,522 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Search API: handler shape ───────────────────────────────────────────
+
+describe("Search API (#148) — module exports", () => {
+  it("exports a GET handler", async () => {
+    const mod = await import("@/app/api/search/route");
+    expect(mod.GET).toBeDefined();
+    expect(typeof mod.GET).toBe("function");
+  });
+});
+
+// ── Search API: auth and validation ─────────────────────────────────────
+
+describe("Search API (#148) — auth & validation", () => {
+  type SupabaseStub = {
+    auth: { getUser: ReturnType<typeof vi.fn> };
+    from: ReturnType<typeof vi.fn>;
+  };
+  let mockSupabase: SupabaseStub;
+
+  function setupSupabase(opts: {
+    user: { id: string } | null;
+    reports?: Array<{
+      id: string;
+      original_filename: string;
+      report_date: string | null;
+      created_at: string;
+      parsed_results: Array<{
+        id: string;
+        biomarkers: Array<{
+          name: string;
+          value: number;
+          unit: string;
+          reference_low: number | null;
+          reference_high: number | null;
+          flag: string;
+        }>;
+      }>;
+    }>;
+  }) {
+    const reports = opts.reports ?? [];
+    mockSupabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: opts.user },
+        }),
+      },
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === "reports") {
+          const builder = {
+            select: vi.fn().mockReturnThis(),
+            order: vi
+              .fn()
+              .mockResolvedValue({ data: reports, error: null }),
+          };
+          return builder;
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          order: vi.fn().mockResolvedValue({ data: [], error: null }),
+        };
+      }),
+    };
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue(mockSupabase),
+    }));
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when there is no authenticated user", async () => {
+    setupSupabase({ user: null });
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(
+      new Request("http://localhost/api/search?q=cholesterol")
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns 400 for empty query", async () => {
+    setupSupabase({ user: { id: "user-1" } });
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(new Request("http://localhost/api/search"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when query is shorter than 2 characters", async () => {
+    setupSupabase({ user: { id: "user-1" } });
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(new Request("http://localhost/api/search?q=a"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/2 characters/i);
+  });
+
+  it("returns 200 with empty results when no matches", async () => {
+    setupSupabase({
+      user: { id: "user-1" },
+      reports: [],
+    });
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(
+      new Request("http://localhost/api/search?q=cholesterol")
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.query).toBe("cholesterol");
+    expect(body.totalResults).toBe(0);
+    expect(body.biomarkers).toEqual([]);
+    expect(body.reports).toEqual([]);
+  });
+});
+
+// ── Search API: biomarker matching & grouping ───────────────────────────
+
+describe("Search API (#148) — biomarker matching", () => {
+  type SupabaseStub = {
+    auth: { getUser: ReturnType<typeof vi.fn> };
+    from: ReturnType<typeof vi.fn>;
+  };
+
+  function setupSupabase(reports: Array<Record<string, unknown>>) {
+    const mockSupabase: SupabaseStub = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation(() => ({
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: reports, error: null }),
+      })),
+    };
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue(mockSupabase),
+    }));
+  }
+
+  const sampleReports = [
+    {
+      id: "report-1",
+      original_filename: "labcorp-2026-01.pdf",
+      report_date: "2026-01-15",
+      created_at: "2026-01-20T10:00:00Z",
+      parsed_results: [
+        {
+          id: "pr-1",
+          biomarkers: [
+            {
+              name: "LDL Cholesterol",
+              value: 142,
+              unit: "mg/dL",
+              reference_low: null,
+              reference_high: 100,
+              flag: "red",
+            },
+            {
+              name: "HDL Cholesterol",
+              value: 55,
+              unit: "mg/dL",
+              reference_low: 40,
+              reference_high: 60,
+              flag: "green",
+            },
+            {
+              name: "Glucose",
+              value: 98,
+              unit: "mg/dL",
+              reference_low: 70,
+              reference_high: 100,
+              flag: "green",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: "report-2",
+      original_filename: "quest-march.pdf",
+      report_date: "2026-03-10",
+      created_at: "2026-03-15T10:00:00Z",
+      parsed_results: [
+        {
+          id: "pr-2",
+          biomarkers: [
+            {
+              name: "ldl-c",
+              value: 118,
+              unit: "mg/dL",
+              reference_low: null,
+              reference_high: 100,
+              flag: "yellow",
+            },
+            {
+              name: "Fasting Glucose",
+              value: 95,
+              unit: "mg/dL",
+              reference_low: 70,
+              reference_high: 100,
+              flag: "green",
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("matches LDL synonym 'ldl' to LDL Cholesterol canonical name", async () => {
+    setupSupabase(sampleReports);
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(
+      new Request("http://localhost/api/search?q=ldl")
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const ldl = body.biomarkers.find(
+      (b: { canonicalName: string }) => b.canonicalName === "LDL Cholesterol"
+    );
+    expect(ldl).toBeDefined();
+    expect(ldl.readingCount).toBe(2);
+  });
+
+  it("is case-insensitive (LDL == ldl == Ldl)", async () => {
+    setupSupabase(sampleReports);
+    const { GET } = await import("@/app/api/search/route");
+    const responses = await Promise.all([
+      GET(new Request("http://localhost/api/search?q=LDL")),
+      GET(new Request("http://localhost/api/search?q=ldl")),
+      GET(new Request("http://localhost/api/search?q=Ldl")),
+    ]);
+    const bodies = await Promise.all(responses.map((r) => r.json()));
+    const counts = bodies.map((b) => b.biomarkers.length);
+    expect(counts[0]).toBe(counts[1]);
+    expect(counts[1]).toBe(counts[2]);
+    expect(counts[0]).toBeGreaterThan(0);
+  });
+
+  it("groups readings by canonical name across multiple reports", async () => {
+    setupSupabase(sampleReports);
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(
+      new Request("http://localhost/api/search?q=ldl")
+    );
+    const body = await res.json();
+    const ldl = body.biomarkers.find(
+      (b: { canonicalName: string }) => b.canonicalName === "LDL Cholesterol"
+    );
+    expect(ldl).toBeDefined();
+    // Both reports contribute readings
+    const reportIds = new Set(
+      ldl.readings.map((r: { reportId: string }) => r.reportId)
+    );
+    expect(reportIds.size).toBe(2);
+    expect(reportIds.has("report-1")).toBe(true);
+    expect(reportIds.has("report-2")).toBe(true);
+  });
+
+  it("sorts readings by date descending (newest first)", async () => {
+    setupSupabase(sampleReports);
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(
+      new Request("http://localhost/api/search?q=ldl")
+    );
+    const body = await res.json();
+    const ldl = body.biomarkers.find(
+      (b: { canonicalName: string }) => b.canonicalName === "LDL Cholesterol"
+    );
+    expect(ldl.readings.length).toBe(2);
+    // March (newer) should come before January
+    expect(ldl.readings[0].reportId).toBe("report-2");
+    expect(ldl.readings[1].reportId).toBe("report-1");
+  });
+
+  it("includes a trend on each biomarker group", async () => {
+    setupSupabase(sampleReports);
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(
+      new Request("http://localhost/api/search?q=ldl")
+    );
+    const body = await res.json();
+    const ldl = body.biomarkers.find(
+      (b: { canonicalName: string }) => b.canonicalName === "LDL Cholesterol"
+    );
+    // LDL dropped 142 -> 118 (lower-is-better) = improving
+    expect(["improving", "worsening", "stable"]).toContain(ldl.trend);
+    expect(ldl.trend).toBe("improving");
+  });
+
+  it("returns biomarker reading shape with required fields", async () => {
+    setupSupabase(sampleReports);
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(
+      new Request("http://localhost/api/search?q=ldl")
+    );
+    const body = await res.json();
+    const ldl = body.biomarkers.find(
+      (b: { canonicalName: string }) => b.canonicalName === "LDL Cholesterol"
+    );
+    const reading = ldl.readings[0];
+    expect(reading).toHaveProperty("reportId");
+    expect(reading).toHaveProperty("reportName");
+    expect(reading).toHaveProperty("date");
+    expect(reading).toHaveProperty("value");
+    expect(reading).toHaveProperty("unit");
+    expect(reading).toHaveProperty("flag");
+  });
+
+  it("returns biomarker group shape with category and readingCount", async () => {
+    setupSupabase(sampleReports);
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(
+      new Request("http://localhost/api/search?q=glucose")
+    );
+    const body = await res.json();
+    expect(body.biomarkers.length).toBeGreaterThan(0);
+    const g = body.biomarkers[0];
+    expect(g).toHaveProperty("canonicalName");
+    expect(g).toHaveProperty("category");
+    expect(g).toHaveProperty("readingCount");
+    expect(g).toHaveProperty("trend");
+    expect(g).toHaveProperty("readings");
+    expect(Array.isArray(g.readings)).toBe(true);
+    expect(g.readingCount).toBe(g.readings.length);
+  });
+});
+
+// ── Search API: report filename matching ────────────────────────────────
+
+describe("Search API (#148) — report filename matching", () => {
+  function setupSupabase(reports: Array<Record<string, unknown>>) {
+    const mockSupabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "user-1" } },
+        }),
+      },
+      from: vi.fn().mockImplementation(() => ({
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: reports, error: null }),
+      })),
+    };
+
+    vi.doMock("@/lib/supabase/server", () => ({
+      createClient: vi.fn().mockResolvedValue(mockSupabase),
+    }));
+  }
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("matches report by filename substring", async () => {
+    setupSupabase([
+      {
+        id: "report-x",
+        original_filename: "annual-physical-2026.pdf",
+        report_date: "2026-02-01",
+        created_at: "2026-02-02T10:00:00Z",
+        parsed_results: [
+          {
+            id: "pr-x",
+            biomarkers: [
+              {
+                name: "Sodium",
+                value: 140,
+                unit: "mEq/L",
+                reference_low: 135,
+                reference_high: 145,
+                flag: "green",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(
+      new Request("http://localhost/api/search?q=annual")
+    );
+    const body = await res.json();
+    expect(body.reports.length).toBe(1);
+    expect(body.reports[0].name).toBe("annual-physical-2026.pdf");
+    expect(body.reports[0].biomarkerCount).toBe(1);
+  });
+
+  it("filename match is case-insensitive", async () => {
+    setupSupabase([
+      {
+        id: "report-y",
+        original_filename: "BLOODWORK-Jan.pdf",
+        report_date: null,
+        created_at: "2026-01-05T10:00:00Z",
+        parsed_results: [],
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/search/route");
+    const res = await GET(
+      new Request("http://localhost/api/search?q=bloodwork")
+    );
+    const body = await res.json();
+    expect(body.reports.length).toBe(1);
+    expect(body.reports[0].id).toBe("report-y");
+  });
+});
+
+// ── SearchBar component ─────────────────────────────────────────────────
+
+describe("SearchBar component (#148)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("exports a default component", async () => {
+    const mod = await import("@/components/ui/SearchBar");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+
+  it("renders an input with the configured placeholder", async () => {
+    vi.doMock("next/navigation", () => ({
+      useRouter: () => ({ push: vi.fn() }),
+    }));
+    const { render, screen } = await import("@testing-library/react");
+    const React = (await import("react")).default;
+    const { default: SearchBar } = await import("@/components/ui/SearchBar");
+
+    render(
+      React.createElement(SearchBar, {
+        placeholder: "Search reports, biomarkers...",
+      })
+    );
+
+    const input = screen.getByPlaceholderText(
+      "Search reports, biomarkers..."
+    ) as HTMLInputElement;
+    expect(input).toBeDefined();
+    expect(input.tagName).toBe("INPUT");
+  });
+
+  it("invokes onSubmit prop when form is submitted with query >= 2 chars", async () => {
+    vi.doMock("next/navigation", () => ({
+      useRouter: () => ({ push: vi.fn() }),
+    }));
+    const { render, screen, fireEvent } = await import(
+      "@testing-library/react"
+    );
+    const React = (await import("react")).default;
+    const { default: SearchBar } = await import("@/components/ui/SearchBar");
+
+    const onSubmit = vi.fn();
+    render(
+      React.createElement(SearchBar, {
+        onSubmit,
+      })
+    );
+
+    const input = screen.getByLabelText("Search query") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "ldl" } });
+    fireEvent.submit(input.closest("form")!);
+    expect(onSubmit).toHaveBeenCalledWith("ldl");
+  });
+
+  it("renders a clear button only when there is text", async () => {
+    vi.doMock("next/navigation", () => ({
+      useRouter: () => ({ push: vi.fn() }),
+    }));
+    const { render, screen, fireEvent } = await import(
+      "@testing-library/react"
+    );
+    const React = (await import("react")).default;
+    const { default: SearchBar } = await import("@/components/ui/SearchBar");
+
+    render(React.createElement(SearchBar, {}));
+
+    expect(screen.queryByLabelText("Clear search")).toBeNull();
+
+    const input = screen.getByLabelText("Search query") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "ldl" } });
+
+    expect(screen.getByLabelText("Clear search")).toBeDefined();
+  });
+});
+
+// ── Search page module ──────────────────────────────────────────────────
+
+describe("Search page (#148) — module exports", () => {
+  it("exports a default component", async () => {
+    vi.doMock("next/navigation", () => ({
+      useSearchParams: () => new URLSearchParams(),
+      useRouter: () => ({ push: vi.fn() }),
+      usePathname: () => "/search",
+    }));
+    const mod = await import("@/app/search/page");
+    expect(mod.default).toBeDefined();
+    expect(typeof mod.default).toBe("function");
+  });
+
+  it("layout exports force-dynamic and default", async () => {
+    const mod = await import("@/app/search/layout");
+    expect(mod.dynamic).toBe("force-dynamic");
+    expect(mod.default).toBeDefined();
+  });
+});

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,245 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import {
+  BIOMARKER_MAPPINGS,
+  SYNONYM_INDEX,
+  type BiomarkerMapping,
+} from "@/lib/health/biomarker-synonyms";
+import { normalizeBiomarkerName } from "@/lib/health/normalize-biomarker";
+import { calculateBiomarkerTrend, type TrendDirection } from "@/lib/health/trend";
+
+interface BiomarkerJSON {
+  name: string;
+  value: number;
+  unit: string;
+  reference_low: number | null;
+  reference_high: number | null;
+  flag: string;
+}
+
+interface BiomarkerReading {
+  reportId: string;
+  reportName: string;
+  date: string;
+  value: number;
+  unit: string;
+  flag: string;
+}
+
+interface BiomarkerSearchResult {
+  canonicalName: string;
+  category: string;
+  readingCount: number;
+  trend: TrendDirection;
+  readings: BiomarkerReading[];
+}
+
+interface ReportSearchResult {
+  id: string;
+  name: string;
+  date: string;
+  biomarkerCount: number;
+}
+
+/**
+ * Find biomarker mappings whose canonical name or synonyms contain the query.
+ * Case-insensitive substring match. Returns unique mappings.
+ */
+function findMatchingMappings(query: string): BiomarkerMapping[] {
+  const q = query.toLowerCase().trim();
+  if (!q) return [];
+
+  // 1. Direct exact synonym match (e.g., "ldl" -> LDL Cholesterol)
+  const exact = SYNONYM_INDEX.get(q);
+  const matches = new Map<string, BiomarkerMapping>();
+  if (exact) {
+    matches.set(exact.canonical, exact);
+  }
+
+  // 2. Substring matches against canonical names + synonyms
+  for (const mapping of BIOMARKER_MAPPINGS) {
+    if (mapping.canonical.toLowerCase().includes(q)) {
+      matches.set(mapping.canonical, mapping);
+      continue;
+    }
+    for (const synonym of mapping.synonyms) {
+      if (synonym.includes(q)) {
+        matches.set(mapping.canonical, mapping);
+        break;
+      }
+    }
+  }
+
+  return Array.from(matches.values());
+}
+
+export async function GET(request: Request) {
+  const supabase = await createClient();
+
+  // Verify authentication
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Parse query parameter
+  const { searchParams } = new URL(request.url);
+  const rawQuery = searchParams.get("q") ?? "";
+  const query = rawQuery.trim();
+
+  if (query.length < 2) {
+    return NextResponse.json(
+      { error: "Query must be at least 2 characters" },
+      { status: 400 }
+    );
+  }
+
+  const queryLower = query.toLowerCase();
+  const matchedCanonicals = new Set(
+    findMatchingMappings(query).map((m) => m.canonical)
+  );
+
+  // Fetch all the user's reports with parsed results (RLS applies)
+  const { data: reports, error: reportsError } = await supabase
+    .from("reports")
+    .select(
+      "id, original_filename, report_date, created_at, parsed_results(id, biomarkers)"
+    )
+    .order("created_at", { ascending: false });
+
+  if (reportsError) {
+    return NextResponse.json(
+      { error: "Failed to fetch reports" },
+      { status: 500 }
+    );
+  }
+
+  // Build per-canonical-name reading collections + match reports
+  const biomarkerMap = new Map<
+    string,
+    { category: string; readings: BiomarkerReading[] }
+  >();
+  const reportResults: ReportSearchResult[] = [];
+
+  for (const report of reports ?? []) {
+    const reportId = report.id as string;
+    const filename = (report.original_filename as string) ?? "";
+    const reportDate =
+      (report.report_date as string | null) ??
+      (report.created_at as string);
+
+    // parsed_results is a relation; can be array or object depending on count
+    const parsedArr = Array.isArray(report.parsed_results)
+      ? report.parsed_results
+      : report.parsed_results
+        ? [report.parsed_results]
+        : [];
+
+    const biomarkers: BiomarkerJSON[] = [];
+    for (const pr of parsedArr) {
+      const bms = (pr as { biomarkers?: BiomarkerJSON[] }).biomarkers;
+      if (Array.isArray(bms)) {
+        biomarkers.push(...bms);
+      }
+    }
+
+    // Filename match -> include in report results
+    if (filename.toLowerCase().includes(queryLower)) {
+      reportResults.push({
+        id: reportId,
+        name: filename,
+        date: reportDate,
+        biomarkerCount: biomarkers.length,
+      });
+    }
+
+    // Walk biomarkers and check matches
+    for (const bm of biomarkers) {
+      if (!bm || typeof bm.name !== "string" || typeof bm.value !== "number") {
+        continue;
+      }
+
+      const norm = normalizeBiomarkerName(bm.name);
+      const canonical = norm.matched ? norm.canonical : bm.name.trim();
+      const category = norm.matched ? norm.category : "Unknown";
+
+      // Match if canonical matches an extracted synonym/canonical, or
+      // if the raw biomarker name itself contains the query (handles unmapped names).
+      const matchedByCanonical = matchedCanonicals.has(canonical);
+      const matchedByRawName = bm.name.toLowerCase().includes(queryLower);
+      const matchedByCanonicalText = canonical
+        .toLowerCase()
+        .includes(queryLower);
+
+      if (!matchedByCanonical && !matchedByRawName && !matchedByCanonicalText) {
+        continue;
+      }
+
+      let entry = biomarkerMap.get(canonical);
+      if (!entry) {
+        entry = { category, readings: [] };
+        biomarkerMap.set(canonical, entry);
+      }
+
+      entry.readings.push({
+        reportId,
+        reportName: filename,
+        date: reportDate,
+        value: bm.value,
+        unit: bm.unit ?? "",
+        flag: bm.flag ?? "unknown",
+      });
+    }
+  }
+
+  // Build biomarker results — sort readings by date desc, compute trend
+  const biomarkerResults: BiomarkerSearchResult[] = [];
+  for (const [canonicalName, { category, readings }] of biomarkerMap) {
+    const sorted = [...readings].sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+    );
+
+    let trend: TrendDirection = "stable";
+    if (sorted.length >= 2) {
+      const newest = sorted[0];
+      const oldest = sorted[sorted.length - 1];
+      trend = calculateBiomarkerTrend(canonicalName, oldest.value, newest.value);
+    }
+
+    biomarkerResults.push({
+      canonicalName,
+      category,
+      readingCount: sorted.length,
+      trend,
+      readings: sorted,
+    });
+  }
+
+  // Sort biomarker results: most readings first, then alphabetical
+  biomarkerResults.sort((a, b) => {
+    if (b.readingCount !== a.readingCount) {
+      return b.readingCount - a.readingCount;
+    }
+    return a.canonicalName.localeCompare(b.canonicalName);
+  });
+
+  // Sort report results by date desc
+  reportResults.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+
+  const totalResults = biomarkerResults.length + reportResults.length;
+
+  return NextResponse.json(
+    {
+      query,
+      totalResults,
+      biomarkers: biomarkerResults,
+      reports: reportResults,
+    },
+    { status: 200 }
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -9851,3 +9851,342 @@ button.chat-send-button[type="submit"]:disabled {
     padding-left: 0;
   }
 }
+
+/* ========================================================================
+   SEARCH BAR & SEARCH PAGE (#148)
+   ======================================================================== */
+
+.search-bar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  max-width: 560px;
+}
+
+.search-bar__icon {
+  position: absolute;
+  left: 0.85rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-gray-500);
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+}
+
+.search-bar__input {
+  width: 100%;
+  padding: 0.7rem 2.5rem 0.7rem 2.5rem;
+  font-size: 0.95rem;
+  border: 1px solid var(--color-gray-300);
+  border-radius: 999px;
+  background: white;
+  color: var(--color-gray-900);
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.search-bar__input::placeholder {
+  color: var(--color-gray-400);
+}
+
+.search-bar__input:focus {
+  border-color: var(--color-green-500);
+  box-shadow: 0 0 0 3px var(--color-green-100);
+}
+
+.search-bar__clear {
+  position: absolute;
+  right: 0.6rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-gray-500);
+  padding: 0.25rem;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.search-bar__clear:hover {
+  background: var(--color-gray-100);
+  color: var(--color-gray-700);
+}
+
+.reports-page__searchbar {
+  padding: 1rem 1.5rem 0;
+  max-width: 1100px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.search-page {
+  min-height: 100vh;
+  background: var(--color-gray-50);
+}
+
+.search-page__container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.search-page__searchbar {
+  margin-bottom: 1.5rem;
+}
+
+.search-page__section {
+  margin-bottom: 2rem;
+  background: white;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 12px;
+  padding: 1.25rem;
+}
+
+.search-page__section-title {
+  margin: 0 0 1rem 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-gray-900);
+}
+
+.search-page__results {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.search-page__empty {
+  text-align: center;
+  padding: 3rem 1.5rem;
+  background: white;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 12px;
+}
+
+.search-page__empty-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem 0;
+  color: var(--color-gray-900);
+}
+
+.search-page__empty-text {
+  color: var(--color-gray-600);
+  margin: 0 0 1rem 0;
+}
+
+.search-page__empty-examples {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.search-page__empty-examples li {
+  background: var(--color-green-50);
+  color: var(--color-green-700);
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  border: 1px solid var(--color-green-200);
+}
+
+.search-page__loading {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.search-page__skeleton {
+  height: 90px;
+  border-radius: 12px;
+  background: linear-gradient(
+    90deg,
+    var(--color-gray-100) 0%,
+    var(--color-gray-200) 50%,
+    var(--color-gray-100) 100%
+  );
+  background-size: 200% 100%;
+  animation: search-skeleton-shimmer 1.5s infinite;
+}
+
+@keyframes search-skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.search-page__error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.search-result-card {
+  display: block;
+  background: white;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 10px;
+  padding: 1rem;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.15s ease, box-shadow 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.search-result-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  border-color: var(--color-green-300);
+}
+
+.search-result-card__toggle {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+
+.search-result-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.search-result-card__title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-gray-900);
+}
+
+.search-result-card__category {
+  font-size: 0.8rem;
+  color: var(--color-gray-500);
+  margin-top: 0.15rem;
+}
+
+.search-result-card__latest {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.search-result-card__latest-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-gray-900);
+}
+
+.search-result-card__latest-unit {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-gray-500);
+}
+
+.search-result-card__latest-date {
+  font-size: 0.8rem;
+  color: var(--color-gray-500);
+}
+
+.search-result-card__flag {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.search-result-card__flag--green {
+  background: var(--color-green-50);
+  color: var(--color-green-700);
+  border-color: var(--color-green-200);
+}
+
+.search-result-card__flag--yellow {
+  background: #fef3c7;
+  color: #92400e;
+  border-color: #fde68a;
+}
+
+.search-result-card__flag--red {
+  background: #fef2f2;
+  color: #991b1b;
+  border-color: #fecaca;
+}
+
+.search-result-card__readings {
+  margin-top: 0.85rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--color-gray-200);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.search-result-card__reading-row {
+  display: grid;
+  grid-template-columns: minmax(90px, auto) minmax(100px, auto) auto 1fr;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.6rem;
+  border-radius: 6px;
+  text-decoration: none;
+  color: inherit;
+  font-size: 0.85rem;
+  transition: background 0.12s ease;
+}
+
+.search-result-card__reading-row:hover {
+  background: var(--color-gray-50);
+}
+
+.search-result-card__reading-date {
+  color: var(--color-gray-600);
+  font-weight: 500;
+}
+
+.search-result-card__reading-value {
+  font-weight: 600;
+  color: var(--color-gray-900);
+}
+
+.search-result-card__reading-report {
+  color: var(--color-gray-500);
+  font-size: 0.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .search-result-card__reading-row {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .search-result-card__reading-report {
+    grid-column: span 2;
+  }
+}

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -2,11 +2,15 @@
 
 import NavHeader from "@/components/ui/NavHeader";
 import ReportList from "@/components/reports/ReportList";
+import SearchBar from "@/components/ui/SearchBar";
 
 export default function ReportsPage() {
   return (
     <div className="reports-page">
       <NavHeader backLabel="Dashboard" />
+      <div className="reports-page__searchbar">
+        <SearchBar />
+      </div>
       <ReportList />
     </div>
   );

--- a/app/search/layout.tsx
+++ b/app/search/layout.tsx
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+
+export default function SearchLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { Suspense, useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import NavHeader from "@/components/ui/NavHeader";
+import SearchBar from "@/components/ui/SearchBar";
+import TrendArrow from "@/components/reports/TrendArrow";
+
+interface BiomarkerReading {
+  reportId: string;
+  reportName: string;
+  date: string;
+  value: number;
+  unit: string;
+  flag: string;
+}
+
+interface BiomarkerResult {
+  canonicalName: string;
+  category: string;
+  readingCount: number;
+  trend: "improving" | "worsening" | "stable";
+  readings: BiomarkerReading[];
+}
+
+interface ReportResult {
+  id: string;
+  name: string;
+  date: string;
+  biomarkerCount: number;
+}
+
+interface SearchResponse {
+  query: string;
+  totalResults: number;
+  biomarkers: BiomarkerResult[];
+  reports: ReportResult[];
+}
+
+function formatDate(d: string): string {
+  return new Date(d).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function flagLabel(flag: string): string {
+  if (flag === "green") return "Normal";
+  if (flag === "yellow") return "Borderline";
+  if (flag === "red") return "Out of range";
+  return flag;
+}
+
+function BiomarkerCard({ result }: { result: BiomarkerResult }) {
+  const [expanded, setExpanded] = useState(false);
+  const latest = result.readings[0];
+
+  return (
+    <div className="search-result-card">
+      <button
+        type="button"
+        className="search-result-card__toggle"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        <div className="search-result-card__header">
+          <div>
+            <div className="search-result-card__title">
+              {result.canonicalName}
+            </div>
+            <div className="search-result-card__category">
+              {result.category} · {result.readingCount} reading
+              {result.readingCount === 1 ? "" : "s"}
+            </div>
+          </div>
+          <TrendArrow trend={result.trend} />
+        </div>
+        {latest && (
+          <div className="search-result-card__latest">
+            <span className="search-result-card__latest-value">
+              {latest.value}
+              <span className="search-result-card__latest-unit">
+                {" "}
+                {latest.unit}
+              </span>
+            </span>
+            <span
+              className={`search-result-card__flag search-result-card__flag--${latest.flag}`}
+            >
+              {flagLabel(latest.flag)}
+            </span>
+            <span className="search-result-card__latest-date">
+              {formatDate(latest.date)}
+            </span>
+          </div>
+        )}
+      </button>
+      {expanded && (
+        <div className="search-result-card__readings">
+          {result.readings.map((r, idx) => (
+            <Link
+              key={`${r.reportId}-${idx}`}
+              href={`/reports/${r.reportId}`}
+              className="search-result-card__reading-row"
+            >
+              <span className="search-result-card__reading-date">
+                {formatDate(r.date)}
+              </span>
+              <span className="search-result-card__reading-value">
+                {r.value} {r.unit}
+              </span>
+              <span
+                className={`search-result-card__flag search-result-card__flag--${r.flag}`}
+              >
+                {flagLabel(r.flag)}
+              </span>
+              <span className="search-result-card__reading-report">
+                {r.reportName}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ReportCard({ result }: { result: ReportResult }) {
+  return (
+    <Link
+      href={`/reports/${result.id}`}
+      className="search-result-card search-result-card--report"
+    >
+      <div className="search-result-card__header">
+        <div className="search-result-card__title">{result.name}</div>
+      </div>
+      <div className="search-result-card__category">
+        {formatDate(result.date)} · {result.biomarkerCount} biomarker
+        {result.biomarkerCount === 1 ? "" : "s"}
+      </div>
+    </Link>
+  );
+}
+
+function SearchContent() {
+  const searchParams = useSearchParams();
+  const query = (searchParams.get("q") ?? "").trim();
+
+  const [data, setData] = useState<SearchResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchResults = useCallback(async (q: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+      if (!res.ok) {
+        if (res.status === 401) {
+          throw new Error("Please log in to search.");
+        }
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || "Search failed");
+      }
+      const json = (await res.json()) as SearchResponse;
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Search failed");
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (query.length >= 2) {
+      fetchResults(query);
+    } else {
+      setData(null);
+      setError(null);
+    }
+  }, [query, fetchResults]);
+
+  return (
+    <div className="search-page">
+      <NavHeader backLabel="Dashboard" />
+      <div className="search-page__container">
+        <div className="search-page__searchbar">
+          <SearchBar defaultValue={query} />
+        </div>
+
+        {query.length < 2 && (
+          <div className="search-page__empty">
+            <h2 className="search-page__empty-title">
+              Search across all your reports
+            </h2>
+            <p className="search-page__empty-text">
+              Find biomarker readings, trends, and reports. Try searching
+              for:
+            </p>
+            <ul className="search-page__empty-examples">
+              <li>cholesterol</li>
+              <li>LDL</li>
+              <li>glucose</li>
+              <li>vitamin d</li>
+              <li>thyroid</li>
+            </ul>
+          </div>
+        )}
+
+        {loading && (
+          <div className="search-page__loading">
+            <div className="search-page__skeleton" />
+            <div className="search-page__skeleton" />
+            <div className="search-page__skeleton" />
+          </div>
+        )}
+
+        {error && !loading && (
+          <div className="search-page__error">{error}</div>
+        )}
+
+        {data && !loading && !error && (
+          <>
+            {data.totalResults === 0 ? (
+              <div className="search-page__empty">
+                <h2 className="search-page__empty-title">No matches found</h2>
+                <p className="search-page__empty-text">
+                  We couldn&apos;t find any biomarkers or reports matching
+                  &quot;{data.query}&quot;. Try a different term — like
+                  &quot;cholesterol&quot;, &quot;a1c&quot;, or part of a
+                  filename.
+                </p>
+              </div>
+            ) : (
+              <>
+                {data.biomarkers.length > 0 && (
+                  <section className="search-page__section">
+                    <h2 className="search-page__section-title">
+                      Matching Biomarkers ({data.biomarkers.length})
+                    </h2>
+                    <div className="search-page__results">
+                      {data.biomarkers.map((b) => (
+                        <BiomarkerCard key={b.canonicalName} result={b} />
+                      ))}
+                    </div>
+                  </section>
+                )}
+
+                {data.reports.length > 0 && (
+                  <section className="search-page__section">
+                    <h2 className="search-page__section-title">
+                      Matching Reports ({data.reports.length})
+                    </h2>
+                    <div className="search-page__results">
+                      {data.reports.map((r) => (
+                        <ReportCard key={r.id} result={r} />
+                      ))}
+                    </div>
+                  </section>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function SearchPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="search-page">
+          <div className="search-page__container">
+            <div className="search-page__loading">Loading...</div>
+          </div>
+        </div>
+      }
+    >
+      <SearchContent />
+    </Suspense>
+  );
+}

--- a/components/ui/SearchBar.tsx
+++ b/components/ui/SearchBar.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState, useCallback, FormEvent, useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+interface SearchBarProps {
+  defaultValue?: string;
+  placeholder?: string;
+  onSubmit?: (query: string) => void;
+}
+
+export default function SearchBar({
+  defaultValue = "",
+  placeholder = "Search reports, biomarkers...",
+  onSubmit,
+}: SearchBarProps) {
+  const router = useRouter();
+  const [value, setValue] = useState(defaultValue);
+
+  // Sync if defaultValue changes (e.g., user navigates with new query)
+  useEffect(() => {
+    setValue(defaultValue);
+  }, [defaultValue]);
+
+  const handleSubmit = useCallback(
+    (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const trimmed = value.trim();
+      if (trimmed.length < 2) return;
+
+      if (onSubmit) {
+        onSubmit(trimmed);
+      } else {
+        router.push(`/search?q=${encodeURIComponent(trimmed)}`);
+      }
+    },
+    [value, onSubmit, router]
+  );
+
+  const handleClear = useCallback(() => {
+    setValue("");
+  }, []);
+
+  return (
+    <form
+      className="search-bar"
+      role="search"
+      onSubmit={handleSubmit}
+      aria-label="Search"
+    >
+      <span className="search-bar__icon" aria-hidden="true">
+        <svg
+          viewBox="0 0 24 24"
+          width="18"
+          height="18"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="11" cy="11" r="7" />
+          <path d="m21 21-4.3-4.3" />
+        </svg>
+      </span>
+      <input
+        type="search"
+        className="search-bar__input"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={placeholder}
+        aria-label="Search query"
+      />
+      {value.length > 0 && (
+        <button
+          type="button"
+          className="search-bar__clear"
+          onClick={handleClear}
+          aria-label="Clear search"
+        >
+          <svg
+            viewBox="0 0 20 20"
+            width="16"
+            height="16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          >
+            <path d="M6 6l8 8M14 6l-8 8" />
+          </svg>
+        </button>
+      )}
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #148. Adds a cross-report search so users can find any biomarker reading across every report they've uploaded, plus filename matches, in one place.

- `GET /api/search?q=<query>` — auth-gated (401), 2-char minimum (400), RLS-scoped to the user's reports. Groups biomarker readings by canonical name, sorts each group newest-first, and computes a trend (`improving` / `worsening` / `stable`) per biomarker via `calculateBiomarkerTrend`.
- Uses the existing `biomarker-synonyms` index so queries like `ldl` resolve to `LDL Cholesterol` and merge readings across reports even when the raw extracted name differs (`ldl-c`, `LDL Cholesterol`, etc.). Also returns matching reports when the query appears in `original_filename`.
- New `SearchBar` (magnifying glass icon, text input, clear button, Enter to submit) is wired onto the reports page and is shared with a dedicated `/search` page.
- `/search` is a client component with `useSearchParams` wrapped in `Suspense` (Next.js 15 requirement) and `force-dynamic` layout. Empty state with suggested queries, loading skeleton, error state, and grouped "Matching Biomarkers" / "Matching Reports" result sections.

## Test plan

- [x] `npm run lint` — clean (only pre-existing unrelated warnings)
- [x] `npm run typecheck` — passes
- [x] `npx vitest run` — 1181 / 1181 tests pass (20 new in `search.test.ts`)
- [ ] Manual: open `/reports`, search "ldl" -> navigates to `/search?q=ldl`, results show grouped readings across all reports with trend arrows
- [ ] Manual: search "annual" matches reports by filename
- [ ] Manual: query of length 0 or 1 shows the empty/suggestions state; no API call fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)